### PR TITLE
API Key UI improvements

### DIFF
--- a/configurator/frontend/src/lib/components/ApiKeys/ApiKeys.tsx
+++ b/configurator/frontend/src/lib/components/ApiKeys/ApiKeys.tsx
@@ -22,6 +22,7 @@ import { default as JitsuClientLibraryCard, jitsuClientLibraries } from "../Jits
 import { Code } from "../Code/Code"
 import { actionNotification } from "../../../ui/components/ActionNotification/ActionNotification"
 import { ApiKeyCard } from "./ApiKeyCard"
+import { Link } from "react-router-dom"
 
 /**
  * What's displayed as loading?
@@ -40,23 +41,6 @@ const ApiKeysComponent: React.FC = () => {
   const [loading, setLoading] = useState<LoadingState>(null)
   const [documentationDrawerKey, setDocumentationDrawerKey] = useState<APIKey>(null)
 
-  let generateNewKey = async () => {
-    setLoading("NEW")
-    try {
-      await keysBackend.add({
-        uid: apiKeysStore.generateApiToken("", 6),
-        serverAuth: apiKeysStore.generateApiToken("s2s"),
-        jsAuth: apiKeysStore.generateApiToken("js"),
-        origins: [],
-      })
-      await flowResult(apiKeysStore.pullApiKeys())
-      actionNotification.info("New API key has been saved!")
-    } catch (error) {
-      actionNotification.error(`Failed to add new token: ${error.message || error}`)
-    } finally {
-      setLoading(null)
-    }
-  }
   const header = (
     <div className="flex flex-row mb-5 items-start justify between">
       <div className="flex-grow flex text-secondaryText">
@@ -82,15 +66,15 @@ const ApiKeysComponent: React.FC = () => {
         !
       </div>
       <div className="flex-shrink">
+        <Link to={'/api-keys/new'}>
         <Button
           type="primary"
           size="large"
           icon={<PlusOutlined />}
           loading={"NEW" === loading}
-          onClick={generateNewKey}
-        >
-          Generate New Key
-        </Button>
+        >Generate New Key
+        </Button></Link>
+
       </div>
     </div>
   )

--- a/configurator/frontend/src/lib/components/ApiKeys/ApiKeys.tsx
+++ b/configurator/frontend/src/lib/components/ApiKeys/ApiKeys.tsx
@@ -66,15 +66,11 @@ const ApiKeysComponent: React.FC = () => {
         !
       </div>
       <div className="flex-shrink">
-        <Link to={'/api-keys/new'}>
-        <Button
-          type="primary"
-          size="large"
-          icon={<PlusOutlined />}
-          loading={"NEW" === loading}
-        >Generate New Key
-        </Button></Link>
-
+        <Link to={"/api-keys/new"}>
+          <Button type="primary" size="large" icon={<PlusOutlined />} loading={"NEW" === loading}>
+            Generate New Key
+          </Button>
+        </Link>
       </div>
     </div>
   )

--- a/configurator/frontend/src/lib/components/ApiKeys/DestinationPicker.tsx
+++ b/configurator/frontend/src/lib/components/ApiKeys/DestinationPicker.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+import { observer } from "mobx-react-lite"
+import { destinationsStore } from "../../../stores/destinations"
+import { Select } from "antd"
+import { DestinationsUtils } from "../../../utils/destinations.utils"
+import { destinationsReferenceMap } from "../../../catalog/destinations/lib"
+import Icon from "@ant-design/icons/lib/components/AntdIcon"
+
+export type DestinationPickerProps = {
+  isSelected: (dst: DestinationData) => boolean
+  allDestinations: DestinationData[]
+
+  onChange?: (value: string[]) => void;
+}
+
+const DestinationPickerComponent: React.FC<DestinationPickerProps> = props => {
+
+  return (
+    <Select
+      mode="multiple"
+      allowClear
+      placeholder="Please select destinations to connect with the key"
+      defaultValue={props.allDestinations.filter(props.isSelected).map(dst => dst._uid)}
+      size="large"
+      onChange={(value) => {
+        props.onChange(value);
+      }}
+    >
+      {props.allDestinations.map(dst => <Select.Option  value={dst._uid}>
+        <div className="flex flex-nowrap space-x-1 items-center">
+          {destinationsReferenceMap[dst._type]?.ui?.icon && <span className="w-6 h-6">{destinationsReferenceMap[dst._type]?.ui?.icon}</span>}
+          <span>{DestinationsUtils.getDisplayName(dst)} ({destinationsReferenceMap[dst._type].displayName})</span>
+        </div>
+      </Select.Option>)}
+    </Select>
+  )
+}
+
+export const DestinationPicker = observer(DestinationPickerComponent)

--- a/configurator/frontend/src/lib/components/ApiKeys/DestinationPicker.tsx
+++ b/configurator/frontend/src/lib/components/ApiKeys/DestinationPicker.tsx
@@ -10,11 +10,10 @@ export type DestinationPickerProps = {
   isSelected: (dst: DestinationData) => boolean
   allDestinations: DestinationData[]
 
-  onChange?: (value: string[]) => void;
+  onChange?: (value: string[]) => void
 }
 
 const DestinationPickerComponent: React.FC<DestinationPickerProps> = props => {
-
   return (
     <Select
       mode="multiple"
@@ -22,16 +21,22 @@ const DestinationPickerComponent: React.FC<DestinationPickerProps> = props => {
       placeholder="Please select destinations to connect with the key"
       defaultValue={props.allDestinations.filter(props.isSelected).map(dst => dst._uid)}
       size="large"
-      onChange={(value) => {
-        props.onChange(value);
+      onChange={value => {
+        props.onChange(value)
       }}
     >
-      {props.allDestinations.map(dst => <Select.Option  value={dst._uid}>
-        <div className="flex flex-nowrap space-x-1 items-center">
-          {destinationsReferenceMap[dst._type]?.ui?.icon && <span className="w-6 h-6">{destinationsReferenceMap[dst._type]?.ui?.icon}</span>}
-          <span>{DestinationsUtils.getDisplayName(dst)} ({destinationsReferenceMap[dst._type].displayName})</span>
-        </div>
-      </Select.Option>)}
+      {props.allDestinations.map(dst => (
+        <Select.Option value={dst._uid}>
+          <div className="flex flex-nowrap space-x-1 items-center">
+            {destinationsReferenceMap[dst._type]?.ui?.icon && (
+              <span className="w-6 h-6">{destinationsReferenceMap[dst._type]?.ui?.icon}</span>
+            )}
+            <span>
+              {DestinationsUtils.getDisplayName(dst)} ({destinationsReferenceMap[dst._type].displayName})
+            </span>
+          </div>
+        </Select.Option>
+      ))}
     </Select>
   )
 }

--- a/configurator/frontend/src/lib/components/Form/Form.tsx
+++ b/configurator/frontend/src/lib/components/Form/Form.tsx
@@ -24,7 +24,7 @@ type FormLayoutProps = {
 
 export const FormField: React.FC<FormFieldProps> = ({ children, label, tooltip, splitter = false }: FormFieldProps) => {
   return (
-    <div className={`flex flex-wrap items-start w-full py-4 ${splitter && "border-b border-splitBorder"}`}>
+    <div className={`flex flex-nowrap items-start w-full py-4 ${splitter && "border-b border-splitBorder"}`}>
       <div style={{ width: "20em", minWidth: "20em" }} className="font-semibold">
         {tooltip ? <LabelWithTooltip documentation={tooltip} render={label} /> : label}
       </div>

--- a/configurator/frontend/src/ui/pages/ConnectionsPage/ConnectionsPage.tsx
+++ b/configurator/frontend/src/ui/pages/ConnectionsPage/ConnectionsPage.tsx
@@ -241,7 +241,7 @@ const AddSourceDropdownOverlay: React.FC = () => {
         {
           id: "api_key",
           title: "Add JS Events API Key",
-          link: "/api_keys",
+          link: "/api-keys/new",
         },
         {
           id: "connectors",


### PR DESCRIPTION
 - Fix API key creation from connections page (it wasn't working)
 - API key creation now works differently: it does not save a new key before opening the form
 - Now it's possible to link destination with key right from API key editing path