### PR TITLE
GCP workload_identity documentation update 

### DIFF
--- a/documentation/configuration/google-authorization.mdx
+++ b/documentation/configuration/google-authorization.mdx
@@ -45,3 +45,23 @@ Service Account key can be referred in a few ways in Jitsu configuration:
         `}
     </CodeTab>
 </CodeInTabs>
+      
+      
+### GKE Workload Identity Configuration       
+Supported since jitsu v1.35.5
+      
+For Improved security and operability, Google developed a mechanism called Workload Identity that eliminates the need to pass around Service account JSON keys.
+- [official docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+      
+To configure Jitsu to use workload identity, 
+provide the following magic string instead of the Service account JSON :
+`workload_identity`
+No quotes.
+      
+Like this:
+![image](https://user-images.githubusercontent.com/6231756/135107450-6ba685d6-222f-4af3-b027-a0e2315afa43.png)
+
+It will cause google SDK to use the default k8s service account associated with the pod running Jitsu.
+This service account should be mapped to a Google Service Account that was assigned the required IAM roles. And workload identity should be enabled in the cluster.
+      
+      


### PR DESCRIPTION
Following [issue 558](https://github.com/jitsucom/jitsu/issues/558)
Adding required docs to explain how to use GKE workload identity, and the changes being introduced in v1.35.5.