### PR TITLE
Fix error in redis LRANGE syntax

### DIFF
--- a/server/drivers/redis/list_key.go
+++ b/server/drivers/redis/list_key.go
@@ -39,7 +39,7 @@ func (lt *listType) get(conn redis.Conn) ([]map[string]interface{}, error) {
 	for start < listLength {
 		end := start + scanChunkSize
 
-		values, err := redis.Strings(conn.Do("LRANGE", lt.key, end))
+		values, err := redis.Strings(conn.Do("LRANGE", lt.key, start, end))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
It looks like Jitsu hasn't worked with Redis all this time. At least from the bdac1ba commit from 18.06.2021.

Redis LRANGE need two arguments, but Jitsu provide only one - https://redis.io/commands/lrange