### PR TITLE
416. Tracking pixel implementation

### DIFF
--- a/server/events/js_processor.go
+++ b/server/events/js_processor.go
@@ -1,23 +1,11 @@
 package events
 
 import (
+	"net/http"
+
 	"github.com/jitsucom/jitsu/server/jsonutils"
 	"github.com/jitsucom/jitsu/server/logging"
-	"net/http"
 )
-
-const (
-	JSPreprocessorType      = "js"
-	APIPreprocessorType     = "api"
-	SegmentPreprocessorType = "segment"
-)
-
-//Processor is used in preprocessing and postprocessing events before consuming(storing)
-type Processor interface {
-	Preprocess(event Event, r *http.Request)
-	Postprocess(event Event, eventID string, destinationIDs []string)
-	Type() string
-}
 
 //JsProcessor preprocess client integration events
 type JsProcessor struct {

--- a/server/events/pixel_processor.go
+++ b/server/events/pixel_processor.go
@@ -1,0 +1,97 @@
+package events
+
+import (
+	"net/http"
+
+	"github.com/jitsucom/jitsu/server/jsonutils"
+	"github.com/jitsucom/jitsu/server/timestamp"
+)
+
+// PixelProcessor preprocess tracking pixel events
+type PixelProcessor struct {
+}
+
+// NewPixelProcessor returns configured PixelProcessor
+func NewPixelProcessor() Processor {
+	return &PixelProcessor{}
+}
+
+// Preprocess set user-agent from request header to configured nodes
+func (pp *PixelProcessor) Preprocess(event Event, r *http.Request) {
+	compatibility := false
+	if _, ok := event["compat"]; ok {
+		compatibility = true
+	}
+
+	urlField := "url"
+	hostField := "doc_host"
+	pathField := "doc_path"
+	searchField := "doc_search"
+	userIdField := "user/anonymous_id"
+	agentField := "user_agent"
+	timeField := "utc_time"
+	if compatibility {
+		urlField = "eventn_ctx/url"
+		hostField = "eventn_ctx/doc_host"
+		pathField = "eventn_ctx/doc_path"
+		searchField = "eventn_ctx/doc_search"
+		userIdField = "eventn_ctx/user/anonymous_id"
+		agentField = "eventn_ctx/user_agent"
+		timeField = "eventn_ctx/utc_time"
+	}
+
+	path := jsonutils.NewJSONPath(urlField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, r.RemoteAddr)
+	}
+
+	path = jsonutils.NewJSONPath(hostField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, r.Host)
+	}
+
+	path = jsonutils.NewJSONPath(pathField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, r.URL.Path)
+	}
+
+	path = jsonutils.NewJSONPath(searchField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, r.URL.RawQuery)
+	}
+
+	path = jsonutils.NewJSONPath(userIdField)
+	if _, exist := path.Get(event); !exist {
+		domain, ok := event["cookie_domain"]
+		if !ok {
+			domain = r.Host
+		}
+
+		if domain_str, ok := domain.(string); ok {
+			cookie, err := r.Cookie(domain_str)
+			if err == nil && cookie != nil {
+				path.Set(event, cookie.Value)
+			}
+		}
+	}
+
+	path = jsonutils.NewJSONPath(agentField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, r.UserAgent())
+	}
+
+	path = jsonutils.NewJSONPath(timeField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, timestamp.NowUTC())
+	}
+
+	event[SrcKey] = "jitsu_gif"
+}
+
+func (pp *PixelProcessor) Postprocess(event Event, eventID string, destinationIDs []string) {
+}
+
+// Type returns preprocessor type
+func (pp *PixelProcessor) Type() string {
+	return PixelPreprocessorType
+}

--- a/server/events/pixel_processor.go
+++ b/server/events/pixel_processor.go
@@ -16,7 +16,7 @@ func NewPixelProcessor() Processor {
 	return &PixelProcessor{}
 }
 
-// Preprocess set user-agent from request header to configured nodes
+// Preprocess set some values from request header into event
 func (pp *PixelProcessor) Preprocess(event Event, r *http.Request) {
 	compatibility := false
 	if _, ok := event["compat"]; ok {

--- a/server/events/processor.go
+++ b/server/events/processor.go
@@ -1,0 +1,18 @@
+package events
+
+import (
+	"net/http"
+)
+
+const (
+	JSPreprocessorType      = "js"
+	APIPreprocessorType     = "api"
+	SegmentPreprocessorType = "segment"
+)
+
+// Processor is used in preprocessing and postprocessing events before and after consuming(storing)
+type Processor interface {
+	Preprocess(event Event, r *http.Request)
+	Postprocess(event Event, eventID string, destinationIDs []string)
+	Type() string
+}

--- a/server/events/processor.go
+++ b/server/events/processor.go
@@ -5,8 +5,9 @@ import (
 )
 
 const (
-	JSPreprocessorType      = "js"
 	APIPreprocessorType     = "api"
+	JSPreprocessorType      = "js"
+	PixelPreprocessorType   = "pixel"
 	SegmentPreprocessorType = "segment"
 )
 

--- a/server/handlers/pixel.go
+++ b/server/handlers/pixel.go
@@ -2,9 +2,12 @@ package handlers
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jitsucom/jitsu/server/jsonutils"
 	"github.com/jitsucom/jitsu/server/logging"
 )
 
@@ -27,5 +30,43 @@ func NewPixelHandler() *PixelHandler {
 }
 
 func (handler *PixelHandler) Handle(c *gin.Context) {
+	go doTracking(c.Copy())
+
 	c.Data(http.StatusOK, "image/gif", handler.data)
+}
+
+func doTracking(c *gin.Context) {
+	event := map[string]interface{}{}
+
+	parameters := c.Request.URL.Query()
+
+	data := parameters.Get("data")
+	if data != "" {
+		value, err := base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			logging.Debugf("Error decoding string: %v", err)
+		} else {
+			err = json.Unmarshal(value, &event)
+			if err != nil {
+				logging.Debugf("Error parsing JSON event: %v", err)
+			}
+		}
+	}
+
+	for key, value := range parameters {
+		if key == "data" {
+			continue
+		}
+
+		converted := strings.ReplaceAll(key, ".", "/")
+		path := jsonutils.NewJSONPath(converted)
+		path.Set(event, value)
+	}
+
+	compatibility := false
+	if _, ok := event["compat"]; ok {
+		compatibility = true
+	}
+
+	logging.Infof("Compatibility: %v, Event: %v", compatibility, event)
 }

--- a/server/handlers/pixel.go
+++ b/server/handlers/pixel.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jitsucom/jitsu/server/logging"
+)
+
+const TRACKING_PIXEL = "R0lGODlhAQABAIAAAAAAAP8AACH5BAEAAAEALAAAAAABAAEAAAICTAEAOw=="
+
+type PixelHandler struct {
+	data []byte
+}
+
+func NewPixelHandler() *PixelHandler {
+	var err error
+	handler := &PixelHandler{}
+
+	handler.data, err = base64.StdEncoding.DecodeString(TRACKING_PIXEL)
+	if err != nil {
+		logging.Warnf("Cannot decode image for tracking pixel: %v", err)
+	}
+
+	return handler
+}
+
+func (handler *PixelHandler) Handle(c *gin.Context) {
+	c.Data(http.StatusOK, "image/gif", handler.data)
+}

--- a/server/handlers/pixel.go
+++ b/server/handlers/pixel.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jitsucom/jitsu/server/jsonutils"
 	"github.com/jitsucom/jitsu/server/logging"
+	"github.com/jitsucom/jitsu/server/timestamp"
 )
 
 const TRACKING_PIXEL = "R0lGODlhAQABAIAAAAAAAP8AACH5BAEAAAEALAAAAAABAAEAAAICTAEAOw=="
@@ -38,6 +39,12 @@ func (handler *PixelHandler) Handle(c *gin.Context) {
 func doTracking(c *gin.Context) {
 	event := map[string]interface{}{}
 
+	restoreEvent(event, c)
+
+	enrichEvent(event, c)
+}
+
+func restoreEvent(event map[string]interface{}, c *gin.Context) {
 	parameters := c.Request.URL.Query()
 
 	data := parameters.Get("data")
@@ -62,11 +69,75 @@ func doTracking(c *gin.Context) {
 		path := jsonutils.NewJSONPath(converted)
 		path.Set(event, value)
 	}
+}
 
+func enrichEvent(event map[string]interface{}, c *gin.Context) {
 	compatibility := false
 	if _, ok := event["compat"]; ok {
 		compatibility = true
 	}
 
-	logging.Infof("Compatibility: %v, Event: %v", compatibility, event)
+	urlField := "url"
+	hostField := "doc_host"
+	pathField := "doc_path"
+	searchField := "doc_search"
+	userIdField := "user/anonymous_id"
+	agentField := "user_agent"
+	timeField := "utc_time"
+	if compatibility {
+		urlField = "eventn_ctx/url"
+		hostField = "eventn_ctx/doc_host"
+		pathField = "eventn_ctx/doc_path"
+		searchField = "eventn_ctx/doc_search"
+		userIdField = "eventn_ctx/user/anonymous_id"
+		agentField = "eventn_ctx/user_agent"
+		timeField = "eventn_ctx/utc_time"
+	}
+
+	path := jsonutils.NewJSONPath(urlField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, c.Request.RemoteAddr)
+	}
+
+	path = jsonutils.NewJSONPath(hostField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, c.Request.Host)
+	}
+
+	path = jsonutils.NewJSONPath(pathField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, c.Request.URL.Path)
+	}
+
+	path = jsonutils.NewJSONPath(searchField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, c.Request.URL.RawQuery)
+	}
+
+	path = jsonutils.NewJSONPath(userIdField)
+	if _, exist := path.Get(event); !exist {
+		domain, ok := event["cookie_domain"]
+		if !ok {
+			domain = c.Request.Host
+		}
+
+		if domain_str, ok := domain.(string); ok {
+			cookie, err := c.Request.Cookie(domain_str)
+			if err == nil && cookie != nil {
+				path.Set(event, cookie.Value)
+			}
+		}
+	}
+
+	path = jsonutils.NewJSONPath(agentField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, c.Request.UserAgent())
+	}
+
+	path = jsonutils.NewJSONPath(timeField)
+	if _, exist := path.Get(event); !exist {
+		path.Set(event, timestamp.NowUTC())
+	}
+
+	event["src"] = "jitsu_gif"
 }

--- a/server/routers/router.go
+++ b/server/routers/router.go
@@ -57,7 +57,7 @@ func SetupRouter(adminToken string, metaStorage meta.Storage, destinations *dest
 	statisticsHandler := handlers.NewStatisticsHandler(metaStorage)
 
 	sourcesHandler := handlers.NewSourcesHandler(sourcesService, metaStorage)
-	pixelHandler := handlers.NewPixelHandler(destinations, eventsCache)
+	pixelHandler := handlers.NewPixelHandler(destinations, events.NewPixelProcessor(), eventsCache)
 
 	adminTokenMiddleware := middleware.AdminToken{Token: adminToken}
 	apiV1 := router.Group("/api/v1")

--- a/server/routers/router.go
+++ b/server/routers/router.go
@@ -57,7 +57,7 @@ func SetupRouter(adminToken string, metaStorage meta.Storage, destinations *dest
 	statisticsHandler := handlers.NewStatisticsHandler(metaStorage)
 
 	sourcesHandler := handlers.NewSourcesHandler(sourcesService, metaStorage)
-	pixelHandler := handlers.NewPixelHandler()
+	pixelHandler := handlers.NewPixelHandler(destinations, eventsCache)
 
 	adminTokenMiddleware := middleware.AdminToken{Token: adminToken}
 	apiV1 := router.Group("/api/v1")


### PR DESCRIPTION
Fixes #416
Implementation allows to track all events from loading pixels.
Event fullfills from `data` field which should be the base64 encoded JSON representation or from other fields.
For example:
* `<img src="http://jitsu.com/api/v1/p.gif?data=eyJIZWxsbyI6IldvcmxkIiwiaWQiOjQyLCJ0b2tlbiI6InNlY3JldF90b2tlbiJ9Cg==" />`
* `<img src="http://jitsu.com/api/v1/p.gif?token=secret_token&id=15&context.author=Alessar" />`
* `<img src="http://jitsu.com/api/v1/p.gif?token=secret_token&id=17&compat=true" />`