### PR TITLE
Send to fallback malformed JSON events from file batches #756

### DIFF
--- a/server/drivers/amplitude/adapter.go
+++ b/server/drivers/amplitude/adapter.go
@@ -285,37 +285,45 @@ func parseEvents(income []byte) ([]map[string]interface{}, error) {
 	eventsArray := make([]map[string]interface{}, 0)
 
 	for _, file := range zipReader.File {
-		fileReader, err := file.Open()
+		array, err := parseFileWithEvents(file)
 		if err != nil {
 			return nil, err
 		}
-		defer fileReader.Close()
-
-		buffer, err := ioutil.ReadAll(fileReader)
-		if err != nil {
-			return nil, err
-		}
-
-		gzipReader, err := gzip.NewReader(bytes.NewReader(buffer))
-		if err != nil {
-			return nil, err
-		}
-		defer gzipReader.Close()
-
-		content, err := ioutil.ReadAll(gzipReader)
-		if err != nil {
-			return nil, err
-		}
-
-		array, err := parsers.ParseJSONFile(content)
-		if err != nil {
-			return nil, err
-		}
-
 		eventsArray = append(eventsArray, array...)
 	}
 
 	return eventsArray, nil
+}
+
+func parseFileWithEvents(file *zip.File) ([]map[string]interface{}, error) {
+	fileReader, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer fileReader.Close()
+
+	buffer, err := ioutil.ReadAll(fileReader)
+	if err != nil {
+		return nil, err
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(buffer))
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+
+	content, err := ioutil.ReadAll(gzipReader)
+	if err != nil {
+		return nil, err
+	}
+
+	array, err := parsers.ParseJSONFile(content)
+	if err != nil {
+		return nil, err
+	}
+
+	return array, nil
 }
 
 type dashboardData struct {

--- a/server/events/event.go
+++ b/server/events/event.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/maputils"
+	"github.com/jitsucom/jitsu/server/parsers"
 )
 
 //Event is a dto for deserialization input events
@@ -28,9 +29,10 @@ func (se *SkippedEvents) IsEmpty() bool {
 
 //FailedEvent is a dto for serialization fallback events
 type FailedEvent struct {
-	Event   json.RawMessage `json:"event,omitempty"`
-	Error   string          `json:"error,omitempty"`
-	EventID string          `json:"event_id,omitempty"`
+	MalformedEvent string          `json:"malformed_event,omitempty"`
+	Event          json.RawMessage `json:"event,omitempty"`
+	Error          string          `json:"error,omitempty"`
+	EventID        string          `json:"event_id,omitempty"`
 }
 
 //FailedEvents is a dto for keeping fallback events per src
@@ -63,4 +65,28 @@ func (f Event) Serialize() string {
 //Clone returns copy of event
 func (f Event) Clone() Event {
 	return maputils.CopyMap(f)
+}
+
+//ParseFallbackJSON returns parsed into map[string]interface{} event from events.FailedFact
+func ParseFallbackJSON(line []byte) (map[string]interface{}, error) {
+	fe := &FailedEvent{}
+	err := parsers.ParseJSONAsObject(line, fe)
+	if err != nil {
+		return nil, err
+	}
+
+	if fe.MalformedEvent != "" {
+		return nil, fmt.Errorf("event: %s was sent to fallback because it is malformed (not valid JSON): %s", fe.MalformedEvent, fe.Error)
+	}
+
+	if len(fe.Event) == 0 {
+		return nil, fmt.Errorf("'event' field can't be empty in fallback object: %s", string(line))
+	}
+
+	originalEvent, err := parsers.ParseJSON(fe.Event)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing event %s from fallback: %v", string(line), err)
+	}
+
+	return originalEvent, nil
 }

--- a/server/events/event_test.go
+++ b/server/events/event_test.go
@@ -32,7 +32,7 @@ func TestParseFallbackJSON(t *testing.T) {
 			"input malformed event",
 			`{"malformed_event":"{\"_timestamp\":\"2022-01-26T15:08:24.692087Z\",\"api_key\":\"js.123.aaa\"{\"aa\":123,\"app\":\"jitsu_cloud\"}","error":"malformed event"}`,
 			nil,
-			"event {\"_timestamp\":\"2022-01-26T15:08:24.692087Z\",\"api_key\":\"js.123.aaa\"{\"aa\":123,\"app\":\"jitsu_cloud\"} was sent to fallback because it is malformed (not valid JSON): malformed event",
+			"event: {\"_timestamp\":\"2022-01-26T15:08:24.692087Z\",\"api_key\":\"js.123.aaa\"{\"aa\":123,\"app\":\"jitsu_cloud\"} was sent to fallback because it is malformed (not valid JSON): malformed event",
 		},
 	}
 	for _, tt := range tests {

--- a/server/events/event_test.go
+++ b/server/events/event_test.go
@@ -1,0 +1,49 @@
+package events
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParseFallbackJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputEvent   string
+		expectObject map[string]interface{}
+		expectedErr  string
+	}{
+		{
+			"empty object",
+			`{}`,
+			map[string]interface{}{},
+			"'event' field can't be empty in fallback object: {}",
+		},
+		{
+			"input event",
+			`{"event":{"_timestamp":"2022-01-26T15:08:24.692087Z","api_key":"js.123.aaa","app":"jitsu_cloud"},"error":"some error"}`,
+			map[string]interface{}{
+				"_timestamp": "2022-01-26T15:08:24.692087Z",
+				"api_key":    "js.123.aaa",
+				"app":        "jitsu_cloud",
+			},
+			"",
+		},
+		{
+			"input malformed event",
+			`{"malformed_event":"{\"_timestamp\":\"2022-01-26T15:08:24.692087Z\",\"api_key\":\"js.123.aaa\"{\"aa\":123,\"app\":\"jitsu_cloud\"}","error":"malformed event"}`,
+			nil,
+			"event {\"_timestamp\":\"2022-01-26T15:08:24.692087Z\",\"api_key\":\"js.123.aaa\"{\"aa\":123,\"app\":\"jitsu_cloud\"} was sent to fallback because it is malformed (not valid JSON): malformed event",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseFallbackJSON([]byte(tt.inputEvent))
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr, "Errors aren't equal")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectObject, actual)
+			}
+		})
+	}
+}

--- a/server/fallback/service.go
+++ b/server/fallback/service.go
@@ -121,7 +121,7 @@ func (s *Service) Replay(fileName, destinationID string, rawFile bool) error {
 		return errors.New(errMsg)
 	}
 
-	parserFunc := parsers.ParseFallbackJSON
+	parserFunc := events.ParseFallbackJSON
 	if rawFile {
 		parserFunc = parsers.ParseJSON
 	}

--- a/server/handlers/bulk.go
+++ b/server/handlers/bulk.go
@@ -103,7 +103,7 @@ func extractBulkEvents(c *gin.Context) ([]map[string]interface{}, error) {
 
 	parserFunc := parsers.ParseJSON
 	if c.Query("fallback") == "true" {
-		parserFunc = parsers.ParseFallbackJSON
+		parserFunc = events.ParseFallbackJSON
 	}
 
 	objects, err := parsers.ParseJSONFileWithFunc(payload, parserFunc)

--- a/server/logfiles/uploader.go
+++ b/server/logfiles/uploader.go
@@ -20,6 +20,8 @@ import (
 	"time"
 )
 
+const parsingErrSrc = "parsing"
+
 //PeriodicUploader read already rotated and closed log files
 //Pass them to storages according to tokens
 //Keep uploading log file with result statuses
@@ -99,10 +101,19 @@ func (u *PeriodicUploader) Start() {
 					continue
 				}
 
-				objects, err := parsers.ParseJSONFile(b)
+				objects, parsingErrors, err := parsers.ParseJSONFileWithFuncFallback(b, parsers.ParseJSON)
 				if err != nil {
 					logging.SystemErrorf("Error parsing JSON file [%s] with events: %v", filePath, err)
 					continue
+				}
+
+				if len(parsingErrors) > 0 {
+					if len(objects) == 0 {
+						logging.SystemErrorf("JSON file [%s] contains only records with errors: [%d]. (for instance event [%s]: %vs)", filePath, len(parsingErrors), string(parsingErrors[0].Original), parsingErrors[0].Error)
+						continue
+					}
+
+					logging.Warnf("JSON file %s contains %d malformed events. They are sent to failed log", filePath, len(parsingErrors))
 				}
 
 				//flag for archiving file if all storages don't have errors while storing this file
@@ -148,7 +159,20 @@ func (u *PeriodicUploader) Start() {
 						continue
 					}
 
-					//events which are failed to process
+					//** Fallback **
+					//events that are failed to be parsed
+					if len(parsingErrors) > 0 {
+						var parsingFailedEvents []*events.FailedEvent
+						for _, pe := range parsingErrors {
+							parsingFailedEvents = append(parsingFailedEvents, &events.FailedEvent{
+								MalformedEvent: string(pe.Original),
+								Error:          pe.Error,
+							})
+						}
+						storage.Fallback(parsingFailedEvents...)
+						telemetry.PushedErrorsPerSrc(tokenID, storage.ID(), map[string]int{parsingErrSrc: len(parsingErrors)})
+					}
+					//events that are failed to be processed
 					if !failedEvents.IsEmpty() {
 						storage.Fallback(failedEvents.Events...)
 

--- a/server/parsers/json.go
+++ b/server/parsers/json.go
@@ -8,12 +8,18 @@ import (
 	"io"
 )
 
+type ParseError struct {
+	Original []byte
+	Error    string
+}
+
 //ParseJSONFile converts bytes (JSON objects with \n delimiter) into slice of map with json Numbers
 func ParseJSONFile(b []byte) ([]map[string]interface{}, error) {
 	return ParseJSONFileWithFunc(b, ParseJSON)
 }
 
 //ParseJSONFileWithFunc converts bytes (JSON objects with \n delimiter) into slice of map with json Numbers
+//failfast: returns err if at least 1 occurred
 func ParseJSONFileWithFunc(b []byte, parseFunc func(b []byte) (map[string]interface{}, error)) ([]map[string]interface{}, error) {
 	var objects []map[string]interface{}
 	input := bytes.NewBuffer(b)
@@ -41,46 +47,61 @@ func ParseJSONFileWithFunc(b []byte, parseFunc func(b []byte) (map[string]interf
 	return objects, nil
 }
 
+//ParseJSONFileWithFuncFallback converts bytes (JSON objects with \n delimiter) into slice of map with json Numbers
+//returns slice with events and slice with parsing errors which contains malformed JSON's(malformed lines)
+func ParseJSONFileWithFuncFallback(b []byte, parseFunc func(b []byte) (map[string]interface{}, error)) ([]map[string]interface{}, []ParseError, error) {
+	var parseErrors []ParseError
+	var objects []map[string]interface{}
+	input := bytes.NewBuffer(b)
+	reader := bufio.NewReaderSize(input, 64*1024)
+	line, readErr := reader.ReadBytes('\n')
+
+	for readErr == nil {
+		object, err := parseFunc(line)
+		if err != nil {
+			parseErrors = append(parseErrors, ParseError{
+				Original: line,
+				Error:    err.Error(),
+			})
+		} else {
+			objects = append(objects, object)
+		}
+
+		line, readErr = reader.ReadBytes('\n')
+		if readErr != nil && readErr != io.EOF {
+			return nil, nil, readErr
+		}
+	}
+
+	if readErr != nil && readErr != io.EOF {
+		return nil, nil, readErr
+	}
+
+	return objects, parseErrors, nil
+}
+
 //ParseJSON converts json bytes into map with json Numbers
 //removes first empty bytes if exist
 func ParseJSON(b []byte) (map[string]interface{}, error) {
-	//check if array contains empty bytes in the begging and removes them
-	p := 0
-	for _, v := range b {
-		if v != 0 {
-			break
-		}
-		p++
-	}
-	if p > 0 {
-		b = b[p:]
-	}
-
-	decoder := json.NewDecoder(bytes.NewReader(b))
-	decoder.UseNumber()
-
 	obj := map[string]interface{}{}
-	err := decoder.Decode(&obj)
-	return obj, err
-}
 
-//ParseFallbackJSON returns parsed into map[string]interface{} event from events.FailedFact
-func ParseFallbackJSON(line []byte) (map[string]interface{}, error) {
-	object, err := ParseJSON(line)
+	err := ParseJSONAsObject(b, &obj)
 	if err != nil {
 		return nil, err
 	}
 
-	event, ok := object["event"]
-	if !ok {
-		return nil, fmt.Errorf("Error parsing event %s from fallback: 'event' key doesn't exist", string(line))
-	}
-	objEvent, ok := event.(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("Error parsing event %s from fallback: 'event' key must be json object", string(line))
-	}
+	return obj, nil
+}
 
-	return objEvent, nil
+//ParseJSONAsObject converts json bytes into the object
+//removes first empty bytes if exist
+func ParseJSONAsObject(b []byte, value interface{}) error {
+	b = RemoveFirstEmptyBytes(b)
+
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.UseNumber()
+
+	return decoder.Decode(&value)
 }
 
 //ParseInterface converts interface into json bytes then into map with json Numbers
@@ -95,4 +116,20 @@ func ParseInterface(v interface{}) (map[string]interface{}, error) {
 	obj := map[string]interface{}{}
 	err = decoder.Decode(&obj)
 	return obj, err
+}
+
+//RemoveFirstEmptyBytes checks if array contains empty bytes in the begging and removes them
+func RemoveFirstEmptyBytes(b []byte) []byte {
+	p := 0
+	for _, v := range b {
+		if v != 0 {
+			break
+		}
+		p++
+	}
+	if p > 0 {
+		b = b[p:]
+	}
+
+	return b
 }

--- a/server/schema/processor_test.go
+++ b/server/schema/processor_test.go
@@ -112,7 +112,7 @@ func TestProcessFilePayload(t *testing.T) {
 		},
 		{
 			"Input fallback file",
-			parsers.ParseFallbackJSON,
+			events.ParseFallbackJSON,
 			"../test_data/fallback_fact_input.log",
 			map[string]*ProcessedFile{
 				"user_2020_08": {FileName: "testfile", payload: []map[string]interface{}{


### PR DESCRIPTION
This PR partially fixies #756. Now all malformed JSON events (not valid JSON) will be sent to fallback which allows other events from the same batch to be processed. There will be a warning log message if a batch contains malformed JSON events. 
Fix affects only destinations in batch mode.