### PR TITLE
workload_identity support for big query

### DIFF
--- a/documentation/configuration/google-authorization.mdx
+++ b/documentation/configuration/google-authorization.mdx
@@ -45,3 +45,21 @@ Service Account key can be referred in a few ways in Jitsu configuration:
         `}
     </CodeTab>
 </CodeInTabs>
+
+
+### GKE Workload Identity Configuration
+Supported since jitsu v1.35.5
+
+For Improved security and operability, Google developed a mechanism called Workload Identity that eliminates the need to pass around Service account JSON keys.
+- [official docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+
+To configure Jitsu to use workload identity,
+provide the following magic string instead of the Service account JSON :
+`workload_identity`
+No quotes.
+
+Like this:
+![image](https://user-images.githubusercontent.com/6231756/135107450-6ba685d6-222f-4af3-b027-a0e2315afa43.png)
+
+It will cause google SDK to use the default k8s service account associated with the pod running Jitsu.
+This service account should be mapped to a Google Service Account that was assigned the required IAM roles. And workload identity should be enabled in the cluster.

--- a/server/adapters/bigquery.go
+++ b/server/adapters/bigquery.go
@@ -43,7 +43,15 @@ type BigQuery struct {
 
 //NewBigQuery return configured BigQuery adapter instance
 func NewBigQuery(ctx context.Context, config *GoogleConfig, queryLogger *logging.QueryLogger, sqlTypes typing.SQLTypes) (*BigQuery, error) {
-	client, err := bigquery.NewClient(ctx, config.Project, config.credentials)
+
+	var client *bigquery.Client
+	var err error
+	if config.credentials == nil {
+		client, err = bigquery.NewClient(ctx, config.Project)
+	} else {
+		client, err = bigquery.NewClient(ctx, config.Project, config.credentials)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Error creating BigQuery client: %v", err)
 	}


### PR DESCRIPTION
big query adaptor contractor used nil credentials, which causes a panic, in a scenario of a workload_identity configuration, now it creates a big query client without any creds which cause the SDK to use the default service account installed on the machine