### PR TITLE
Gcp workload identity support

### DIFF
--- a/server/adapters/google_cloud_storage_test.go
+++ b/server/adapters/google_cloud_storage_test.go
@@ -1,0 +1,20 @@
+package adapters
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidate_WorkloadIdentity_ServiceAccountKey_pass_dont_set_credentials(t *testing.T) {
+	uut := &GoogleConfig{
+		Bucket:      "foo",
+		Project:     "bar",
+		Dataset:     "baz",
+		KeyFile:     "workload_identity",
+	}
+
+	err := uut.Validate(false)
+
+	assert.Nilf(t, err, "err %v", err)
+	assert.Nil(t, uut.credentials)
+}


### PR DESCRIPTION
This is an initial proposal
Following [issue 558](https://github.com/jitsucom/jitsu/issues/558)
adding a magic string : "workload_identity" that can be used instead of a GCP service account JSON key.
In this scenario,  google cloud storage adapter validation will not fail
and the cloud storage client will be created without any credentials.
which will cause google SDK to use the default service account installed on the pod.
which should be granted perms to access gloud storage by GKE cluster admin.

This change will affect Both Snowflake destination and Biguery destination. ( as they both use gcp cloud storage adapter )
It should work with both cases 

A more elegant way to handle this will probably require adding some checkbox to jitsu UI.
It's a bit hacky solution I know.
Its a phase 1 solution.
If this change is accepted I will be glad to also update the UI. 
Thanks in advance 🙏 