### PR TITLE
appconfig/version: fix default selection

### DIFF
--- a/server/appconfig/version.go
+++ b/server/appconfig/version.go
@@ -48,7 +48,6 @@ func (vn *VersionReminder) Start() {
 				return
 			case <-ticker.C:
 				vn.showReminder()
-			default:
 			}
 		}
 	})


### PR DESCRIPTION
I noticed that jitsu/server was using more CPU than usual. 
After investigating a bit, I saw that "VersionReminder" was running a for-select with a "default" case.

