### PR TITLE
[Doc fix] corrected chomod to chmod in documentation

### DIFF
--- a/documentation/deployment/deploy-with-docker/joint-image.mdx
+++ b/documentation/deployment/deploy-with-docker/joint-image.mdx
@@ -109,7 +109,7 @@ under `/configurator` path
 
 ```
 mkdir $PWD/server_logs/ $PWD/configurator_logs/
-chomod -R 777 $PWD/server_logs/ $PWD/configurator_logs/
+chmod -R 777 $PWD/server_logs/ $PWD/configurator_logs/
 ```
 
 (you need the one above to ensure that Jitsu can write data to those dirs)


### PR DESCRIPTION
# Description

Man, OCD is kicking in... Found some [documentation](https://jitsu.com/docs/deployment/deploy-with-docker/joint-image) that was misspelled. I decided to just correct it through a PR.

