### PR TITLE
326. Syncronize sources and destinations

### DIFF
--- a/server/adapters/aws_redshift.go
+++ b/server/adapters/aws_redshift.go
@@ -192,7 +192,7 @@ func (ar *AwsRedshift) GetTableSchema(tableName string) (*Table, error) {
 }
 
 func (ar *AwsRedshift) CreateDB(databaseName string) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("AwsRedshift doesn't support CreateDB() func")
 }
 
 //CreateTable create database table with name,columns provided in Table representation

--- a/server/adapters/aws_redshift.go
+++ b/server/adapters/aws_redshift.go
@@ -3,11 +3,12 @@ package adapters
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/typing"
 	_ "github.com/lib/pq"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -190,6 +191,10 @@ func (ar *AwsRedshift) GetTableSchema(tableName string) (*Table, error) {
 	return table, nil
 }
 
+func (ar *AwsRedshift) CreateDB(databaseName string) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
 //CreateTable create database table with name,columns provided in Table representation
 func (ar *AwsRedshift) CreateTable(tableSchema *Table) error {
 	wrappedTx, err := ar.OpenTx()
@@ -296,6 +301,14 @@ func (ar *AwsRedshift) recreateNotNullColumnInTransaction(wrappedTx *Transaction
 	}
 
 	return nil
+}
+
+func (ar *AwsRedshift) BulkInsert(table *Table, objects []map[string]interface{}) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
+func (ar *AwsRedshift) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //Close underlying sql.DB

--- a/server/adapters/bigquery.go
+++ b/server/adapters/bigquery.go
@@ -186,7 +186,18 @@ func (bq *BigQuery) PatchTableSchema(patchSchema *Table) error {
 }
 
 func (bq *BigQuery) BulkInsert(table *Table, objects []map[string]interface{}) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	eventContext := &EventContext{
+		Table: table,
+	}
+
+	for _, event := range objects {
+		eventContext.ProcessedEvent = event
+		if err := bq.Insert(eventContext); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (bq *BigQuery) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
@@ -203,8 +214,8 @@ func (bq *BigQuery) BulkUpdate(table *Table, objects []map[string]interface{}, d
 	return nil
 }
 
-func (bq *BigQuery) deleteWithConditions(table *Table, deleteCondition *DeleteConditions) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+func (bq *BigQuery) deleteWithConditions(table *Table, deleteConditions *DeleteConditions) error {
+	return fmt.Errorf("Not IMPLEMENTED")
 }
 
 func (bq *BigQuery) logQuery(messageTemplate string, entity interface{}, ddl bool) {

--- a/server/adapters/bigquery.go
+++ b/server/adapters/bigquery.go
@@ -82,7 +82,7 @@ func (bq *BigQuery) Insert(eventContext *EventContext) error {
 }
 
 func (bq *BigQuery) CreateDB(databaseName string) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("BigQuery doesn't support CreateDB() func")
 }
 
 //GetTableSchema return google BigQuery table (name,columns) representation wrapped in Table struct
@@ -215,7 +215,7 @@ func (bq *BigQuery) BulkUpdate(table *Table, objects []map[string]interface{}, d
 }
 
 func (bq *BigQuery) deleteWithConditions(table *Table, deleteConditions *DeleteConditions) error {
-	return fmt.Errorf("Not IMPLEMENTED")
+	return fmt.Errorf("BigQuery doesn't support deleteWithConditions() func")
 }
 
 func (bq *BigQuery) logQuery(messageTemplate string, entity interface{}, ddl bool) {

--- a/server/adapters/bigquery.go
+++ b/server/adapters/bigquery.go
@@ -1,15 +1,16 @@
 package adapters
 
 import (
-	"cloud.google.com/go/bigquery"
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+
+	"cloud.google.com/go/bigquery"
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/typing"
 	"google.golang.org/api/googleapi"
-	"net/http"
-	"strings"
 )
 
 var (
@@ -78,6 +79,10 @@ func (bq *BigQuery) Insert(eventContext *EventContext) error {
 	inserter := bq.client.Dataset(bq.config.Dataset).Table(eventContext.Table.Name).Inserter()
 	bq.logQuery(fmt.Sprintf("Inserting values to table %s: ", eventContext.Table.Name), eventContext.ProcessedEvent, false)
 	return inserter.Put(bq.ctx, BQItem{values: eventContext.ProcessedEvent})
+}
+
+func (bq *BigQuery) CreateDB(databaseName string) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //GetTableSchema return google BigQuery table (name,columns) representation wrapped in Table struct
@@ -178,6 +183,28 @@ func (bq *BigQuery) PatchTableSchema(patchSchema *Table) error {
 	}
 
 	return nil
+}
+
+func (bq *BigQuery) BulkInsert(table *Table, objects []map[string]interface{}) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
+func (bq *BigQuery) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
+	if !deleteConditions.IsEmpty() {
+		if err := bq.deleteWithConditions(table, deleteConditions); err != nil {
+			return err
+		}
+	}
+
+	if err := bq.BulkInsert(table, objects); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (bq *BigQuery) deleteWithConditions(table *Table, deleteCondition *DeleteConditions) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 func (bq *BigQuery) logQuery(messageTemplate string, entity interface{}, ddl bool) {

--- a/server/adapters/facebook_conversion_api.go
+++ b/server/adapters/facebook_conversion_api.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jitsucom/jitsu/server/logging"
-	"github.com/jitsucom/jitsu/server/timestamp"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/jitsucom/jitsu/server/logging"
+	"github.com/jitsucom/jitsu/server/timestamp"
 )
 
 const (
@@ -155,6 +156,10 @@ func (fc *FacebookConversionAPI) GetTableSchema(tableName string) (*Table, error
 	}, nil
 }
 
+func (fc *FacebookConversionAPI) CreateDB(databaseName string) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
 //CreateTable Facebook doesn't use tables
 func (fc *FacebookConversionAPI) CreateTable(schemaToCreate *Table) error {
 	return nil
@@ -163,6 +168,14 @@ func (fc *FacebookConversionAPI) CreateTable(schemaToCreate *Table) error {
 //PatchTableSchema Facebook doesn't use tables
 func (fc *FacebookConversionAPI) PatchTableSchema(schemaToAdd *Table) error {
 	return nil
+}
+
+func (fc *FacebookConversionAPI) BulkInsert(table *Table, objects []map[string]interface{}) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
+func (fc *FacebookConversionAPI) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //Close closes underlying HTTPAdapter

--- a/server/adapters/facebook_conversion_api.go
+++ b/server/adapters/facebook_conversion_api.go
@@ -157,7 +157,7 @@ func (fc *FacebookConversionAPI) GetTableSchema(tableName string) (*Table, error
 }
 
 func (fc *FacebookConversionAPI) CreateDB(databaseName string) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("FacebookConversionAPI doesn't support CreateDB() func")
 }
 
 //CreateTable Facebook doesn't use tables
@@ -171,11 +171,11 @@ func (fc *FacebookConversionAPI) PatchTableSchema(schemaToAdd *Table) error {
 }
 
 func (fc *FacebookConversionAPI) BulkInsert(table *Table, objects []map[string]interface{}) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("FacebookConversionAPI doesn't support BulkInsert() func")
 }
 
 func (fc *FacebookConversionAPI) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("FacebookConversionAPI doesn't support BulkUpdate() func")
 }
 
 //Close closes underlying HTTPAdapter

--- a/server/adapters/google_analytics.go
+++ b/server/adapters/google_analytics.go
@@ -115,7 +115,7 @@ func (ga *GoogleAnalytics) GetTableSchema(tableName string) (*Table, error) {
 }
 
 func (ga *GoogleAnalytics) CreateDB(databaseName string) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("FacebookConversionAPI doesn't support CreateDB() func")
 }
 
 //CreateTable GA doesn't use tables
@@ -129,11 +129,11 @@ func (ga *GoogleAnalytics) PatchTableSchema(schemaToAdd *Table) error {
 }
 
 func (ga *GoogleAnalytics) BulkInsert(table *Table, objects []map[string]interface{}) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("FacebookConversionAPI doesn't support BulkInsert() func")
 }
 
 func (ga *GoogleAnalytics) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("FacebookConversionAPI doesn't support BulkUpdate() func")
 }
 
 //Close closes HTTPAdapter

--- a/server/adapters/google_analytics.go
+++ b/server/adapters/google_analytics.go
@@ -114,6 +114,10 @@ func (ga *GoogleAnalytics) GetTableSchema(tableName string) (*Table, error) {
 	}, nil
 }
 
+func (ga *GoogleAnalytics) CreateDB(databaseName string) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
 //CreateTable GA doesn't use tables
 func (ga *GoogleAnalytics) CreateTable(schemaToCreate *Table) error {
 	return nil
@@ -122,6 +126,14 @@ func (ga *GoogleAnalytics) CreateTable(schemaToCreate *Table) error {
 //PatchTableSchema GA doesn't use tables
 func (ga *GoogleAnalytics) PatchTableSchema(schemaToAdd *Table) error {
 	return nil
+}
+
+func (ga *GoogleAnalytics) BulkInsert(table *Table, objects []map[string]interface{}) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
+func (ga *GoogleAnalytics) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //Close closes HTTPAdapter

--- a/server/adapters/postgres.go
+++ b/server/adapters/postgres.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jitsucom/jitsu/server/logging"
-	"github.com/jitsucom/jitsu/server/typing"
-	_ "github.com/lib/pq"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jitsucom/jitsu/server/logging"
+	"github.com/jitsucom/jitsu/server/typing"
+	_ "github.com/lib/pq"
 )
 
 const (
@@ -171,6 +172,11 @@ func (p *Postgres) OpenTx() (*Transaction, error) {
 	}
 
 	return &Transaction{tx: tx, dbType: p.Type()}, nil
+}
+
+// CreateDB creates database instance if doesn't exist
+func (p *Postgres) CreateDB(databaseName string) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //CreateDbSchema creates database schema instance if doesn't exist

--- a/server/adapters/postgres.go
+++ b/server/adapters/postgres.go
@@ -176,7 +176,7 @@ func (p *Postgres) OpenTx() (*Transaction, error) {
 
 // CreateDB creates database instance if doesn't exist
 func (p *Postgres) CreateDB(databaseName string) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("Postgres doesn't support CreateDB() func")
 }
 
 //CreateDbSchema creates database schema instance if doesn't exist

--- a/server/adapters/snowflake.go
+++ b/server/adapters/snowflake.go
@@ -136,7 +136,7 @@ func (s *Snowflake) OpenTx() (*Transaction, error) {
 }
 
 func (s *Snowflake) CreateDB(databaseName string) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("Snowflake doesn't support CreateDB() func")
 }
 
 //CreateDbSchema create database schema instance if doesn't exist
@@ -316,7 +316,24 @@ func (s *Snowflake) insertInTransaction(wrappedTx *Transaction, eventContext *Ev
 }
 
 func (s *Snowflake) BulkInsert(table *Table, objects []map[string]interface{}) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	wrappedTx, err := s.OpenTx()
+	if err != nil {
+		return err
+	}
+
+	eventContext := &EventContext{
+		Table: table,
+	}
+
+	for _, event := range objects {
+		eventContext.ProcessedEvent = event
+		if err := s.insertInTransaction(wrappedTx, eventContext); err != nil {
+			wrappedTx.Rollback()
+			return err
+		}
+	}
+
+	return wrappedTx.DirectCommit()
 }
 
 func (s *Snowflake) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {

--- a/server/adapters/snowflake.go
+++ b/server/adapters/snowflake.go
@@ -27,6 +27,7 @@ const (
 	addSFColumnTemplate                 = `ALTER TABLE %s.%s ADD COLUMN %s`
 	createSFTableTemplate               = `CREATE TABLE %s.%s (%s)`
 	insertSFTemplate                    = `INSERT INTO %s.%s (%s) VALUES (%s)`
+	deleteSFTemplate                    = `DELETE FROM %s.%s.%s WHERE %s`
 )
 
 var (
@@ -268,8 +269,23 @@ func (s *Snowflake) Copy(fileName, tableName string, header []string) error {
 	return wrappedTx.DirectCommit()
 }
 
-//Insert provided object in snowflake
+// Insert inserts provided object into Snowflake
 func (s *Snowflake) Insert(eventContext *EventContext) error {
+	wrappedTx, err := s.OpenTx()
+	if err != nil {
+		return err
+	}
+
+	if err := s.insertInTransaction(wrappedTx, eventContext); err != nil {
+		wrappedTx.Rollback()
+		return err
+	}
+
+	return wrappedTx.DirectCommit()
+}
+
+// insertInTransaction inserts provided object into Snowflake in transaction
+func (s *Snowflake) insertInTransaction(wrappedTx *Transaction, eventContext *EventContext) error {
 	var header, placeholders string
 	var values []interface{}
 	for name, value := range eventContext.ProcessedEvent {
@@ -286,24 +302,17 @@ func (s *Snowflake) Insert(eventContext *EventContext) error {
 	query := fmt.Sprintf(insertSFTemplate, s.config.Schema, reformatValue(eventContext.Table.Name), header, placeholders)
 	s.queryLogger.LogQueryWithValues(query, values)
 
-	wrappedTx, err := s.OpenTx()
-	if err != nil {
-		return err
-	}
-
 	insertStmt, err := wrappedTx.tx.PrepareContext(s.ctx, query)
 	if err != nil {
-		wrappedTx.Rollback()
 		return fmt.Errorf("Error preparing insert table %s statement: %v", eventContext.Table.Name, err)
 	}
 
 	_, err = insertStmt.ExecContext(s.ctx, values...)
 	if err != nil {
-		wrappedTx.Rollback()
 		return fmt.Errorf("Error inserting in %s table with statement: %s values: %v: %v", eventContext.Table.Name, header, values, err)
 	}
 
-	return wrappedTx.DirectCommit()
+	return nil
 }
 
 func (s *Snowflake) BulkInsert(table *Table, objects []map[string]interface{}) error {
@@ -311,7 +320,63 @@ func (s *Snowflake) BulkInsert(table *Table, objects []map[string]interface{}) e
 }
 
 func (s *Snowflake) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	wrappedTx, err := s.OpenTx()
+	if err != nil {
+		return err
+	}
+
+	if !deleteConditions.IsEmpty() {
+		if err := s.deleteWithConditions(wrappedTx, table, deleteConditions); err != nil {
+			wrappedTx.Rollback()
+			return err
+		}
+	}
+
+	eventContext := &EventContext{
+		Table: table,
+	}
+
+	for _, event := range objects {
+		eventContext.ProcessedEvent = event
+		if err := s.insertInTransaction(wrappedTx, eventContext); err != nil {
+			wrappedTx.Rollback()
+			return err
+		}
+	}
+
+	return wrappedTx.DirectCommit()
+}
+
+// deleteWithConditions deletes objects from Snowflake in transaction
+func (s *Snowflake) deleteWithConditions(wrappedTx *Transaction, table *Table, deleteConditions *DeleteConditions) error {
+	deleteCondition, values := s.toDeleteQuery(deleteConditions)
+	query := fmt.Sprintf(deleteSFTemplate, s.config.Db, s.config.Schema, reformatValue(table.Name), deleteCondition)
+	s.queryLogger.LogQueryWithValues(query, values)
+
+	deleteStatement, err := wrappedTx.tx.PrepareContext(s.ctx, query)
+	if err != nil {
+		return fmt.Errorf("Error preparing delete table %s statement: %v", table.Name, err)
+	}
+
+	_, err = deleteStatement.ExecContext(s.ctx, values...)
+	if err != nil {
+		return fmt.Errorf("Error deleting in %s table with statement: %s values: %v: %v", table.Name, deleteCondition, values, err)
+	}
+
+	return nil
+}
+
+func (s *Snowflake) toDeleteQuery(conditions *DeleteConditions) (string, []interface{}) {
+	var queryConditions []string
+	var values []interface{}
+
+	for _, condition := range conditions.Conditions {
+		conditionString := condition.Field + " " + condition.Clause + " ?"
+		queryConditions = append(queryConditions, conditionString)
+		values = append(values, condition.Value)
+	}
+
+	return strings.Join(queryConditions, conditions.JoinCondition), values
 }
 
 //Close underlying sql.DB

--- a/server/adapters/snowflake.go
+++ b/server/adapters/snowflake.go
@@ -5,11 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/typing"
 	sf "github.com/snowflakedb/gosnowflake"
-	"sort"
-	"strings"
 )
 
 const (
@@ -131,6 +132,10 @@ func (s *Snowflake) OpenTx() (*Transaction, error) {
 	}
 
 	return &Transaction{tx: tx, dbType: s.Type()}, nil
+}
+
+func (s *Snowflake) CreateDB(databaseName string) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //CreateDbSchema create database schema instance if doesn't exist
@@ -299,6 +304,14 @@ func (s *Snowflake) Insert(eventContext *EventContext) error {
 	}
 
 	return wrappedTx.DirectCommit()
+}
+
+func (s *Snowflake) BulkInsert(table *Table, objects []map[string]interface{}) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
+func (s *Snowflake) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //Close underlying sql.DB

--- a/server/adapters/sql_adapter.go
+++ b/server/adapters/sql_adapter.go
@@ -2,9 +2,11 @@ package adapters
 
 //SQLAdapter is a manager for DWH tables
 type SQLAdapter interface {
+	CreateDB(databaseName string) error
 	Insert(eventContext *EventContext) error
 	GetTableSchema(tableName string) (*Table, error)
 	CreateTable(schemaToCreate *Table) error
 	PatchTableSchema(schemaToAdd *Table) error
+	BulkInsert(table *Table, objects []map[string]interface{}) error
 	BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error
 }

--- a/server/adapters/sql_adapter.go
+++ b/server/adapters/sql_adapter.go
@@ -6,4 +6,5 @@ type SQLAdapter interface {
 	GetTableSchema(tableName string) (*Table, error)
 	CreateTable(schemaToCreate *Table) error
 	PatchTableSchema(schemaToAdd *Table) error
+	BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error
 }

--- a/server/adapters/webhook.go
+++ b/server/adapters/webhook.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"errors"
+	"fmt"
+
 	"github.com/jitsucom/jitsu/server/typing"
 )
 
@@ -75,6 +77,10 @@ func (wh *WebHook) GetTableSchema(tableName string) (*Table, error) {
 	}, nil
 }
 
+func (wh *WebHook) CreateDB(databaseName string) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
 //CreateTable returns nil
 func (wh *WebHook) CreateTable(schemaToCreate *Table) error {
 	return nil
@@ -83,6 +89,14 @@ func (wh *WebHook) CreateTable(schemaToCreate *Table) error {
 //PatchTableSchema returns nil
 func (wh *WebHook) PatchTableSchema(schemaToAdd *Table) error {
 	return nil
+}
+
+func (wh *WebHook) BulkInsert(table *Table, objects []map[string]interface{}) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
+}
+
+func (wh *WebHook) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
+	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
 //Close closes underlying HTTPAdapter

--- a/server/adapters/webhook.go
+++ b/server/adapters/webhook.go
@@ -78,7 +78,7 @@ func (wh *WebHook) GetTableSchema(tableName string) (*Table, error) {
 }
 
 func (wh *WebHook) CreateDB(databaseName string) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("WebHook doesn't support CreateDB() func")
 }
 
 //CreateTable returns nil
@@ -92,11 +92,11 @@ func (wh *WebHook) PatchTableSchema(schemaToAdd *Table) error {
 }
 
 func (wh *WebHook) BulkInsert(table *Table, objects []map[string]interface{}) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("WebHook doesn't support BulkInsert() func")
 }
 
 func (wh *WebHook) BulkUpdate(table *Table, objects []map[string]interface{}, deleteConditions *DeleteConditions) error {
-	return fmt.Errorf("NOT IMPLEMENTED")
+	return fmt.Errorf("WebHook doesn't support BulkUpdate() func")
 }
 
 //Close closes underlying HTTPAdapter

--- a/server/drivers/google_play.go
+++ b/server/drivers/google_play.go
@@ -3,18 +3,19 @@ package drivers
 import (
 	"archive/zip"
 	"bytes"
-	"cloud.google.com/go/storage"
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/parsers"
 	"github.com/jitsucom/jitsu/server/typing"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"io/ioutil"
-	"strings"
-	"time"
 )
 
 const (
@@ -57,6 +58,11 @@ func (gpc *GooglePlayConfig) Validate() error {
 	if gpc.AccountID == "" {
 		return errors.New("GooglePlay account_id is required")
 	}
+
+	if gpc.AccountKey == nil {
+		return errors.New("GooglePlay auth is required")
+	}
+
 	return gpc.AccountKey.Validate()
 }
 

--- a/server/storages/abstract.go
+++ b/server/storages/abstract.go
@@ -2,6 +2,8 @@ package storages
 
 import (
 	"fmt"
+	"math/rand"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/jitsucom/jitsu/server/adapters"
 	"github.com/jitsucom/jitsu/server/caching"
@@ -9,8 +11,8 @@ import (
 	"github.com/jitsucom/jitsu/server/events"
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/metrics"
+	"github.com/jitsucom/jitsu/server/schema"
 	"github.com/jitsucom/jitsu/server/telemetry"
-	"math/rand"
 )
 
 //Abstract is an Abstract destination storage
@@ -20,6 +22,7 @@ type Abstract struct {
 	destinationID  string
 	fallbackLogger *logging.AsyncLogger
 	eventsCache    *caching.EventsCache
+	processor      *schema.Processor
 
 	tableHelpers []*TableHelper
 	sqlAdapters  []adapters.SQLAdapter
@@ -30,6 +33,11 @@ type Abstract struct {
 //ID returns destination ID
 func (a *Abstract) ID() string {
 	return a.destinationID
+}
+
+// Processor returns processor
+func (a *Abstract) Processor() *schema.Processor {
+	return a.processor
 }
 
 //ErrorEvent writes error to metrics/counters/telemetry/events cache

--- a/server/storages/bigquery.go
+++ b/server/storages/bigquery.go
@@ -177,9 +177,9 @@ func (bq *BigQuery) Update(object map[string]interface{}) error {
 	return errors.New("BigQuery doesn't support updates")
 }
 
-//SyncStore isn't supported
+// SyncStore is used in storing chunk of pulled data to BigQuery with processing
 func (bq *BigQuery) SyncStore(overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string, cacheTable bool) error {
-	return fmt.Errorf("BigQuery doesn't support SyncStore() func")
+	return syncStoreImpl(bq, overriddenDataSchema, objects, timeIntervalValue, cacheTable)
 }
 
 //GetUsersRecognition returns disabled users recognition configuration

--- a/server/storages/bigquery.go
+++ b/server/storages/bigquery.go
@@ -179,7 +179,7 @@ func (bq *BigQuery) Update(object map[string]interface{}) error {
 
 //SyncStore isn't supported
 func (bq *BigQuery) SyncStore(overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string, cacheTable bool) error {
-	return errors.New("BigQuery doesn't support sync store")
+	return fmt.Errorf("BigQuery doesn't support SyncStore() func")
 }
 
 //GetUsersRecognition returns disabled users recognition configuration

--- a/server/storages/bigquery.go
+++ b/server/storages/bigquery.go
@@ -3,11 +3,11 @@ package storages
 import (
 	"errors"
 	"fmt"
-	"github.com/jitsucom/jitsu/server/identifiers"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jitsucom/jitsu/server/adapters"
 	"github.com/jitsucom/jitsu/server/events"
+	"github.com/jitsucom/jitsu/server/identifiers"
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/schema"
 )
@@ -22,7 +22,6 @@ type BigQuery struct {
 
 	gcsAdapter           *adapters.GoogleCloudStorage
 	bqAdapter            *adapters.BigQuery
-	processor            *schema.Processor
 	streamingWorker      *StreamingWorker
 	uniqueIDField        *identifiers.UniqueID
 	staged               bool
@@ -80,7 +79,6 @@ func NewBigQuery(config *Config) (Storage, error) {
 	bq := &BigQuery{
 		gcsAdapter:           gcsAdapter,
 		bqAdapter:            bigQueryAdapter,
-		processor:            config.processor,
 		uniqueIDField:        config.uniqueIDField,
 		staged:               config.destination.Staged,
 		cachingConfiguration: config.destination.CachingConfiguration,
@@ -88,6 +86,7 @@ func NewBigQuery(config *Config) (Storage, error) {
 
 	//Abstract
 	bq.destinationID = config.destinationID
+	bq.processor = config.processor
 	bq.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	bq.eventsCache = config.eventsCache
 	bq.tableHelpers = []*TableHelper{tableHelper}

--- a/server/storages/facebook.go
+++ b/server/storages/facebook.go
@@ -3,6 +3,7 @@ package storages
 import (
 	"errors"
 	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/jitsucom/jitsu/server/adapters"
 	"github.com/jitsucom/jitsu/server/events"
@@ -16,7 +17,6 @@ type Facebook struct {
 
 	fbAdapter            *adapters.FacebookConversionAPI
 	tableHelper          *TableHelper
-	processor            *schema.Processor
 	streamingWorker      *StreamingWorker
 	uniqueIDField        *identifiers.UniqueID
 	staged               bool
@@ -42,7 +42,6 @@ func NewFacebook(config *Config) (Storage, error) {
 	requestDebugLogger := config.loggerFactory.CreateSQLQueryLogger(config.destinationID)
 
 	fb := &Facebook{
-		processor:            config.processor,
 		uniqueIDField:        config.uniqueIDField,
 		staged:               config.destination.Staged,
 		cachingConfiguration: config.destination.CachingConfiguration,
@@ -68,6 +67,7 @@ func NewFacebook(config *Config) (Storage, error) {
 
 	//Abstract (SQLAdapters and tableHelpers are omitted)
 	fb.destinationID = config.destinationID
+	fb.processor = config.processor
 	fb.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	fb.eventsCache = config.eventsCache
 	fb.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)

--- a/server/storages/google_analytics.go
+++ b/server/storages/google_analytics.go
@@ -3,6 +3,7 @@ package storages
 import (
 	"errors"
 	"fmt"
+
 	"github.com/jitsucom/jitsu/server/identifiers"
 
 	"github.com/hashicorp/go-multierror"
@@ -17,7 +18,6 @@ type GoogleAnalytics struct {
 
 	gaAdapter            *adapters.GoogleAnalytics
 	tableHelper          *TableHelper
-	processor            *schema.Processor
 	streamingWorker      *StreamingWorker
 	uniqueIDField        *identifiers.UniqueID
 	staged               bool
@@ -41,7 +41,6 @@ func NewGoogleAnalytics(config *Config) (Storage, error) {
 	}
 
 	ga := &GoogleAnalytics{
-		processor:            config.processor,
 		uniqueIDField:        config.uniqueIDField,
 		staged:               config.destination.Staged,
 		cachingConfiguration: config.destination.CachingConfiguration,
@@ -68,6 +67,7 @@ func NewGoogleAnalytics(config *Config) (Storage, error) {
 
 	//Abstract (SQLAdapters and tableHelpers are omitted)
 	ga.destinationID = config.destinationID
+	ga.processor = config.processor
 	ga.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	ga.eventsCache = config.eventsCache
 	ga.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)

--- a/server/storages/postgres.go
+++ b/server/storages/postgres.go
@@ -3,8 +3,9 @@ package storages
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jitsucom/jitsu/server/identifiers"
 	"time"
+
+	"github.com/jitsucom/jitsu/server/identifiers"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jitsucom/jitsu/server/adapters"
@@ -20,7 +21,6 @@ type Postgres struct {
 	Abstract
 
 	adapter                       *adapters.Postgres
-	processor                     *schema.Processor
 	streamingWorker               *StreamingWorker
 	usersRecognitionConfiguration *UserRecognitionConfiguration
 	uniqueIDField                 *identifiers.UniqueID
@@ -69,7 +69,6 @@ func NewPostgres(config *Config) (Storage, error) {
 
 	p := &Postgres{
 		adapter:                       adapter,
-		processor:                     config.processor,
 		usersRecognitionConfiguration: config.usersRecognition,
 		uniqueIDField:                 config.uniqueIDField,
 		staged:                        config.destination.Staged,
@@ -78,6 +77,7 @@ func NewPostgres(config *Config) (Storage, error) {
 
 	//Abstract
 	p.destinationID = config.destinationID
+	p.processor = config.processor
 	p.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	p.eventsCache = config.eventsCache
 	p.tableHelpers = []*TableHelper{tableHelper}
@@ -158,60 +158,7 @@ func (p *Postgres) storeTable(fdata *schema.ProcessedFile, table *adapters.Table
 
 //SyncStore is used in storing chunk of pulled data to Postgres with processing
 func (p *Postgres) SyncStore(overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string, cacheTable bool) error {
-	_, tableHelper := p.getAdapters()
-	flatData, err := p.processor.ProcessPulledEvents(timeIntervalValue, objects)
-	if err != nil {
-		return err
-	}
-
-	deleteConditions := adapters.DeleteByTimeChunkCondition(timeIntervalValue)
-
-	//table schema overridden
-	if overriddenDataSchema != nil && len(overriddenDataSchema.Fields) > 0 {
-		var data []map[string]interface{}
-		//ignore table multiplexing from mapping step
-		for _, fdata := range flatData {
-			data = append(data, fdata.GetPayload()...)
-			//enrich overridden schema with new fields (some system fields or e.g. after lookup step)
-			overriddenDataSchema.Fields.Add(fdata.BatchHeader.Fields)
-		}
-
-		table := tableHelper.MapTableSchema(overriddenDataSchema)
-
-		dbSchema, err := tableHelper.EnsureTable(p.ID(), table, cacheTable)
-		if err != nil {
-			return err
-		}
-		start := time.Now()
-		if err = p.adapter.BulkUpdate(dbSchema, data, deleteConditions); err != nil {
-			return err
-		}
-		logging.Debugf("[%s] Inserted [%d] rows in [%.2f] seconds", p.ID(), len(data), time.Now().Sub(start).Seconds())
-
-		return nil
-	}
-
-	//plain flow
-	for _, fdata := range flatData {
-		table := tableHelper.MapTableSchema(fdata.BatchHeader)
-
-		//overridden table destinationID
-		if overriddenDataSchema != nil && overriddenDataSchema.TableName != "" {
-			table.Name = overriddenDataSchema.TableName
-		}
-
-		dbSchema, err := tableHelper.EnsureTable(p.ID(), table, cacheTable)
-		if err != nil {
-			return err
-		}
-		start := time.Now()
-		if err = p.adapter.BulkUpdate(dbSchema, fdata.GetPayload(), deleteConditions); err != nil {
-			return err
-		}
-		logging.Debugf("[%s] Inserted [%d] rows in [%.2f] seconds", p.ID(), len(fdata.GetPayload()), time.Now().Sub(start).Seconds())
-	}
-
-	return nil
+	return syncStoreImpl(p, overriddenDataSchema, objects, timeIntervalValue, cacheTable)
 }
 
 //Update uses SyncStore under the hood

--- a/server/storages/redshift.go
+++ b/server/storages/redshift.go
@@ -1,7 +1,6 @@
 package storages
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -174,9 +173,9 @@ func (ar *AwsRedshift) storeTable(fdata *schema.ProcessedFile, table *adapters.T
 	return nil
 }
 
-//SyncStore isn't supported
+// SyncStore is used in storing chunk of pulled data to AwsRedshift with processing
 func (ar *AwsRedshift) SyncStore(overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string, cacheTable bool) error {
-	return errors.New("RedShift doesn't support sync store")
+	return syncStoreImpl(ar, overriddenDataSchema, objects, timeIntervalValue, cacheTable)
 }
 
 //Update updates record in Redshift

--- a/server/storages/redshift.go
+++ b/server/storages/redshift.go
@@ -3,8 +3,9 @@ package storages
 import (
 	"errors"
 	"fmt"
-	"github.com/jitsucom/jitsu/server/identifiers"
 	"time"
+
+	"github.com/jitsucom/jitsu/server/identifiers"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jitsucom/jitsu/server/adapters"
@@ -21,7 +22,6 @@ type AwsRedshift struct {
 
 	s3Adapter                     *adapters.S3
 	redshiftAdapter               *adapters.AwsRedshift
-	processor                     *schema.Processor
 	streamingWorker               *StreamingWorker
 	usersRecognitionConfiguration *UserRecognitionConfiguration
 	uniqueIDField                 *identifiers.UniqueID
@@ -80,7 +80,6 @@ func NewAwsRedshift(config *Config) (Storage, error) {
 	ar := &AwsRedshift{
 		s3Adapter:                     s3Adapter,
 		redshiftAdapter:               redshiftAdapter,
-		processor:                     config.processor,
 		usersRecognitionConfiguration: config.usersRecognition,
 		uniqueIDField:                 config.uniqueIDField,
 		staged:                        config.destination.Staged,
@@ -89,6 +88,7 @@ func NewAwsRedshift(config *Config) (Storage, error) {
 
 	//Abstract
 	ar.destinationID = config.destinationID
+	ar.processor = config.processor
 	ar.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	ar.eventsCache = config.eventsCache
 	ar.tableHelpers = []*TableHelper{tableHelper}

--- a/server/storages/s3.go
+++ b/server/storages/s3.go
@@ -3,6 +3,7 @@ package storages
 import (
 	"errors"
 	"fmt"
+
 	"github.com/jitsucom/jitsu/server/adapters"
 	"github.com/jitsucom/jitsu/server/caching"
 	"github.com/jitsucom/jitsu/server/events"
@@ -16,7 +17,6 @@ type S3 struct {
 	Abstract
 
 	s3Adapter            *adapters.S3
-	processor            *schema.Processor
 	fallbackLogger       *logging.AsyncLogger
 	eventsCache          *caching.EventsCache
 	uniqueIDField        *identifiers.UniqueID
@@ -47,7 +47,6 @@ func NewS3(config *Config) (Storage, error) {
 
 	s3 := &S3{
 		s3Adapter:            s3Adapter,
-		processor:            config.processor,
 		uniqueIDField:        config.uniqueIDField,
 		staged:               config.destination.Staged,
 		cachingConfiguration: config.destination.CachingConfiguration,
@@ -55,6 +54,7 @@ func NewS3(config *Config) (Storage, error) {
 
 	//Abstract (SQLAdapters and tableHelpers and archive logger are omitted)
 	s3.destinationID = config.destinationID
+	s3.processor = config.processor
 	s3.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	s3.eventsCache = config.eventsCache
 

--- a/server/storages/snowflake.go
+++ b/server/storages/snowflake.go
@@ -234,9 +234,9 @@ func (s *Snowflake) IsCachingDisabled() bool {
 	return s.cachingConfiguration != nil && s.cachingConfiguration.Disabled
 }
 
-//SyncStore isn't supported
+// SyncStore is used in storing chunk of pulled data to Snowflake with processing
 func (s *Snowflake) SyncStore(overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string, cacheTable bool) error {
-	return errors.New("Snowflake doesn't support sync store")
+	return syncStoreImpl(s, overriddenDataSchema, objects, timeIntervalValue, cacheTable)
 }
 
 //Update isn't supported

--- a/server/storages/snowflake.go
+++ b/server/storages/snowflake.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/jitsucom/jitsu/server/identifiers"
 	"github.com/jitsucom/jitsu/server/typing"
 
@@ -23,7 +24,6 @@ type Snowflake struct {
 
 	stageAdapter         adapters.Stage
 	snowflakeAdapter     *adapters.Snowflake
-	processor            *schema.Processor
 	streamingWorker      *StreamingWorker
 	uniqueIDField        *identifiers.UniqueID
 	staged               bool
@@ -91,7 +91,6 @@ func NewSnowflake(config *Config) (Storage, error) {
 	snowflake := &Snowflake{
 		stageAdapter:         stageAdapter,
 		snowflakeAdapter:     snowflakeAdapter,
-		processor:            config.processor,
 		uniqueIDField:        config.uniqueIDField,
 		staged:               config.destination.Staged,
 		cachingConfiguration: config.destination.CachingConfiguration,
@@ -99,6 +98,7 @@ func NewSnowflake(config *Config) (Storage, error) {
 
 	//Abstract
 	snowflake.destinationID = config.destinationID
+	snowflake.processor = config.processor
 	snowflake.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	snowflake.eventsCache = config.eventsCache
 	snowflake.tableHelpers = []*TableHelper{tableHelper}

--- a/server/storages/types.go
+++ b/server/storages/types.go
@@ -32,6 +32,8 @@ type Storage interface {
 	Fallback(events ...*events.FailedEvent)
 	GetUsersRecognition() *UserRecognitionConfiguration
 	GetUniqueIDField() *identifiers.UniqueID
+	getAdapters() (adapters.SQLAdapter, *TableHelper)
+	Processor() *schema.Processor
 	ID() string
 	Type() string
 	IsStaging() bool

--- a/server/storages/utils.go
+++ b/server/storages/utils.go
@@ -1,10 +1,14 @@
 package storages
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/jitsucom/jitsu/server/adapters"
 	"github.com/jitsucom/jitsu/server/events"
+	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/schema"
-	"strings"
 )
 
 func dryRun(payload events.Event, processor *schema.Processor, tableHelper *TableHelper) ([]adapters.TableField, error) {
@@ -30,4 +34,73 @@ func isConnectionError(err error) bool {
 		strings.Contains(err.Error(), "context deadline exceeded") ||
 		strings.Contains(err.Error(), "connection reset by peer") ||
 		strings.Contains(err.Error(), "write: connection timed out")
+}
+
+// syncStoreImpl implements common behaviour used to storing chunk of pulled data to any storages with processing
+func syncStoreImpl(storage Storage, overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string) error {
+	adapter, tableHelper := storage.getAdapters()
+
+	processor := storage.Processor()
+	if processor == nil {
+		return fmt.Errorf("Storage '%v' of '%v' type was badly configured")
+	}
+
+	flatData, err := processor.ProcessPulledEvents(timeIntervalValue, objects)
+	if err != nil {
+		return err
+	}
+
+	deleteConditions := adapters.DeleteByTimeChunkCondition(timeIntervalValue)
+
+	// table schema overridden (is used by Singer sources)
+	if overriddenDataSchema != nil && len(overriddenDataSchema.Fields) > 0 {
+		var data []map[string]interface{}
+
+		// ignore table multiplexing from mapping step
+		for _, fdata := range flatData {
+			data = append(data, fdata.GetPayload()...)
+
+			// enrich overridden schema with new fields (some system fields or e.g. after lookup step)
+			overriddenDataSchema.Fields.Add(fdata.BatchHeader.Fields)
+		}
+
+		table := tableHelper.MapTableSchema(overriddenDataSchema)
+
+		dbSchema, err := tableHelper.EnsureTableWithoutCaching(storage.ID(), table)
+		if err != nil {
+			return err
+		}
+
+		start := time.Now()
+		if err = adapter.BulkUpdate(dbSchema, data, deleteConditions); err != nil {
+			return err
+		}
+
+		logging.Debugf("[%s] Inserted [%d] rows in [%.2f] seconds", storage.ID(), len(data), time.Now().Sub(start).Seconds())
+		return nil
+	}
+
+	// plain flow
+	for _, fdata := range flatData {
+		table := tableHelper.MapTableSchema(fdata.BatchHeader)
+
+		// overridden table destinationID
+		if overriddenDataSchema != nil && overriddenDataSchema.TableName != "" {
+			table.Name = overriddenDataSchema.TableName
+		}
+
+		dbSchema, err := tableHelper.EnsureTableWithoutCaching(storage.ID(), table)
+		if err != nil {
+			return err
+		}
+
+		start := time.Now()
+		if err := adapter.BulkUpdate(dbSchema, fdata.GetPayload(), deleteConditions); err != nil {
+			return err
+		}
+
+		logging.Debugf("[%s] Inserted [%d] rows in [%.2f] seconds", storage.ID(), len(fdata.GetPayload()), time.Now().Sub(start).Seconds())
+	}
+
+	return nil
 }

--- a/server/storages/utils.go
+++ b/server/storages/utils.go
@@ -37,12 +37,12 @@ func isConnectionError(err error) bool {
 }
 
 // syncStoreImpl implements common behaviour used to storing chunk of pulled data to any storages with processing
-func syncStoreImpl(storage Storage, overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string) error {
+func syncStoreImpl(storage Storage, overriddenDataSchema *schema.BatchHeader, objects []map[string]interface{}, timeIntervalValue string, cacheTable bool) error {
 	adapter, tableHelper := storage.getAdapters()
 
 	processor := storage.Processor()
 	if processor == nil {
-		return fmt.Errorf("Storage '%v' of '%v' type was badly configured")
+		return fmt.Errorf("Storage '%v' of '%v' type was badly configured", storage.ID(), storage.Type())
 	}
 
 	flatData, err := processor.ProcessPulledEvents(timeIntervalValue, objects)
@@ -66,7 +66,7 @@ func syncStoreImpl(storage Storage, overriddenDataSchema *schema.BatchHeader, ob
 
 		table := tableHelper.MapTableSchema(overriddenDataSchema)
 
-		dbSchema, err := tableHelper.EnsureTableWithoutCaching(storage.ID(), table)
+		dbSchema, err := tableHelper.EnsureTable(storage.ID(), table, cacheTable)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func syncStoreImpl(storage Storage, overriddenDataSchema *schema.BatchHeader, ob
 			table.Name = overriddenDataSchema.TableName
 		}
 
-		dbSchema, err := tableHelper.EnsureTableWithoutCaching(storage.ID(), table)
+		dbSchema, err := tableHelper.EnsureTable(storage.ID(), table, cacheTable)
 		if err != nil {
 			return err
 		}

--- a/server/storages/webhook.go
+++ b/server/storages/webhook.go
@@ -3,13 +3,13 @@ package storages
 import (
 	"errors"
 	"fmt"
-	"github.com/jitsucom/jitsu/server/identifiers"
 	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jitsucom/jitsu/server/adapters"
 	"github.com/jitsucom/jitsu/server/events"
+	"github.com/jitsucom/jitsu/server/identifiers"
 	"github.com/jitsucom/jitsu/server/schema"
 )
 
@@ -29,7 +29,6 @@ type WebHook struct {
 	Abstract
 
 	tableHelper          *TableHelper
-	processor            *schema.Processor
 	streamingWorker      *StreamingWorker
 	uniqueIDField        *identifiers.UniqueID
 	staged               bool
@@ -62,7 +61,6 @@ func NewWebHook(config *Config) (Storage, error) {
 	}
 
 	wh := &WebHook{
-		processor:            config.processor,
 		uniqueIDField:        config.uniqueIDField,
 		staged:               config.destination.Staged,
 		cachingConfiguration: config.destination.CachingConfiguration,
@@ -89,6 +87,7 @@ func NewWebHook(config *Config) (Storage, error) {
 
 	//Abstract (SQLAdapters and tableHelpers are omitted)
 	wh.destinationID = config.destinationID
+	wh.processor = config.processor
 	wh.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	wh.eventsCache = config.eventsCache
 	wh.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)


### PR DESCRIPTION
Fix #326 

Syncronization becomes available for additional destination types: `BigQuery`, `RedShift`, `SnowFlake`