### PR TITLE
747 made users recognition by any identification node

### DIFF
--- a/configurator/frontend/src/catalog/mappings/lib/segment.tsx
+++ b/configurator/frontend/src/catalog/mappings/lib/segment.tsx
@@ -144,6 +144,16 @@ const mapping: DestinationConfigurationTemplate = {
       action: "move",
     },
     {
+      src: "/eventn_ctx/user/id",
+      dst: "/user_id",
+      action: "move",
+    },
+    {
+      src: "/user/id",
+      dst: "/user_id",
+      action: "move",
+    },
+    {
       src: "/eventn_ctx/user/internal_id",
       dst: "/user_id",
       action: "move",

--- a/documentation/destinations-configuration/mixpanel.mdx
+++ b/documentation/destinations-configuration/mixpanel.mdx
@@ -29,7 +29,7 @@ from `user_identify` events.
 
 ### Aliases
 
-Jitsu automatically create aliases in Mixpanel on  `user_identify` events if `user.internal_id` or `user.email` is present in event along with `user.anonymous_id`.
+Jitsu automatically create aliases in Mixpanel on `user_identify` events if `user.id` or `user.email` is present in event along with `user.anonymous_id`.
 
 ### User Profiles properties and counters
 

--- a/documentation/other-features/admin-endpoints.mdx
+++ b/documentation/other-features/admin-endpoints.mdx
@@ -148,7 +148,7 @@ Evaluates input [JavaScript functions](/docs/configuration/javascript-functions)
     "app": "jitsu_cloud",
     "user": {
       "anonymous_id": "anonym_id",
-      "internal_id": "internal_id"
+      "id": "id"
     },
     "src": "jitsu",
     "event_type": "site_page"

--- a/documentation/other-features/retroactive-user-recognition/index.mdx
+++ b/documentation/other-features/retroactive-user-recognition/index.mdx
@@ -4,7 +4,7 @@ title: User Recognition
 
 # Retroactive User Recognition
 
-**Jitsu** supports storing all events from anonymous users and updates them in DWH with user id after user identification.
+**Jitsu** supports storing all events from anonymous users and updates them in DWH with user id after users identification.
 At present this functionality is supported only for [Postgres](/docs/destinations-configuration/postgres), [Redshift](/docs/destinations-configuration/redshift), [ClickHouse](/docs/destinations-configuration/clickhouse-destination),
 [Snowflake](/docs/destinations-configuration/snowflake) and [MySQL](/docs/destinations-configuration/mysql).
 
@@ -40,10 +40,10 @@ Read <a href="/docs/other-features/retroactive-user-recognition/redis-optimizati
 
 ### Configuration
 
-To enable this feature, set `users_recognition.enabled` to `true` in configuration file. Or use its env variable equivalent `USER_RECOGNITION_ENABLED`.
+To enable this feature, set `users_recognition.enabled` to `true` in the configuration file. Or use its env variable equivalent `USER_RECOGNITION_ENABLED=true`.
 
-This setting will enable user recognition for all supported destinations: Postgres, Redshift, Snowflake, MySQL and ClickHouse. By default,
-`/user/anonymous_id` will be user as a node for getting anonymous_id. `/user/internal_id` and `/user/email` will be used as a source for user identification field
+This setting enables user recognition for all supported destinations: Postgres, Redshift, Snowflake, MySQL and ClickHouse. By default,
+`/user/anonymous_id` will be used as a node for getting anonymous_id. `/user/id` and `/user/email` will be used as a source for user identification field.
 
 Those settings can be redefined on global level of config file:
 
@@ -52,7 +52,7 @@ users_recognition:
   enabled: true #Disabled by default.
   anonymous_id_node: /user/anonymous_id
   identification_nodes:
-    - /user/internal_id
+    - /user/id
     - /user/email
 ```
 
@@ -67,7 +67,7 @@ destinations:
       enabled: true
       anonymous_id_node: /user/anonymous_id
       identification_nodes:
-        - /user/internal_id
+        - /user/id
         - /user/email
 ```
 
@@ -81,7 +81,7 @@ memory optimization. Read more [about options here](/docs/other-features/retroac
 <Hint>
     This feature requires:
     1. <code inline="true">users_recognition.redis</code> or <code inline="true">meta.storage.redis</code> configuration
-    2. <code inline="true">primary_key_fields</code> configuration in Postgres, Redshift, MySQL destination.
+    2. <code inline="true">primary_key_fields</code> configuration in Postgres, Redshift and MySQL destinations.
     Read more about those settings on <a href="/docs/configuration/">General Configuration</a>
 </Hint>
 

--- a/documentation/other-features/retroactive-user-recognition/redis-optimization.mdx
+++ b/documentation/other-features/retroactive-user-recognition/redis-optimization.mdx
@@ -31,7 +31,7 @@ You can configure it with the following steps:
 users_recognition:
   enabled: true
   identification_nodes:
-    - /user/internal_id
+    - /user/id
     - /user/email
   redis:
     host: redis_host
@@ -108,7 +108,7 @@ users_recognition:
   enabled: true
   compression: 'gzip'
   identification_nodes:
-    - /user/internal_id
+    - /user/id
     - /user/email
   redis:
     host: redis_host

--- a/documentation/sending-data/javascript-reference/initialization-parameters.mdx
+++ b/documentation/sending-data/javascript-reference/initialization-parameters.mdx
@@ -31,7 +31,7 @@ If EventNative is [not configured to listen to Google Analytics or Segment event
 eventN.id({
     "name": "Man with No Name",
     "email": "thegoods@western.com",
-    "internal_id": "6"
+    "id": "6"
 })
 ```
 

--- a/documentation/sending-data/js-sdk/migrating.mdx
+++ b/documentation/sending-data/js-sdk/migrating.mdx
@@ -64,7 +64,7 @@ Replace `eventN.init({...opts})` with `let eventN = jitsuClient({...opts})` and 
        //identify user
        jitsu.id({
          "email": getEmail(),
-         "internal_id": getId()
+         "id": getId()
        });
        //track page views
        jitsu.track('app_page');
@@ -84,7 +84,8 @@ Replace `eventN.init({...opts})` with `let eventN = jitsuClient({...opts})` and 
 -eventN.id({
 +jitsu.id({
      "email": getEmail(),
-     "internal_id": getId()
+-    "internal_id": getId()
++    "id": getId()
  });
  //track page views
 -eventN.track('app_page');
@@ -197,7 +198,7 @@ you need to make following changes in your configuration
 
 ### Retroactive users recognition changes
 
-Jitsu saves each anonymous event in Redis. On each identification event server gets saved events by event id from Redis and updates it in Data warehouse.
+Jitsu saves each anonymous event JSON in Redis. On each identification event server gets saved events by event id from Redis and updates them in Data warehouse.
 If you have already had configured users recognition then you should change it in eventnative.yaml according to a new format:
 
 ```
@@ -205,7 +206,8 @@ users_recognition:
  enabled: true
  anonymous_id_node: /eventn_ctx/user/anonymous_id||/user/anonymous_id
  identification_nodes:
-  - /eventn_ctx/user/internal_id||/user/internal_id
+  - /eventn_ctx/user/id||/user/id
+  - /eventn_ctx/user/email||/user/email
 ```
 or just:
 ```

--- a/documentation/sending-data/js-sdk/package.mdx
+++ b/documentation/sending-data/js-sdk/package.mdx
@@ -54,7 +54,7 @@ Jitsu exposes only two methods `id()` - for identifyling users and `track()` for
 jitsu.id({
     "name": "Man with No Name",
     "email": "thegoods@western.com",
-    "internal_id": "6"
+    "id": "6"
 })
 ```
 

--- a/documentation/sending-data/mobile-api.mdx
+++ b/documentation/sending-data/mobile-api.mdx
@@ -37,7 +37,7 @@ JSON array body example:
     "user": {
       "anonymous_id": "sh1ah4rvsasdf",
       "email": "foo@bar.com",
-      "internal_id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
+      "id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
     },
     "user_language": "en-GB",
     "location": {
@@ -70,7 +70,7 @@ JSON array body example:
     "user": {
       "anonymous_id": "sh1ah4rvqeadfasdf",
       "email": "foo@bar.com",
-      "internal_id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
+      "id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
     },
     "user_language": "en-GB",
     "custom_param_2": "34"
@@ -98,7 +98,7 @@ JSON object with template body:
 		"user": {
 			"anonymous_id": "sh1ah4rvqeadsfd",
 			"email": "foo@bar.com",
-			"internal_id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
+			"id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
 		}
 	},
 	"events": [
@@ -162,7 +162,7 @@ Based on this request Jitsu creates 2 events. Both events have fields from `temp
     "user": {
       "anonymous_id": "sh1ah4rvqeadsfd",
       "email": "foo@bar.com",
-      "internal_id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
+      "id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
     }
   },
   {
@@ -186,7 +186,7 @@ Based on this request Jitsu creates 2 events. Both events have fields from `temp
     "user": {
       "anonymous_id": "sh1ah4rvqeadsfd",
       "email": "foo@bar.com",
-      "internal_id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
+      "id": "pzrWMXvtZUThJ24JW5iL2bvG9SA2"
     }
   }
 ]

--- a/server/appconfig/appconfig.go
+++ b/server/appconfig/appconfig.go
@@ -101,7 +101,7 @@ func setDefaultParams(containerized bool) {
 
 	viper.SetDefault("users_recognition.enabled", false)
 	viper.SetDefault("users_recognition.anonymous_id_node", "/eventn_ctx/user/anonymous_id||/user/anonymous_id||/eventn_ctx/user/hashed_anonymous_id||/user/hashed_anonymous_id")
-	viper.SetDefault("users_recognition.identification_nodes", []string{"/eventn_ctx/user/internal_id||/user/internal_id"})
+	viper.SetDefault("users_recognition.identification_nodes", []string{"/eventn_ctx/user/id||/user/id", "/eventn_ctx/user/email||/user/email", "/eventn_ctx/user/internal_id||/user/internal_id"}) // internal_id is DEPRECATED and is set for backward compatibility
 	viper.SetDefault("users_recognition.pool.size", 10)
 
 	viper.SetDefault("singer-bridge.python", "python3")
@@ -141,6 +141,7 @@ func setDefaultParams(containerized bool) {
 		"/anonymousId -> /user/anonymous_id",
 		"/userId -> /ids/ajs_user_id",
 		"/userId -> /user/internal_id",
+		"/userId -> /user/id",
 		"/context/campaign -> /utm",
 		"/context/campaign/name -> /utm/campaign",
 		"/campaign ->",

--- a/server/appconfig/config.template.yaml
+++ b/server/appconfig/config.template.yaml
@@ -416,7 +416,7 @@ destinations:
 ### It is applied to all destinations, but you could override this configuration on the destination level
 ### Note: only Postgres, Clickhouse and Redshift support this feature
 #users_recognition:
-### Optional. Default value is true
+### Optional. Default value is false
 #  enabled: true
 ### Optional. Json path to user anonymous id. Default value is /eventn_ctx/user/anonymous_id.
 ### Note: Set value to /user/anonymous_id while using JS SDK 2.0
@@ -424,7 +424,7 @@ destinations:
 ### Optional. Json path to identification user properties. Default value is /eventn_ctx/user/internal_id
 ### Note: Set value to /user/internal_id while using JS SDK 2.0
 #  identification_nodes:
-#    - /eventn_ctx/user/internal_id
+#    - /eventn_ctx/user/id
 #    - /eventn_ctx/user/email
 
 

--- a/server/integration_tests/retroactive_users_recognition_test.go
+++ b/server/integration_tests/retroactive_users_recognition_test.go
@@ -18,17 +18,17 @@ type recogTestData = struct {
 	testName    string
 	eventIds    []string
 	anonymousId string
-	internalId  string
+	id          string
 	userAgent   string
 	expObjects  []map[string]interface{}
 }
 
 var recogTest = []recogTestData{
 	{"Firefox", []string{"1", "2"}, "anonym1", "id1kk", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:97.0) Gecko/20100101 Firefox/97.0",
-		[]map[string]interface{}{{"eventn_ctx_event_id": "1", "eventn_ctx_user_anonymous_id": "anonym1", "eventn_ctx_user_internal_id": "id1kk"}, {"eventn_ctx_event_id": "2", "eventn_ctx_user_anonymous_id": "anonym1", "eventn_ctx_user_internal_id": "id1kk"}}},
-	//expect for event with eventn_ctx_event_id=3 from Google bot eventn_ctx_user_internal_id still be null
+		[]map[string]interface{}{{"eventn_ctx_event_id": "1", "eventn_ctx_user_anonymous_id": "anonym1", "eventn_ctx_user_id": "id1kk"}, {"eventn_ctx_event_id": "2", "eventn_ctx_user_anonymous_id": "anonym1", "eventn_ctx_user_id": "id1kk"}}},
+	//expect for event with eventn_ctx_event_id=3 from Google bot eventn_ctx_user_id still be null
 	{"GoogleBot", []string{"3", "4"}, "anonym2", "id2kk", "Googlebot/2.1 (+http://www.google.com/bot.html)",
-		[]map[string]interface{}{{"eventn_ctx_event_id": "3", "eventn_ctx_user_anonymous_id": "anonym2", "eventn_ctx_user_internal_id": nil}, {"eventn_ctx_event_id": "4", "eventn_ctx_user_anonymous_id": "anonym2", "eventn_ctx_user_internal_id": "id2kk"}}},
+		[]map[string]interface{}{{"eventn_ctx_event_id": "3", "eventn_ctx_user_anonymous_id": "anonym2", "eventn_ctx_user_id": nil}, {"eventn_ctx_event_id": "4", "eventn_ctx_user_anonymous_id": "anonym2", "eventn_ctx_user_id": "id2kk"}}},
 }
 
 //
@@ -133,7 +133,7 @@ func TestPostgresRetroactiveUsersRecognition(t *testing.T) {
     "event_id": "` + testData.eventIds[1] + `",
     "user": {
       "anonymous_id": "` + testData.anonymousId + `",
-      "internal_id": "` + testData.internalId + `"
+      "id": "` + testData.id + `"
     },
     "user_agent": "` + testData.userAgent + `",
     "utc_time": "2020-12-24T17:55:54.900000Z",
@@ -163,7 +163,7 @@ func TestPostgresRetroactiveUsersRecognition(t *testing.T) {
 
 			time.Sleep(2 * time.Second)
 
-			objects, err := postgresContainer.GetSortedRows("recognition_events", "eventn_ctx_event_id, eventn_ctx_user_anonymous_id, eventn_ctx_user_internal_id", "eventn_ctx_user_anonymous_id='"+testData.anonymousId+"'", "order by eventn_ctx_utc_time")
+			objects, err := postgresContainer.GetSortedRows("recognition_events", "eventn_ctx_event_id, eventn_ctx_user_anonymous_id, eventn_ctx_user_id", "eventn_ctx_user_anonymous_id='"+testData.anonymousId+"'", "order by eventn_ctx_utc_time")
 			require.NoError(t, err, "Error selecting all events")
 
 			require.Equal(t, testData.expObjects, objects, "Objects in DWH and expected objects aren't equal")

--- a/server/jsonutils/paths.go
+++ b/server/jsonutils/paths.go
@@ -44,18 +44,18 @@ func (jpa *JSONPaths) String() string {
 // 	  "key7/key8/key9" -> value3
 func (jpa *JSONPaths) Get(event map[string]interface{}) (map[string]interface{}, bool) {
 	result := false
-	array := make(map[string]interface{})
+	values := make(map[string]interface{})
 
 	for key, path := range jpa.paths {
 		value, answer := path.Get(event)
-		array[key] = value
+		values[key] = value
 		result = result || answer
 	}
 
-	return array, result
+	return values, result
 }
 
-// Set puts values into event according to configuration settings
+// Set puts all non nil values into event according to inner JSON paths settings
 func (jpa *JSONPaths) Set(event map[string]interface{}, values map[string]interface{}) error {
 	for key, path := range jpa.paths {
 		value := values[key]

--- a/server/jsonutils/paths_test.go
+++ b/server/jsonutils/paths_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewPathes(t *testing.T) {
+func TestNewPaths(t *testing.T) {
 	var configuration []string = nil
 	value := NewJSONPaths(configuration)
 	require.NotNil(t, value)
@@ -29,7 +29,7 @@ func TestNewPathes(t *testing.T) {
 	require.Len(t, value.paths, 3)
 }
 
-func TestGetPathes(t *testing.T) {
+func TestGetPaths(t *testing.T) {
 	var configuration []string = nil
 
 	event := map[string]interface{}{
@@ -66,17 +66,19 @@ func TestGetPathes(t *testing.T) {
 	require.Equal(t, "value", object["key3"])
 }
 
-func TestSetPathes(t *testing.T) {
+func TestSetPaths(t *testing.T) {
 	var configuration []string = nil
 
 	event := map[string]interface{}{
 		"key1": 7,
+		"key4": 10,
 	}
 
 	values := map[string]interface{}{
 		"key1": 42,
 		"key2": "value",
 		"key3": true,
+		"key4": nil,
 	}
 
 	pathes := NewJSONPaths(configuration)
@@ -85,6 +87,7 @@ func TestSetPathes(t *testing.T) {
 	require.Equal(t, 7, event["key1"])
 	require.Equal(t, nil, event["key2"])
 	require.Equal(t, nil, event["key3"])
+	require.Equal(t, 10, event["key4"])
 
 	configuration = []string{"key/subkey"}
 	pathes = NewJSONPaths(configuration)
@@ -93,12 +96,14 @@ func TestSetPathes(t *testing.T) {
 	require.Equal(t, 7, event["key1"])
 	require.Equal(t, nil, event["key2"])
 	require.Equal(t, nil, event["key3"])
+	require.Equal(t, 10, event["key4"])
 
-	configuration = []string{"key1", "key2", "key3"}
+	configuration = []string{"key1", "key2", "key3", "key4"}
 	pathes = NewJSONPaths(configuration)
 	err = pathes.Set(event, values)
 	require.Nil(t, err)
 	require.Equal(t, 42, event["key1"])
 	require.Equal(t, "value", event["key2"])
 	require.Equal(t, true, event["key3"])
+	require.Equal(t, 10, event["key4"])
 }

--- a/server/schema/segment.js
+++ b/server/schema/segment.js
@@ -20,10 +20,10 @@ function toSegment($) {
 
   return {
     JITSU_TABLE_NAME: tableName($),
-    name: $.src_payload?.name,
+    name: $.src_payload?.name || payloadObj.traits?.name,
     title: context.page_title || page.title,
     url: context.url || page.url,
-    user_id: user.internal_id || payloadObj.userId,
+    user_id: user.id || user.internal_id || payloadObj.userId,
     anonymous_id: user.anonymous_id || payloadObj.anonymousId,
     context_library_version: payloadObj.context?.library?.version,
     context_page_referrer: page.referrer,
@@ -43,7 +43,6 @@ function toSegment($) {
     context_locale: context.user_language || payloadObj.context?.locale,
     context_page_path: page.path,
     context_page_title: page.title,
-    name: payloadObj.traits?.name,
     email: user.email || payloadObj.traits?.email,
     context_campaign_source: utm.campaign,
     app: $.app,

--- a/server/test_data/segment_api_events_output_2.0.json
+++ b/server/test_data/segment_api_events_output_2.0.json
@@ -245,6 +245,7 @@
       "firstName": "Ned",
       "hashed_anonymous_id":"fae67b1cccc98d3e7e1f722238568662",
       "internal_id": "user1",
+      "id": "user1",
       "lastName": "Stark",
       "role": "the Lord of Winterfell"
     },
@@ -332,6 +333,7 @@
       "firstName": "Ned",
       "hashed_anonymous_id":"fae67b1cccc98d3e7e1f722238568662",
       "internal_id": "user1",
+      "id": "user1",
       "lastName": "Stark",
       "role": "the Lord of Winterfell"
     },
@@ -418,6 +420,7 @@
       "firstName": "Ned",
       "hashed_anonymous_id":"fae67b1cccc98d3e7e1f722238568662",
       "internal_id": "user1",
+      "id": "user1",
       "lastName": "Stark",
       "role": "the Lord of Winterfell"
     },
@@ -508,6 +511,7 @@
       "firstName": "Ned",
       "hashed_anonymous_id":"fae67b1cccc98d3e7e1f722238568662",
       "internal_id": "user1",
+      "id": "user1",
       "lastName": "Stark",
       "role": "the Lord of Winterfell"
     },

--- a/server/test_data/segment_function_identify_event_output.json
+++ b/server/test_data/segment_function_identify_event_output.json
@@ -42,7 +42,8 @@
     "email": "mbrown@example.com",
     "hashed_anonymous_id":"f56dca73ba080f5ac7a401a7b2c4d3d5",
     "internal_id": "f4ca124298",
-    "name": "Michael Brown"
+    "name": "Michael Brown",
+    "id": "f4ca124298"
   },
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
   "user_language": "ru-RU",

--- a/server/test_data/segment_function_track_event_output.json
+++ b/server/test_data/segment_function_track_event_output.json
@@ -42,7 +42,8 @@
   "user": {
     "anonymous_id": "e10d0b70-0a3e-44b5-82ea-43f1372904ee",
     "hashed_anonymous_id":"f56dca73ba080f5ac7a401a7b2c4d3d5",
-    "internal_id": "f4ca124298"
+    "internal_id": "f4ca124298",
+    "id": "f4ca124298"
   },
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
   "user_language": "ru-RU",

--- a/server/users/models.go
+++ b/server/users/models.go
@@ -16,12 +16,12 @@ type EventIdentifiers struct {
 	IdentificationValues map[string]interface{}
 }
 
-func (ei *EventIdentifiers) IsAllIdentificationValuesFilled() bool {
+func (ei *EventIdentifiers) IsAnyIdentificationValueFilled() bool {
 	for _, value := range ei.IdentificationValues {
-		if value == nil {
-			return false
+		if value != nil {
+			return true
 		}
 	}
 
-	return true
+	return false
 }

--- a/server/users/service.go
+++ b/server/users/service.go
@@ -156,12 +156,12 @@ func (rs *RecognitionService) getDestinationsForRecognition(event events.Event, 
 
 		anonymousIDStr := fmt.Sprint(anonymousID)
 
-		properties, ok := configuration.IdentificationJSONPathes.Get(event)
+		values, ok := configuration.IdentificationJSONPathes.Get(event)
 
 		identifiers[destinationID] = EventIdentifiers{
 			EventID:              eventID,
 			AnonymousID:          anonymousIDStr,
-			IdentificationValues: properties,
+			IdentificationValues: values,
 		}
 	}
 
@@ -235,9 +235,9 @@ func (rs *RecognitionService) processRecognitionPayload(rp *RecognitionPayload) 
 	destinationIdentifiers := rs.getDestinationsForRecognition(rp.Event, rp.EventID, rp.DestinationIDs)
 
 	for destinationID, identifiers := range destinationIdentifiers {
-		if identifiers.IsAllIdentificationValuesFilled() {
-			// Run pipeline only if all identification values were recognized,
-			// it is needed to update all other anonymous events
+		if identifiers.IsAnyIdentificationValueFilled() {
+			// Run pipeline if any identification value has been recognized,
+			// then update all other anonymous events
 			if err := rs.reprocessAnonymousEvents(destinationID, identifiers); err != nil {
 				return fmt.Errorf("[%s] Error running recognizing pipeline: %v", destinationID, err)
 			}


### PR DESCRIPTION
[747 issue]: made all identification events which have at least one identification node value a sign to update anonymous events in DWH. 
fixed default recognition identification nodes - now they are: /user/email and /user/id.
