### PR TITLE
Documentation of Creating Jitsu Destination Plugin using Jitsu SDK.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             cd server && make test_backend | tee ${TEST_RESULTS}/go-test.out
       - store_test_results:
           path: /tmp/test-results
-      - run: go mod tidy
+      - run: go mod download
       - save_cache:
           key: go-mod-v1-{{ checksum "./server/go.sum" }}
           paths:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Build Server
       if: ${{ success() && (steps.go-change.outputs.server == 1 || steps.go-change.outputs.backend == 1) }}
       run: |
-        go mod tidy
+        go mod download
         go build
       working-directory: ./server
 
@@ -66,7 +66,7 @@ jobs:
       run: |
         go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen
         go generate
-        go mod tidy
+        go mod download
         go build
       working-directory: ./configurator/backend
 

--- a/configurator-release.Dockerfile
+++ b/configurator-release.Dockerfile
@@ -39,7 +39,7 @@ WORKDIR /go/src/github.com/jitsucom/jitsu/$CONFIGURATOR_USER/backend
 #Caching dependencies
 ADD configurator/backend/go.mod ./
 ADD server/go.mod /go/src/github.com/jitsucom/jitsu/server/
-RUN go mod tidy && go mod download
+RUN go mod download
 
 #tmp workaround until next version of v8go will be release
 RUN git clone https://github.com/rogchap/v8go.git /tmp/v8go@v0.7.0

--- a/configurator.Dockerfile
+++ b/configurator.Dockerfile
@@ -68,7 +68,7 @@ WORKDIR /go/src/github.com/jitsucom/jitsu/$CONFIGURATOR_USER/backend
 #Caching dependencies
 ADD configurator/backend/go.mod ./
 ADD server/go.mod /go/src/github.com/jitsucom/jitsu/server/
-RUN go mod tidy && go mod download
+RUN go mod download
 
 #tmp workaround until next version of v8go will be release
 RUN git clone https://github.com/rogchap/v8go.git /tmp/v8go@v0.7.0

--- a/configurator/backend/Makefile
+++ b/configurator/backend/Makefile
@@ -31,7 +31,7 @@ go_generate:
 
 deps_backend:
 	echo "Using path $(PATH)"
-	go mod tidy
+	go mod download
 
 build_backend:
 	$(GOBUILD_PREFIX) go build -ldflags "-X main.commit=${commit} -X main.builtAt=${built_at} -X main.tag=${tag}" -o configurator

--- a/documentation/destinations-configuration/npm.mdx
+++ b/documentation/destinations-configuration/npm.mdx
@@ -1,0 +1,41 @@
+# NPM plugins
+
+**Jitsu** supports [Destination Plugins](/docs/extending/destination-plugins).
+New type of destination may be added to Jitsu Server from npm package.
+
+
+## Configuration
+
+NPM based destination configs consist of the following schema:
+
+```yaml
+destinations:
+  my_plugin:
+    type: npm
+    package: jitsu-custom-destination@^1.0.0
+    mode: stream
+    config:
+      #config depends on particular plugin implementation
+```
+
+## Plugin Configuration Parameters
+
+| Parameter | Description |
+| :--- | :--- |
+| `package` (required) | package can be:<ul><li>npm package name - if a plugin is published to npm repository. We recommend providing package name with version expression to prevent backward compatibility issues: jitsu-slack-destination@^1.0.0</li><li>HTTP URL - e.g.: `https://my-site.com/plugins/jitsu-slack-destination.tgz`</li><li>filesystem path - in case of a docker image, provided path needs to be reachable inside of docker image filesystem. `/home/eventnative/data/plugins/` needs to be mounted to host filesystem directory where plugin's .tgz is located, e.g. following param may be added to docker run command: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`</li></ul> |
+
+## Mixpanel v2 Plugin Example
+
+```yaml
+destinations:
+  mixpanel2:
+    type: npm
+    package: jitsu-mixpanel-destination@^0.2.0
+    mode: stream
+    config:
+      anonymous_users_enabled: false
+      api_secret: "abc"
+      project_id: "123456"
+      token: "ZZZZZZZ"
+      users_enabled: true
+```

--- a/documentation/extending/destination-plugins.mdx
+++ b/documentation/extending/destination-plugins.mdx
@@ -126,7 +126,7 @@ If everything is fine we should get following output:
 ## Pushing to the destination
 
 Lets get to the main part of plugin – pushing data to the target destination.
-We need to replace placeholder of DestinationFunction with the proper version:
+We need to write proper version of DestinationFunction instead of placeholder:
 ```typescript
 export const destination: DestinationFunction = (event: DefaultJitsuEvent, dstContext: JitsuDestinationContext<DestinationConfig>) => {
   return { url: "https://test.com", method: "POST", body: { a: (event.a || 0) + 1 } };
@@ -138,12 +138,15 @@ DestinationFunction receives two parameters:
  * **dstContext** - type: JitsuDestinationContext - destination context containing: **destinationId**, **destinationType**
 and what is more important: **config** - config object that we described in the beginning filled by Jitsu Server
 
-Return values:
-As we mentioned in the beginning, plugin itself don't send anything to internet. Instead,
-DestinationFunction may return: a single instance of DestinationMessage, array of DestinationMessage's or null.
-When DestinationFunction return null it means that Jitsu must skip this event.
+**Return values**:
 
-DestinationMessage is an object that tells Jitsu Server what HTTP request it needs to make to push data to the destination.
+As we mentioned in the beginning, plugin itself doesn't send anything to internet. Instead,
+DestinationFunction may return:
+ * a single instance of DestinationMessage
+ * array of DestinationMessage's - to produce multiple pushes to destination
+ * null - null means that Jitsu must skip this event.
+
+DestinationMessage is an object that tells Jitsu Server what HTTP request it needs to make to push data to the destination:
 ```typescript
 export declare type DestinationMessage = {
   url: string;
@@ -177,6 +180,7 @@ To implement the test we need to fill DestinationTestParams properties and pass 
 ```typescript
 testDestination({
   name: "proper case",
+
   context: {
     destinationId: "test",
     destinationType: "twitter",
@@ -185,7 +189,9 @@ testDestination({
       "accessToken":"Q0Mzb0VhZ0"
     }
   },
+
   destination: destination,
+
   event: {
     event_type: 'registration',
     user: {
@@ -193,6 +199,7 @@ testDestination({
       email: "test_new_user@example.com"
     }
   },
+
   expectedResult: {
     method: "POST",
     url: "https://api.twitter.com/2/tweets",
@@ -264,7 +271,7 @@ Tests:       1 passed, 1 total
 ```
 
 Ok main logic is ready. But nothing appears on Twitter yet. We need Jitsu for that.
-But before we add our plugin to Jitsu lets fill some meta information that will help users identify plugin, understand its purpose and properly set config parameters.
+But before we add our plugin to Jitsu lets fill some meta information that will help users to identify plugin, understand its purpose and properly set config parameters.
 
 ## Providing meta information
 
@@ -323,7 +330,7 @@ In case of our destination command will look like:
 tar -cvzf jitsu-twitter-destination.tgz -C /Users/testaccount/projects/ jitsu-twitter-destination
 ```
 
-**jitsu-twitter-destination.tgz** file will appear in current directory.
+`jitsu-twitter-destination.tgz` file will appear in current directory.
 
 #### publish to npm repository
 
@@ -360,7 +367,7 @@ destinations:
 **package** can be:
  * **filesystem path** - in case of docker image, provided path need to be reachable inside of docker image filesystem.
 /home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where file jitsu-twitter-destination.tgz is located,
-e.g.: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`
+e.g. following param may be added to docker run command: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`
  * **HTTP URL** - e.g.: `https://my-site.com/plugins/jitsu-twitter-destination.tgz`
  * **npm package name** - in case plugin is published to npm repository. It is recommended to provide package name with version expression,
 to prevent backward compatibility issues when new version of plugin will require some features that current version of server doesn't support,

--- a/documentation/extending/destination-plugins.mdx
+++ b/documentation/extending/destination-plugins.mdx
@@ -65,7 +65,7 @@ Config will consist from oauth 2.0 access token and text template for tweets:
 ```typescript
 export type DestinationConfig = {
   accessToken: string, //oauth 2.0 access token
-  tweetTemplate: string //string literals template e.g. `Welcome new user ${event.user.email} !🎉`
+  tweetTemplate: string //string literals template e.g. `Welcome new user ${event.user?.id} !🎉`
 }
 ```
 
@@ -113,7 +113,7 @@ export const validator: ConfigValidator<DestinationConfig> = async (config: Dest
 Now we can test our validator with validate-config action that jitsu-cli already added to the project
 
 ```shell
-yarn build && yarn validate-config -j '{"tweetTemplate":"Welcome new user ${event.user.email} !🎉", "accessToken":"Q0Mzb0VhZ0"}'
+yarn build && yarn validate-config -j '{"tweetTemplate":"Welcome new user ${event.user?.id} !🎉", "accessToken":"Q0Mzb0VhZ0"}'
 ```
 
 If everything is fine we should get following output:
@@ -181,7 +181,7 @@ testDestination({
     destinationId: "test",
     destinationType: "twitter",
     config: {
-      "tweetTemplate":"Welcome new user ${event.user.id}!🎉",
+      "tweetTemplate":"Welcome new user ${event.user?.id}!🎉",
       "accessToken":"Q0Mzb0VhZ0"
     }
   },
@@ -291,7 +291,7 @@ const descriptor: ExtensionDescriptor = {
       type: "string",
       required: true,
       displayName: "Tweet template",
-      documentation: "Template of tweet text.<br/>You can use string literals expressions to add values from incoming event, e.g.:<br/>Welcome ${event.user.email}<br/>Received event ${event.event_type}"
+      documentation: "Template of tweet text.<br/>You can use string literals expressions to add values from incoming event, e.g.:<br/>Welcome ${event.user?.id}<br/>Received event ${event.event_type}"
     }
   ],
 };
@@ -301,6 +301,73 @@ if you want Jitsu to display nice graphic icon along with destination name you n
 
 ## Adding to Jitsu
 
-### manual tarball
+To add our plugin to jitsu we need to build it and make package.
 
-### npm publish
+To build plugin code use:
+```shell
+yarn build
+```
+For making package there are 2 options:
+
+#### handmade .tgz tarball
+
+Making .tgz is fast and simple.
+This way is perfect if we don't plan to share our plugin with anybody else.
+
+Use command like that to make compressed .tgz package of destination project directory:
+```shell
+tar -cvzf package_name.tgz -C /workspace_directory/ destination_project_directory
+```
+In case of our destination command will look like:
+```shell
+tar -cvzf jitsu-twitter-destination.tgz -C /Users/testaccount/projects/ jitsu-twitter-destination
+```
+
+**jitsu-twitter-destination.tgz** file will appear in current directory.
+
+#### publish to npm repository
+
+In case we want to share plugin with other people - publishing to public npm repository is a preferable way.
+You need to have account in https://www.npmjs.com
+
+The following commands in project directory may be used to publish package to npmjs repository.
+```shell
+npm login
+```
+```shell
+npm publish
+```
+npm will ask to provide some additional details to complete publishing
+
+### Setting up Jitsu Server
+
+Users of standalone jitsu server can setup destination based on plugin since version 1.38.
+Simply add new destination of type **npm**, information about plugin package and config to `eventnative.yaml` config file:
+```yaml
+destinations:
+...
+  my_twitter_destination:
+    only_tokens:
+      - my_token
+    type: npm
+    package: /home/eventnative/data/plugins/jitsu-twitter-destination.tgz
+    mode: stream
+    config:
+      accessToken: "Q0Mzb0VhZ0"
+      tweetTemplate: "Welcome new user ${event.user?.id} !\U0001F389"
+```
+
+**package** can be:
+ * **filesystem path** - in case of docker image, provided path need to be reachable inside of docker image filesystem.
+/home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where file jitsu-twitter-destination.tgz is located,
+e.g.: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`
+ * **HTTP URL** - e.g.: `https://my-site.com/plugins/jitsu-twitter-destination.tgz`
+ * **npm package name** - in case plugin is published to npm repository. It is recommended to provide package name with version expression,
+to prevent backward compatibility issues when new version of plugin will require some features that current version of server doesn't support,
+e.g.: `jitsu-twitter-destination@^1.0.0`
+
+### Setting up Jitsu Joint Image or Configurator UI
+
+UI support for adding plugin based destinations is not ready yet.
+To make your destination plugin appear in Jitsu Configurator UI please create a new ticket or pull request in
+[jitsu repository](https://github.com/jitsucom/jitsu)

--- a/documentation/extending/destination-plugins.mdx
+++ b/documentation/extending/destination-plugins.mdx
@@ -2,19 +2,13 @@
 title: Destination Plugins
 ---
 
-With Jitsu SDK you can implement plugins for Jitsu using Typescript language.
-
-Plugin types:
- * Destination
- * Transformation (Not implemented yet)
- * Source (Not implemented yet)
-
 # Destination Plugin
+
+Jitsu Destination Plugins allows anyone to implement new destination type for Jitsu,
+and publish it to make it available for all users of Jitsu.
 
 Jitsu Destination Plugins are designed to work with HTTP based APIs.
 Plugin receives Jitsu event and returns object describing HTTP requests necessary to push data to destination.
-Jitsu server is in charge of queuing, executing and retrying HTTP requests the same as with builtin destinations like webhook.
-Main plugin code doesn't have access to any external resources and doesn't support async execution.
 
 ## Create New Destination Plugin
 
@@ -143,8 +137,8 @@ and what is more important: **config** - config object that we described in the 
 
 **Return values**:
 
-As we mentioned in the beginning, plugin itself doesn't send anything to internet. Instead,
-DestinationFunction may return:
+Main plugin code doesn't support async execution and doesn't have access to any external resources.
+Instead, DestinationFunction needs to return:
  * a single instance of DestinationMessage
  * array of DestinationMessage's - to produce multiple pushes to destination
  * null - null means that Jitsu must skip this event.
@@ -158,6 +152,7 @@ export declare type DestinationMessage = {
   body: any;
 };
 ```
+Jitsu server is in charge of queuing, executing and retrying HTTP requests the same as with builtin destinations like webhook.
 
 ### Writing a test
 
@@ -354,33 +349,16 @@ if you want Jitsu to display nice graphic icon along with destination name you n
 
 ## Adding to Jitsu
 
-To add our plugin to jitsu we need to build it and make package.
+To add our plugin to jitsu we need to build it and publish.
 
 To build plugin code use:
 ```shell
 yarn build
 ```
-For making package there are 2 options:
 
-#### handmade .tgz tarball
+### publish to npm repository
 
-Making .tgz is fast and simple.
-This way is perfect if we don't plan to share our plugin with anybody else.
-
-Use command like that to make compressed .tgz package of destination project directory:
-```shell
-tar -cvzf package_name.tgz -C /workspace_directory/ destination_project_directory
-```
-In case of our destination command will look like:
-```shell
-tar -cvzf jitsu-slack-destination.tgz -C /Users/testaccount/projects/ jitsu-slack-destination
-```
-
-`jitsu-slack-destination.tgz` file will appear in current directory.
-
-#### publish to npm repository
-
-In case we want to share plugin with other people - publishing to public npm repository is a preferable way.
+Publishing plugin to public npm repository to make it available for other users..
 You need to have account in https://www.npmjs.com
 
 The following commands in project directory may be used to publish package to npmjs repository.
@@ -403,7 +381,7 @@ destinations:
     only_tokens:
       - my_token
     type: npm
-    package: /home/eventnative/data/plugins/jitsu-slack-destination.tgz
+    package: jitsu-slack-destination@^1.0.0
     mode: stream
     config:
       webhookUrl: "https://hooks.slack.com/services/ABC/XYZ/etc"
@@ -412,16 +390,36 @@ destinations:
 ```
 
 **package** can be:
- * **filesystem path** - in case of docker image, provided path need to be reachable inside of docker image filesystem.
-/home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where file jitsu-slack-destination.tgz is located,
-e.g. following param may be added to docker run command: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`
- * **HTTP URL** - e.g.: `https://my-site.com/plugins/jitsu-slack-destination.tgz`
  * **npm package name** - in case plugin is published to npm repository. It is recommended to provide package name with version expression,
 to prevent backward compatibility issues when new version of plugin will require some features that current version of server doesn't support,
 e.g.: `jitsu-slack-destination@^1.0.0`
+ * **HTTP URL** - e.g.: `https://my-site.com/plugins/jitsu-slack-destination.tgz`
+ * **filesystem path** - in case of docker image, provided path need to be reachable inside of docker image filesystem.
+/home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where file jitsu-slack-destination.tgz is located,
+e.g. following param may be added to docker run command: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`
 
 ### Setting up Jitsu Joint Image or Configurator UI
 
 UI support for adding plugin based destinations is not ready yet.
 To make your destination plugin appear in Jitsu Configurator UI please create a new ticket or pull request in
 [jitsu repository](https://github.com/jitsucom/jitsu)
+
+### Publishing plugin locally
+
+In case that there is no intention to publish plugin for other users you can keep it for yourself.
+
+You need to build .tgz package manually:
+
+Use command like that to make compressed .tgz package of destination project directory:
+```shell
+tar -cvzf package_name.tgz -C /workspace_directory/ destination_project_directory
+```
+In case of our destination command will look like:
+```shell
+tar -cvzf jitsu-slack-destination.tgz -C /Users/testaccount/projects/ jitsu-slack-destination
+```
+`jitsu-slack-destination.tgz` file will appear in current directory.
+
+See [Setting Up Jitsu Server](#setting-up-jitsu-server) to check how to pass local package to Jitsu Server
+
+

--- a/documentation/extending/destination-plugins.mdx
+++ b/documentation/extending/destination-plugins.mdx
@@ -181,7 +181,7 @@ testDestination({
     destinationId: "test",
     destinationType: "twitter",
     config: {
-      "tweetTemplate":"Welcome new user ${event.user.id} !🎉",
+      "tweetTemplate":"Welcome new user ${event.user.id}!🎉",
       "accessToken":"Q0Mzb0VhZ0"
     }
   },
@@ -216,22 +216,91 @@ yarn test
 Test fails because we still need to replace placeholder for DestinationFunction with proper implementation.
 
 In real plugin for production usage one test for "proper case" probably won't be enough.
-It would be great to add test cases when Jitsu Event doesn't have user.id or event_type is not "registration"
+It would be great to add test cases when event_type is not "registration"
 to make sure that nothing bad happens in that cases and we get **null** result.
-
 
 
 ### Writing DestinationFunction
 
-
 Now we can write DestinationFunction implementation that prepares DestinationMessage with HTTP request that creates a new tweet.
-DestinationFunction must skip all events with event type other than "registration" and events that dont contain user.id information.
-Let's get back to the **src/destination.ts** file and write some code.
+DestinationFunction must skip all events with event type other than "registration".
+Let's get back to the **src/destination.ts** file and write some code:
 
+```typescript
+export const destination: DestinationFunction = (event: DefaultJitsuEvent, dstContext: JitsuDestinationContext<DestinationConfig>) => {
+  if (event.event_type != "registration") {
+    return null
+  }
+  let tweetText = eval("`" + dstContext.config.tweetTemplate + "`")
+  if (!tweetText) {
+    return null;
+  }
+  return {
+    url: "https://api.twitter.com/2/tweets",
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer " + dstContext.config.accessToken,
+      "Content-type": "application/json",
+    },
+    body: {
+      "text": tweetText
+    }
+  };
+};
+```
 
-##
+That is it!
+Now let's run tests again to make sure that everything works fine.
+```shell
+yarn test
+```
+Output must contain following line.
+```text
+ PASS  __test__/destination.test.ts
+  ✓ proper case (1 ms)
 
-npm publish
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+```
 
-##
-how to add to Jitsu
+Ok main logic is ready. But nothing appears on Twitter yet. We need Jitsu for that.
+But before we add our plugin to Jitsu lets fill some meta information that will help users identify plugin, understand its purpose and properly set config parameters.
+
+## Providing meta information
+
+Let's open file **src/index.ts**
+Here we can find placeholder object that jitsu-cli made for us.
+Let's fill it with some real data
+
+```typescript
+const descriptor: ExtensionDescriptor = {
+  id: "jitsu-twitter-destination",
+  displayName: "Twitter",
+  icon: "<svg xmlns=\"http:\/\/www.w3.org\/2000\/svg\" xml:space=\"preserve\" width=\"70.5556mm\" height=\"57.3391mm\" version=\"1.1\" style=\"shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd\"\r\nviewBox=\"0 0 6701 5446\"\r\n xmlns:xlink=\"http:\/\/www.w3.org\/1999\/xlink\">\r\n <defs>\r\n  <style type=\"text\/css\">\r\n   <![CDATA[\r\n    .fil0 {fill:#41ABE1}\r\n   ]]>\r\n  <\/style>\r\n <\/defs>\r\n <g id=\"Livello_x0020_1\">\r\n  <metadata id=\"CorelCorpID_0Corel-Layer\"\/>\r\n  <path class=\"fil0\" d=\"M6701 645c-247,109 -512,183 -790,216 284,-170 502,-440 604,-761 -266,158 -560,272 -873,334 -251,-267 -608,-434 -1004,-434 -759,0 -1375,616 -1375,1375 0,108 12,213 36,313 -1143,-57 -2156,-605 -2834,-1437 -118,203 -186,439 -186,691 0,477 243,898 612,1144 -225,-7 -437,-69 -623,-172 0,6 0,11 0,17 0,666 474,1222 1103,1348 -115,31 -237,48 -362,48 -89,0 -175,-9 -259,-25 175,546 683,944 1284,955 -471,369 -1063,589 -1708,589 -111,0 -220,-7 -328,-19 608,390 1331,618 2108,618 2529,0 3912,-2095 3912,-3912 0,-60 -1,-119 -4,-178 269,-194 502,-436 686,-712z\"\/>\r\n <\/g>\r\n<\/svg>",
+  description: "Destination that posts a tweet welcoming new user on receiving \"registration\" event.",
+  configurationParameters: [
+    {
+      id: "accessToken",
+      type: "string",
+      required: true,
+      displayName: "Access Token",
+      documentation: "Oauth 2.0 Access Token"
+    },
+    {
+      id: "tweetTemplate",
+      type: "string",
+      required: true,
+      displayName: "Tweet template",
+      documentation: "Template of tweet text.<br/>You can use string literals expressions to add values from incoming event, e.g.:<br/>Welcome ${event.user.email}<br/>Received event ${event.event_type}"
+    }
+  ],
+};
+```
+
+if you want Jitsu to display nice graphic icon along with destination name you need to provide svg code of icon to "icon" parameter of ExtensionDescriptor.
+
+## Adding to Jitsu
+
+### manual tarball
+
+### npm publish

--- a/documentation/extending/destination-plugins.mdx
+++ b/documentation/extending/destination-plugins.mdx
@@ -19,7 +19,8 @@ Main plugin code doesn't have access to any external resources and doesn't suppo
 ## Create New Destination Plugin
 
 In this article we explain creation of Jitsu destination plugin step by step.
-As an example we implement a simple destination that will post a tweet welcoming new user on receiving Jitsu event with event_type = "registration".
+As an example we implement a simple destination that will post message to a Slack webhook 
+on receiving Jitsu event with provided types.
 
 ## Bootstrapping project
 
@@ -31,9 +32,9 @@ npx jitsu-cli extension create --type destination
 
 We need to provide project name and directory.
 ```text
-? Please, provide project name: jitsu-twitter-destination
-? Project directory: /Users/testaccount/projects/jitsu-twitter-destination
-[info ] - Creating new jitsu project in /Users/testaccount/projects/jitsu-twitter-destination
+? Please, provide project name: jitsu-slack-destination
+? Project directory: /Users/testaccount/projects/jitsu-slack-destination
+[info ] - Creating new jitsu project in /Users/testaccount/projects/jitsu-slack-destination
 [info ] - Project directory doesn't exist, creating it!
 [info ] - ✨ Done
 ```
@@ -59,66 +60,68 @@ id, icon,  name, description, configuration parameters.
 ## Destination Config
 
 No destination can work without configuration.
-Let's open **src/destination.ts** file and prepare DestinationConfig object for out Twitter destination.
-Config will consist from oauth 2.0 access token and text template for tweets:
+Let's open **src/destination.ts** file and prepare DestinationConfig object for out Slack destination.
+Config will consist from webhook url, list of event types to react on and message template for Slack message:
 
 ```typescript
 export type DestinationConfig = {
-  accessToken: string, //oauth 2.0 access token
-  tweetTemplate: string //string literals template e.g. `Welcome new user ${event.user?.id} !🎉`
+  webhookUrl: string, //url of slack webhook https://hooks.slack.com/services/ABC/XYZ/etc
+  eventTypes: string, //comma separated list of event types to trigger Slack message
+  messageTemplate: string //message template that will be filled with data from event e.g. `New event: ${event_type}!`
 }
 ```
 
-Destination plugin must not handle authorization process. If our twitter plugin manage to become part of Jitsu server -
-Jitsu server will handle authorization and obtain accessToken. For UI users that will look like "Grant Jitsu Access to Twitter" button.
-
-What plugin can do – is to check validness of access token.
+It is nice to tell users in advance in case they make a mistake in config.
+That is why destination plugin have ConfigValidator
 
 ## Validating Config
 
 Once we have destination config we can implement **validator**.
 It is optional part, but it is highly recommended to implement it.
 
+ConfigValidator is the only part of plugin that can access internet using `fetch` method.
+The main logic of plugins relies on Jitsu Server pipelines for sending HTTP requests
+
 We replace placeholder implementation with to following code
 ```typescript
 export const validator: ConfigValidator<DestinationConfig> = async (config: DestinationConfig) => {
   //check that all config parameters are present
-  if (!config.tweetTemplate) {
-    return "Missing required parameter: tweetTemplate";
+  if (!config.webhookUrl) {
+    return "Missing required parameter: webhookUrl";
   }
-  if (!config.accessToken) {
-    return "Missing required parameter: accessToken";
+  if (!config.eventTypes) {
+    return "Missing required parameter: eventTypes";
   }
-  //check that authorization passed
-  return await fetch("https://api.twitter.com/2/users/me", {
-    method: 'get',
-    headers: {
-      "Authorization": "Bearer " + config.accessToken
+  if (!config.messageTemplate) {
+    return "Missing required parameter: messageTemplate";
+  }
+  //check validness of provided webhookUrl.
+  try {
+    //validator must not send any real messages, so we intentionally miss request body
+    let response = await fetch(config.webhookUrl, { method: 'post' });
+    let responseText = await response.text()
+    if (responseText == "invalid_payload") {
+      //invalid_payload - is success case because we haven't sent any. It means that webhookUrl is correct
+      //otherwise that would be other kind of error response
+      return true
+    } else {
+      return "Error: " + responseText
     }
-  }).then(response => response.json())
-      .then(result => {
-        if (result.data) {
-          //we got data in response
-          return true
-        } else {
-          return "Error: " + result["status"] + ": " +  result["title"] + " (" + result["detail"] + ")"
-        }
-      })
-      .catch(error => {
-        return "Error: " + error.toString()
-      });
+  } catch (error) {
+    return "Error: " + error.toString()
+  }
 }
 ```
 
 Now we can test our validator with validate-config action that jitsu-cli already added to the project
 
 ```shell
-yarn build && yarn validate-config -j '{"tweetTemplate":"Welcome new user ${event.user?.id} !🎉", "accessToken":"Q0Mzb0VhZ0"}'
+yarn build && yarn validate-config -j '{"webhookUrl":"https://hooks.slack.com/services/ABC/XYZ/etc", "eventTypes":"registration,error", "messageTemplate": "Important event of type: ${event_type}"}'
 ```
 
 If everything is fine we should get following output:
 ```text
-[info ] - 🤔 Validating configuration {"tweetTemplate":"sasd","accessToken":"Q0Mzb0VhZ0"}
+[info ] - 🤔 Validating configuration {"webhookUrl":"https://hooks.slack.com/services/ABC/XYZ/etc", "eventTypes":"registration,error", "messageTemplate": "Important event of type: ${event_type}"}
 [info ] - ✅ Config is valid. Hooray!
 [info ] - ✨ Done
 ```
@@ -179,42 +182,45 @@ To implement the test we need to fill DestinationTestParams properties and pass 
 
 ```typescript
 testDestination({
-  name: "proper case",
+    name: "proper case",
 
-  context: {
-    destinationId: "test",
-    destinationType: "twitter",
-    config: {
-      "tweetTemplate":"Welcome new user ${event.user?.id}!🎉",
-      "accessToken":"Q0Mzb0VhZ0"
-    }
-  },
-
-  destination: destination,
-
-  event: {
-    event_type: 'registration',
-    user: {
-      id: "test_new_user",
-      email: "test_new_user@example.com"
-    }
-  },
-
-  expectedResult: {
-    method: "POST",
-    url: "https://api.twitter.com/2/tweets",
-    headers: {
-      "Authorization": "Bearer Q0Mzb0VhZ0",
-      "Content-type": "application/json",
+    context: {
+        destinationId: "test",
+        destinationType: "slack",
+        config: {
+            "webhookUrl": "https://hooks.slack.com/services/ABC/XYZ/etc",
+            "eventTypes": "registration,error",
+            "messageTemplate": "Important event of type: ${event_type}"
+        }
     },
-    body: {"text": "Welcome new user test_new_user!🎉"},
-  },
+
+    destination: destination,
+
+    event: {
+        event_type: 'registration'
+    },
+
+    expectedResult: {
+        method: "POST",
+        url: "https://hooks.slack.com/services/ABC/XYZ/etc",
+        body: {
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Important event of type: registration"
+                    }
+                }
+            ]
+        }
+    },
 })
 ```
 This is a test for "proper case". We provide testDestination function with:
  * properly set context with a config,
  * Jitsu event - very short one with fields that may be used in plugin code
- * our expectation of HTTP request jitsu should make to Twitter API in case of receiving such event.
+ * our expectation of HTTP request jitsu should make to a Slack webhook URL in case of receiving such event.
 
 Run the test
 ```shell
@@ -229,30 +235,58 @@ to make sure that nothing bad happens in that cases and we get **null** result.
 
 ### Writing DestinationFunction
 
-Now we can write DestinationFunction implementation that prepares DestinationMessage with HTTP request that creates a new tweet.
-DestinationFunction must skip all events with event type other than "registration".
+Now we can write DestinationFunction implementation that prepares DestinationMessage with HTTP request that creates a new Slack Message.
+DestinationFunction must skip all events which types diffe.
 Let's get back to the **src/destination.ts** file and write some code:
 
 ```typescript
+function get(obj: any, key: string | string[]) {
+    if (typeof key == 'string')
+        key = key.split('.');
+
+    if (key.length == 1)
+        return obj[key[0]];
+    else if (key.length == 0)
+        return obj;
+    else
+        return get(obj[key[0]], key.slice(1));
+}
+
+function renderTemplateMessage(str, obj) {
+    return str.replace(/\$\{(.+)\}/g, (match, p1) => {
+        return get(obj, p1)
+    })
+}
+
 export const destination: DestinationFunction = (event: DefaultJitsuEvent, dstContext: JitsuDestinationContext<DestinationConfig>) => {
-  if (event.event_type != "registration") {
-    return null
-  }
-  let tweetText = eval("`" + dstContext.config.tweetTemplate + "`")
-  if (!tweetText) {
-    return null;
-  }
-  return {
-    url: "https://api.twitter.com/2/tweets",
-    method: "POST",
-    headers: {
-      "Authorization": "Bearer " + dstContext.config.accessToken,
-      "Content-type": "application/json",
-    },
-    body: {
-      "text": tweetText
+    const eventTypes = dstContext.config.eventTypes.split(",")
+    if (!eventTypes.includes(event.event_type)) {
+        return null
     }
-  };
+    let messageText = renderTemplateMessage(dstContext.config.messageTemplate, event)
+    if (!messageText) {
+        return null;
+    }
+    //Using Block Kit to build message. See: https://api.slack.com/block-kit
+    let blocks = [];
+    blocks.push({
+        "type": "section",
+        "text": {
+            "type": "plain_text",
+            "text": messageText
+        }
+    })
+    if (event.slack_destinantion_message_blocks) {
+        //extensibility with javascript transformation
+        blocks.push(...event.slack_destinantion_message_blocks)
+    }
+    return {
+        url: dstContext.config.webhookUrl,
+        method: "POST",
+        body: {
+            "blocks": blocks
+        }
+    };
 };
 ```
 
@@ -270,7 +304,7 @@ Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 ```
 
-Ok main logic is ready. But nothing appears on Twitter yet. We need Jitsu for that.
+Ok main logic is ready. But nothing appears on Slack yet. We need Jitsu for that.
 But before we add our plugin to Jitsu lets fill some meta information that will help users to identify plugin, understand its purpose and properly set config parameters.
 
 ## Providing meta information
@@ -279,26 +313,38 @@ Let's open file **src/index.ts**
 Here we can find placeholder object that jitsu-cli made for us.
 Let's fill it with some real data
 
+export type DestinationConfig = {
+  webhookUrl: string, //url of slack webhook https://hooks.slack.com/services/ABC/XYZ/etc
+  eventTypes: string, //comma separated list of event types to trigger Slack message
+  messageTemplate: string //message template that will be filled with data from event e.g. `New event: ${event_type}!`
+}
 ```typescript
 const descriptor: ExtensionDescriptor = {
-  id: "jitsu-twitter-destination",
-  displayName: "Twitter",
-  icon: "<svg xmlns=\"http:\/\/www.w3.org\/2000\/svg\" xml:space=\"preserve\" width=\"70.5556mm\" height=\"57.3391mm\" version=\"1.1\" style=\"shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd\"\r\nviewBox=\"0 0 6701 5446\"\r\n xmlns:xlink=\"http:\/\/www.w3.org\/1999\/xlink\">\r\n <defs>\r\n  <style type=\"text\/css\">\r\n   <![CDATA[\r\n    .fil0 {fill:#41ABE1}\r\n   ]]>\r\n  <\/style>\r\n <\/defs>\r\n <g id=\"Livello_x0020_1\">\r\n  <metadata id=\"CorelCorpID_0Corel-Layer\"\/>\r\n  <path class=\"fil0\" d=\"M6701 645c-247,109 -512,183 -790,216 284,-170 502,-440 604,-761 -266,158 -560,272 -873,334 -251,-267 -608,-434 -1004,-434 -759,0 -1375,616 -1375,1375 0,108 12,213 36,313 -1143,-57 -2156,-605 -2834,-1437 -118,203 -186,439 -186,691 0,477 243,898 612,1144 -225,-7 -437,-69 -623,-172 0,6 0,11 0,17 0,666 474,1222 1103,1348 -115,31 -237,48 -362,48 -89,0 -175,-9 -259,-25 175,546 683,944 1284,955 -471,369 -1063,589 -1708,589 -111,0 -220,-7 -328,-19 608,390 1331,618 2108,618 2529,0 3912,-2095 3912,-3912 0,-60 -1,-119 -4,-178 269,-194 502,-436 686,-712z\"\/>\r\n <\/g>\r\n<\/svg>",
-  description: "Destination that posts a tweet welcoming new user on receiving \"registration\" event.",
+  id: "jitsu-slack-destination",
+  displayName: "Slack",
+  icon: "<svg enable-background=\"new 0 0 2447.6 2452.5\" viewBox=\"0 0 2447.6 2452.5\" xmlns=\"http:\/\/www.w3.org\/2000\/svg\"><g clip-rule=\"evenodd\" fill-rule=\"evenodd\"><path d=\"m897.4 0c-135.3.1-244.8 109.9-244.7 245.2-.1 135.3 109.5 245.1 244.8 245.2h244.8v-245.1c.1-135.3-109.5-245.1-244.9-245.3.1 0 .1 0 0 0m0 654h-652.6c-135.3.1-244.9 109.9-244.8 245.2-.2 135.3 109.4 245.1 244.7 245.3h652.7c135.3-.1 244.9-109.9 244.8-245.2.1-135.4-109.5-245.2-244.8-245.3z\" fill=\"#36c5f0\"\/><path d=\"m2447.6 899.2c.1-135.3-109.5-245.1-244.8-245.2-135.3.1-244.9 109.9-244.8 245.2v245.3h244.8c135.3-.1 244.9-109.9 244.8-245.3zm-652.7 0v-654c.1-135.2-109.4-245-244.7-245.2-135.3.1-244.9 109.9-244.8 245.2v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.3z\" fill=\"#2eb67d\"\/><path d=\"m1550.1 2452.5c135.3-.1 244.9-109.9 244.8-245.2.1-135.3-109.5-245.1-244.8-245.2h-244.8v245.2c-.1 135.2 109.5 245 244.8 245.2zm0-654.1h652.7c135.3-.1 244.9-109.9 244.8-245.2.2-135.3-109.4-245.1-244.7-245.3h-652.7c-135.3.1-244.9 109.9-244.8 245.2-.1 135.4 109.4 245.2 244.7 245.3z\" fill=\"#ecb22e\"\/><path d=\"m0 1553.2c-.1 135.3 109.5 245.1 244.8 245.2 135.3-.1 244.9-109.9 244.8-245.2v-245.2h-244.8c-135.3.1-244.9 109.9-244.8 245.2zm652.7 0v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.2v-653.9c.2-135.3-109.4-245.1-244.7-245.3-135.4 0-244.9 109.8-244.8 245.1 0 0 0 .1 0 0\" fill=\"#e01e5a\"\/><\/g><\/svg>",
+  description: "Destination that posts messages to Slack Webhook on receiving Jitsu evens with specified event_types",
   configurationParameters: [
     {
-      id: "accessToken",
+      id: "webhookUrl",
       type: "string",
       required: true,
-      displayName: "Access Token",
-      documentation: "Oauth 2.0 Access Token"
+      displayName: "Webhook URL",
+      documentation: "Url of slack webhook https://hooks.slack.com/services/ABC/XYZ/etc"
     },
     {
-      id: "tweetTemplate",
+      id: "eventTypes",
       type: "string",
       required: true,
-      displayName: "Tweet template",
-      documentation: "Template of tweet text.<br/>You can use string literals expressions to add values from incoming event, e.g.:<br/>Welcome ${event.user?.id}<br/>Received event ${event.event_type}"
+      displayName: "Event Types",
+      documentation: "comma separated list of event types to trigger Slack message"
+    }
+    {
+      id: "messageTemplate",
+      type: "string",
+      required: true,
+      displayName: "Message Template",
+      documentation: "Template of Slack message.<br/>You can use ${parameter} expressions to add values from incoming event, e.g.:<br/>Welcome ${user.id}<br/>Received event ${event_type}"
     }
   ],
 };
@@ -327,10 +373,10 @@ tar -cvzf package_name.tgz -C /workspace_directory/ destination_project_director
 ```
 In case of our destination command will look like:
 ```shell
-tar -cvzf jitsu-twitter-destination.tgz -C /Users/testaccount/projects/ jitsu-twitter-destination
+tar -cvzf jitsu-slack-destination.tgz -C /Users/testaccount/projects/ jitsu-slack-destination
 ```
 
-`jitsu-twitter-destination.tgz` file will appear in current directory.
+`jitsu-slack-destination.tgz` file will appear in current directory.
 
 #### publish to npm repository
 
@@ -353,25 +399,26 @@ Simply add new destination of type **npm**, information about plugin package and
 ```yaml
 destinations:
 ...
-  my_twitter_destination:
+  my_slack_destination:
     only_tokens:
       - my_token
     type: npm
-    package: /home/eventnative/data/plugins/jitsu-twitter-destination.tgz
+    package: /home/eventnative/data/plugins/jitsu-slack-destination.tgz
     mode: stream
     config:
-      accessToken: "Q0Mzb0VhZ0"
-      tweetTemplate: "Welcome new user ${event.user?.id} !\U0001F389"
+      webhookUrl: "https://hooks.slack.com/services/ABC/XYZ/etc"
+      eventTypes: "registration,error"
+      messageTemplate: "Important event of type: ${event_type}"
 ```
 
 **package** can be:
  * **filesystem path** - in case of docker image, provided path need to be reachable inside of docker image filesystem.
-/home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where file jitsu-twitter-destination.tgz is located,
+/home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where file jitsu-slack-destination.tgz is located,
 e.g. following param may be added to docker run command: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`
- * **HTTP URL** - e.g.: `https://my-site.com/plugins/jitsu-twitter-destination.tgz`
+ * **HTTP URL** - e.g.: `https://my-site.com/plugins/jitsu-slack-destination.tgz`
  * **npm package name** - in case plugin is published to npm repository. It is recommended to provide package name with version expression,
 to prevent backward compatibility issues when new version of plugin will require some features that current version of server doesn't support,
-e.g.: `jitsu-twitter-destination@^1.0.0`
+e.g.: `jitsu-slack-destination@^1.0.0`
 
 ### Setting up Jitsu Joint Image or Configurator UI
 

--- a/documentation/extending/destination-plugins.mdx
+++ b/documentation/extending/destination-plugins.mdx
@@ -1,0 +1,237 @@
+---
+title: Destination Plugins
+---
+
+With Jitsu SDK you can implement plugins for Jitsu using Typescript language.
+
+Plugin types:
+ * Destination
+ * Transformation (Not implemented yet)
+ * Source (Not implemented yet)
+
+# Destination Plugin
+
+Jitsu Destination Plugins are designed to work with HTTP based APIs.
+Plugin receives Jitsu event and returns object describing HTTP requests necessary to push data to destination.
+Jitsu server is in charge of queuing, executing and retrying HTTP requests the same as with builtin destinations like webhook.
+Main plugin code doesn't have access to any external resources and doesn't support async execution.
+
+## Create New Destination Plugin
+
+In this article we explain creation of Jitsu destination plugin step by step.
+As an example we implement a simple destination that will post a tweet welcoming new user on receiving Jitsu event with event_type = "registration".
+
+## Bootstrapping project
+
+We need to use Jitsu SDK's CLI tool to bootstrap a project for new destination plugin
+with some preconfigured configs and placeholder functions:
+```shell
+npx jitsu-cli extension create --type destination
+```
+
+We need to provide project name and directory.
+```text
+? Please, provide project name: jitsu-twitter-destination
+? Project directory: /Users/testaccount/projects/jitsu-twitter-destination
+[info ] - Creating new jitsu project in /Users/testaccount/projects/jitsu-twitter-destination
+[info ] - Project directory doesn't exist, creating it!
+[info ] - ✨ Done
+```
+
+jitsu-cli will generate project directory structure with set of files typical for Typescript node.js project:
+```text
+├── package.json
+├── src
+│   ├── destination.ts
+│   └── index.ts
+├── __test__
+│   └── destination.test.ts
+└── tsconfig.json
+```
+
+ * **package.json** – file contains meta information about npm project including name, version
+ * **src/index.ts** – file contains the instance of ExtensionDescriptor that Jitsu uses to collect info about destination:
+id, icon,  name, description, configuration parameters.
+ * **src/destination.ts** – file where must be implemented main logic of destination along with config object and config validator
+ * **__test__/destination.test.ts** – test for destination logic must be written here
+ * **tsconfig.json** – settings for Typescript compiler. No need to change that
+
+## Destination Config
+
+No destination can work without configuration.
+Let's open **src/destination.ts** file and prepare DestinationConfig object for out Twitter destination.
+Config will consist from oauth 2.0 access token and text template for tweets:
+
+```typescript
+export type DestinationConfig = {
+  accessToken: string, //oauth 2.0 access token
+  tweetTemplate: string //string literals template e.g. `Welcome new user ${event.user.email} !🎉`
+}
+```
+
+Destination plugin must not handle authorization process. If our twitter plugin manage to become part of Jitsu server -
+Jitsu server will handle authorization and obtain accessToken. For UI users that will look like "Grant Jitsu Access to Twitter" button.
+
+What plugin can do – is to check validness of access token.
+
+## Validating Config
+
+Once we have destination config we can implement **validator**.
+It is optional part, but it is highly recommended to implement it.
+
+We replace placeholder implementation with to following code
+```typescript
+export const validator: ConfigValidator<DestinationConfig> = async (config: DestinationConfig) => {
+  //check that all config parameters are present
+  if (!config.tweetTemplate) {
+    return "Missing required parameter: tweetTemplate";
+  }
+  if (!config.accessToken) {
+    return "Missing required parameter: accessToken";
+  }
+  //check that authorization passed
+  return await fetch("https://api.twitter.com/2/users/me", {
+    method: 'get',
+    headers: {
+      "Authorization": "Bearer " + config.accessToken
+    }
+  }).then(response => response.json())
+      .then(result => {
+        if (result.data) {
+          //we got data in response
+          return true
+        } else {
+          return "Error: " + result["status"] + ": " +  result["title"] + " (" + result["detail"] + ")"
+        }
+      })
+      .catch(error => {
+        return "Error: " + error.toString()
+      });
+}
+```
+
+Now we can test our validator with validate-config action that jitsu-cli already added to the project
+
+```shell
+yarn build && yarn validate-config -j '{"tweetTemplate":"Welcome new user ${event.user.email} !🎉", "accessToken":"Q0Mzb0VhZ0"}'
+```
+
+If everything is fine we should get following output:
+```text
+[info ] - 🤔 Validating configuration {"tweetTemplate":"sasd","accessToken":"Q0Mzb0VhZ0"}
+[info ] - ✅ Config is valid. Hooray!
+[info ] - ✨ Done
+```
+
+## Pushing to the destination
+
+Lets get to the main part of plugin – pushing data to the target destination.
+We need to replace placeholder of DestinationFunction with the proper version:
+```typescript
+export const destination: DestinationFunction = (event: DefaultJitsuEvent, dstContext: JitsuDestinationContext<DestinationConfig>) => {
+  return { url: "https://test.com", method: "POST", body: { a: (event.a || 0) + 1 } };
+};
+```
+
+DestinationFunction receives two parameters:
+ * **event** – type: DefaultJitsuEvent – event received and enriched by Jitsu Server
+ * **dstContext** - type: JitsuDestinationContext - destination context containing: **destinationId**, **destinationType**
+and what is more important: **config** - config object that we described in the beginning filled by Jitsu Server
+
+Return values:
+As we mentioned in the beginning, plugin itself don't send anything to internet. Instead,
+DestinationFunction may return: a single instance of DestinationMessage, array of DestinationMessage's or null.
+When DestinationFunction return null it means that Jitsu must skip this event.
+
+DestinationMessage is an object that tells Jitsu Server what HTTP request it needs to make to push data to the destination.
+```typescript
+export declare type DestinationMessage = {
+  url: string;
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  headers?: { [key: string]: string };
+  body: any;
+};
+```
+
+### Writing a test
+
+But before actually writing DestinationFunction lets write a test for it.
+By writing a test first we will be sure that our DestinationFunction works as we expect.
+Otherwise, we risk to create a test that simply matches DestinationFunction results that we just wrote - which may happen to be incorrect.
+
+Let's open **__test__/destination.test.ts**
+To write a test we simply need to make a call to the function **testDestination**.
+testDestination accepts a single parameter - object of DestinationTestParams type
+```typescript
+export declare type DestinationTestParams = {
+  name: string;                                    //name of the test
+  context: JitsuDestinationContext;                //JitsuDestinationContext containing: destinationId, destinationType and config
+  destination: DestinationFunction;                //DestinationFunction we are going to test
+  event: DefaultJitsuEvent;                        //JitsuEvent
+  expectedResult: ObjectSet<DestinationMessage>;   //Result object we expect to get after processing event with provided DestinationFunction
+};
+
+```
+To implement the test we need to fill DestinationTestParams properties and pass it to the function **testDestination**
+
+```typescript
+testDestination({
+  name: "proper case",
+  context: {
+    destinationId: "test",
+    destinationType: "twitter",
+    config: {
+      "tweetTemplate":"Welcome new user ${event.user.id} !🎉",
+      "accessToken":"Q0Mzb0VhZ0"
+    }
+  },
+  destination: destination,
+  event: {
+    event_type: 'registration',
+    user: {
+      id: "test_new_user",
+      email: "test_new_user@example.com"
+    }
+  },
+  expectedResult: {
+    method: "POST",
+    url: "https://api.twitter.com/2/tweets",
+    headers: {
+      "Authorization": "Bearer Q0Mzb0VhZ0",
+      "Content-type": "application/json",
+    },
+    body: {"text": "Welcome new user test_new_user!🎉"},
+  },
+})
+```
+This is a test for "proper case". We provide testDestination function with:
+ * properly set context with a config,
+ * Jitsu event - very short one with fields that may be used in plugin code
+ * our expectation of HTTP request jitsu should make to Twitter API in case of receiving such event.
+
+Run the test
+```shell
+yarn test
+```
+Test fails because we still need to replace placeholder for DestinationFunction with proper implementation.
+
+In real plugin for production usage one test for "proper case" probably won't be enough.
+It would be great to add test cases when Jitsu Event doesn't have user.id or event_type is not "registration"
+to make sure that nothing bad happens in that cases and we get **null** result.
+
+
+
+### Writing DestinationFunction
+
+
+Now we can write DestinationFunction implementation that prepares DestinationMessage with HTTP request that creates a new tweet.
+DestinationFunction must skip all events with event type other than "registration" and events that dont contain user.id information.
+Let's get back to the **src/destination.ts** file and write some code.
+
+
+##
+
+npm publish
+
+##
+how to add to Jitsu

--- a/documentation/extending/destination-plugins.mdx
+++ b/documentation/extending/destination-plugins.mdx
@@ -4,36 +4,43 @@ title: Destination Plugins
 
 # Destination Plugin
 
-Jitsu Destination Plugins allows anyone to implement new destination type for Jitsu,
+1. [Overview](#overview)
+2. [Quickstart](#quickstart)
+3. [Project Structure](#project-structure)
+4. [Destination Config](#destination-config)
+5. [Pushing to the Destination](#pushing-to-the-destination)
+6. [Providing Meta Information](#providing-meta-information)
+7. [Writing a Test](#writing-a-test)
+8. [Adding to Jitsu](#adding-to-jitsu)
+
+
+
+## Overview
+
+Jitsu Destination Plugins allow anyone to implement a new destination type for Jitsu
 and publish it to make it available for all users of Jitsu.
 
-Jitsu Destination Plugins are designed to work with HTTP based APIs.
-Plugin receives Jitsu event and returns object describing HTTP requests necessary to push data to destination.
+Jitsu Destination Plugins are designed to work with HTTP APIs in stream mode.
 
-## Create New Destination Plugin
+A plugin receives a Jitsu event and returns objects describing HTTP requests necessary to push data to destinations.
 
-In this article we explain creation of Jitsu destination plugin step by step.
-As an example we implement a simple destination that will post message to a Slack webhook 
-on receiving Jitsu event with provided types.
+## Quickstart
 
-## Bootstrapping project
-
-We need to use Jitsu SDK's CLI tool to bootstrap a project for new destination plugin
-with some preconfigured configs and placeholder functions:
+We need to use Jitsu SDK's CLI tool to bootstrap a project for new destination plugin:
 ```shell
 npx jitsu-cli extension create --type destination
 ```
 
-We need to provide project name and directory.
-```text
-? Please, provide project name: jitsu-slack-destination
-? Project directory: /Users/testaccount/projects/jitsu-slack-destination
-[info ] - Creating new jitsu project in /Users/testaccount/projects/jitsu-slack-destination
-[info ] - Project directory doesn't exist, creating it!
-[info ] - ✨ Done
-```
+jitsu-cli creates a functioning project for a destination plugin. All parts are working, but they are placeholder implementation and don't do anything meaningful.
 
-jitsu-cli will generate project directory structure with set of files typical for Typescript node.js project:
+If you are an experienced developer, you can start replacing placeholder logic with your own right away.
+
+This article will explain the creation of a Jitsu destination plugin step by step.<br/>
+As an example, we will implement a simple destination that will post a message to a Slack webhook on receiving a Jitsu event with provided types.
+
+## Project Structure
+
+jitsu-cli generates project directory structure with a set of files typical for Typescript node.js project:
 ```text
 ├── package.json
 ├── src
@@ -44,37 +51,39 @@ jitsu-cli will generate project directory structure with set of files typical fo
 └── tsconfig.json
 ```
 
- * **package.json** – file contains meta information about npm project including name, version
- * **src/index.ts** – file contains the instance of ExtensionDescriptor that Jitsu uses to collect info about destination:
+ * `package.json` – file contains meta-information about npm project including name, version
+ * `src/index.ts` – file contains the instance of ExtensionDescriptor that Jitsu uses to collect info about the destination:
 id, icon,  name, description, configuration parameters.
- * **src/destination.ts** – file where must be implemented main logic of destination along with config object and config validator
- * **__test__/destination.test.ts** – test for destination logic must be written here
- * **tsconfig.json** – settings for Typescript compiler. No need to change that
+ * `src/destination.ts` – file where must be implemented main logic of destination along with config object and config validator
+ * `__test__/destination.test.ts` – test for destination logic must be written here
+ * `tsconfig.json` – settings for Typescript compiler. No need to change that
+
+We recommend working on the project in an integrated development environment (IDE) like Visual Studio Code or WebStorm.
 
 ## Destination Config
 
 No destination can work without configuration.
-Let's open **src/destination.ts** file and prepare DestinationConfig object for out Slack destination.
-Config will consist from webhook url, list of event types to react on and message template for Slack message:
+Let's open `src/destination.ts` file and prepare the DestinationConfig object for our Slack destination.
+Config will consist of webhook URL, list of event types to react on, and message template for Slack message:
 
 ```typescript
 export type DestinationConfig = {
   webhookUrl: string, //url of slack webhook https://hooks.slack.com/services/ABC/XYZ/etc
-  eventTypes: string, //comma separated list of event types to trigger Slack message
+  eventTypes: string, //comma-separated list of event types to trigger Slack message
   messageTemplate: string //message template that will be filled with data from event e.g. `New event: ${event_type}!`
 }
 ```
 
-It is nice to tell users in advance in case they make a mistake in config.
-That is why destination plugin have ConfigValidator
+It is nice to tell users in advance if they make a mistake in their config.
+That is why destination plugins have ConfigValidator
 
-## Validating Config
+### Validating Config
 
-Once we have destination config we can implement **validator**.
-It is optional part, but it is highly recommended to implement it.
+Once we have the destination config, we can implement the `validator`.
+It is an optional part, but we highly recommend implementing it.
 
-ConfigValidator is the only part of plugin that can access internet using `fetch` method.
-The main logic of plugins relies on Jitsu Server pipelines for sending HTTP requests
+ConfigValidator is the only part of the plugin that can access internet using the `fetch` method.
+The main logic of plugins relies on Jitsu Server pipelines for sending HTTP requests.
 
 We replace placeholder implementation with to following code
 ```typescript
@@ -113,14 +122,14 @@ Now we can test our validator with validate-config action that jitsu-cli already
 yarn build && yarn validate-config -j '{"webhookUrl":"https://hooks.slack.com/services/ABC/XYZ/etc", "eventTypes":"registration,error", "messageTemplate": "Important event of type: ${event_type}"}'
 ```
 
-If everything is fine we should get following output:
+If everything is fine, we should get the following output:
 ```text
 [info ] - 🤔 Validating configuration {"webhookUrl":"https://hooks.slack.com/services/ABC/XYZ/etc", "eventTypes":"registration,error", "messageTemplate": "Important event of type: ${event_type}"}
 [info ] - ✅ Config is valid. Hooray!
 [info ] - ✨ Done
 ```
 
-## Pushing to the destination
+## Pushing to the Destination
 
 Lets get to the main part of plugin – pushing data to the target destination.
 We need to write proper version of DestinationFunction instead of placeholder:
@@ -131,16 +140,15 @@ export const destination: DestinationFunction = (event: DefaultJitsuEvent, dstCo
 ```
 
 DestinationFunction receives two parameters:
- * **event** – type: DefaultJitsuEvent – event received and enriched by Jitsu Server
- * **dstContext** - type: JitsuDestinationContext - destination context containing: **destinationId**, **destinationType**
-and what is more important: **config** - config object that we described in the beginning filled by Jitsu Server
+ * `event` – type: DefaultJitsuEvent – event received and enriched by Jitsu Server
+ * `dstContext` - type: JitsuDestinationContext - destination context containing: `destinationId`, `destinationType`
+and what is more important: `config` - config object that we described at the beginning filled by Jitsu Server
 
-**Return values**:
+### Return values
 
-Main plugin code doesn't support async execution and doesn't have access to any external resources.
-Instead, DestinationFunction needs to return:
+The main plugin code doesn't support async execution and doesn't have access to any external resources. So instead, DestinationFunction needs to return:
  * a single instance of DestinationMessage
- * array of DestinationMessage's - to produce multiple pushes to destination
+ * an array of DestinationMessage's - to produce multiple pushes to destination
  * null - null means that Jitsu must skip this event.
 
 DestinationMessage is an object that tells Jitsu Server what HTTP request it needs to make to push data to the destination:
@@ -152,17 +160,137 @@ export declare type DestinationMessage = {
   body: any;
 };
 ```
-Jitsu server is in charge of queuing, executing and retrying HTTP requests the same as with builtin destinations like webhook.
+Jitsu server is in charge of queuing, executing, and retrying HTTP requests, the same as with built-in destinations like webhook.
 
-### Writing a test
+### Writing DestinationFunction
 
-But before actually writing DestinationFunction lets write a test for it.
-By writing a test first we will be sure that our DestinationFunction works as we expect.
-Otherwise, we risk to create a test that simply matches DestinationFunction results that we just wrote - which may happen to be incorrect.
+Now we can write DestinationFunction implementation that prepares DestinationMessage with HTTP request that creates a new Slack Message.
+DestinationFunction must skip all events whose types differ from those provided in the config.
+Let's get back to the **src/destination.ts** file and write some code:
 
-Let's open **__test__/destination.test.ts**
-To write a test we simply need to make a call to the function **testDestination**.
-testDestination accepts a single parameter - object of DestinationTestParams type
+```typescript
+//Function that fill string template with values from obj
+function renderTemplateMessage(str, obj) {
+    const get = (obj: any, key: string | string[]) => {
+        if (typeof key == 'string')
+            key = key.split('.');
+
+        if (key.length == 1)
+            return obj[key[0]];
+        else if (key.length == 0)
+            return obj;
+        else
+            return get(obj[key[0]], key.slice(1));
+    }
+    return str.replace(/\$\{(.+)\}/g, (match, p1) => {
+        return get(obj, p1)
+    })
+}
+
+export const destination: DestinationFunction = (event: DefaultJitsuEvent, dstContext: JitsuDestinationContext<DestinationConfig>) => {
+    const eventTypes = dstContext.config.eventTypes.split(",")
+    if (!eventTypes.includes(event.event_type)) {
+        return null
+    }
+    let messageText = renderTemplateMessage(dstContext.config.messageTemplate, event)
+    if (!messageText) {
+        return null;
+    }
+    //Using Block Kit to build message. See: https://api.slack.com/block-kit
+    let blocks = [];
+    blocks.push({
+        "type": "section",
+        "text": {
+            "type": "plain_text",
+            "text": messageText
+        }
+    })
+    if (event.slack_destinantion_message_blocks) {
+        //extensibility with javascript transformation
+        blocks.push(...event.slack_destinantion_message_blocks)
+    }
+    return {
+        url: dstContext.config.webhookUrl,
+        method: "POST",
+        body: {
+            "blocks": blocks
+        }
+    };
+};
+```
+
+That is it!
+
+### Testing destination
+
+We need Jitsu Server to run the plugin, but jitsu-cli created our project with the `run` action that allows executing the plugin for a single event.
+`run` action performs HTTP requests from returned `DestinationMessage`.
+
+You need to prepare JSON file with a sample of a Jitsu event first.
+```shell
+yarn run --file event.json -j '{"webhookUrl":"https://hooks.slack.com/services/ABC/XYZ/etc", "eventTypes":"registration,error", "messageTemplate": "Important event of type: ${event_type}"}'
+```
+Since `run` action actually performs HTTP request, it makes changes in the destination.
+We not always can afford to put test data to a destination.
+In that case, it is good to write an automated test that checks the correctness of returned `DestinationMessage`'s in most possible cases.
+See [Writing a Test](#writing_a_test) section
+
+## Providing Meta Information
+
+Let's open file **src/index.ts**
+Here we can find a placeholder object that jitsu-cli made for us.
+Let's fill it with some real data
+
+```typescript
+const descriptor: ExtensionDescriptor = {
+  id: "jitsu-slack-destination",
+  displayName: "Slack",
+  icon: "<svg enable-background=\"new 0 0 2447.6 2452.5\" viewBox=\"0 0 2447.6 2452.5\" xmlns=\"http:\/\/www.w3.org\/2000\/svg\"><g clip-rule=\"evenodd\" fill-rule=\"evenodd\"><path d=\"m897.4 0c-135.3.1-244.8 109.9-244.7 245.2-.1 135.3 109.5 245.1 244.8 245.2h244.8v-245.1c.1-135.3-109.5-245.1-244.9-245.3.1 0 .1 0 0 0m0 654h-652.6c-135.3.1-244.9 109.9-244.8 245.2-.2 135.3 109.4 245.1 244.7 245.3h652.7c135.3-.1 244.9-109.9 244.8-245.2.1-135.4-109.5-245.2-244.8-245.3z\" fill=\"#36c5f0\"\/><path d=\"m2447.6 899.2c.1-135.3-109.5-245.1-244.8-245.2-135.3.1-244.9 109.9-244.8 245.2v245.3h244.8c135.3-.1 244.9-109.9 244.8-245.3zm-652.7 0v-654c.1-135.2-109.4-245-244.7-245.2-135.3.1-244.9 109.9-244.8 245.2v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.3z\" fill=\"#2eb67d\"\/><path d=\"m1550.1 2452.5c135.3-.1 244.9-109.9 244.8-245.2.1-135.3-109.5-245.1-244.8-245.2h-244.8v245.2c-.1 135.2 109.5 245 244.8 245.2zm0-654.1h652.7c135.3-.1 244.9-109.9 244.8-245.2.2-135.3-109.4-245.1-244.7-245.3h-652.7c-135.3.1-244.9 109.9-244.8 245.2-.1 135.4 109.4 245.2 244.7 245.3z\" fill=\"#ecb22e\"\/><path d=\"m0 1553.2c-.1 135.3 109.5 245.1 244.8 245.2 135.3-.1 244.9-109.9 244.8-245.2v-245.2h-244.8c-135.3.1-244.9 109.9-244.8 245.2zm652.7 0v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.2v-653.9c.2-135.3-109.4-245.1-244.7-245.3-135.4 0-244.9 109.8-244.8 245.1 0 0 0 .1 0 0\" fill=\"#e01e5a\"\/><\/g><\/svg>",
+  description: "Destination that posts messages to Slack Webhook on receiving Jitsu evens with specified event_types",
+  configurationParameters: [
+    {
+      id: "webhookUrl",
+      type: "string",
+      required: true,
+      displayName: "Webhook URL",
+      documentation: "Url of slack webhook https://hooks.slack.com/services/ABC/XYZ/etc"
+    },
+    {
+      id: "eventTypes",
+      type: "string",
+      required: true,
+      displayName: "Event Types",
+      documentation: "comma separated list of event types to trigger Slack message"
+    },
+    {
+      id: "messageTemplate",
+      type: "string",
+      required: true,
+      displayName: "Message Template",
+      documentation: "Template of Slack message.<br/>You can use ${parameter} expressions to add values from incoming event, e.g.:<br/>Welcome ${user.id}<br/>Received event ${event_type}"
+    }
+  ],
+};
+```
+
+configurationParameters's parameters can have type from the list:
+ * string
+ * int
+ * boolean
+ * password
+ * json
+ * dashDate - Date formatted like YYYY-MM-DD, e.g: 2022-01-31
+ * isoUtcDate - Date and time formatted according to [ISO_8601](https://en.wikipedia.org/wiki/ISO_8601) standard, e.g.: 2022-01-31T10:28:13Z
+
+If you want Jitsu to display a nice graphic icon along with destination name you need to provide svg code of icon to "icon" parameter of ExtensionDescriptor.
+
+## Writing a Test
+
+Tests allow to check plugin logic without actually posting anything to the destination.
+
+Let's open `__test__/destination.test.ts`
+To write a test we simply need to make a call to the function `testDestination`.
+testDestination accepts a single parameter - object of DestinationTestParams type:
 ```typescript
 export declare type DestinationTestParams = {
   name: string;                                    //name of the test
@@ -215,82 +343,13 @@ testDestination({
 This is a test for "proper case". We provide testDestination function with:
  * properly set context with a config,
  * Jitsu event - very short one with fields that may be used in plugin code
- * our expectation of HTTP request jitsu should make to a Slack webhook URL in case of receiving such event.
+ * our expectation of HTTP request jitsu should make to a Slack webhook URL in case of receiving such an event.
 
-Run the test
+Now let's run tests to make sure that everything works fine.
 ```shell
 yarn test
 ```
-Test fails because we still need to replace placeholder for DestinationFunction with proper implementation.
-
-In real plugin for production usage one test for "proper case" probably won't be enough.
-It would be great to add test cases when event_type is not "registration"
-to make sure that nothing bad happens in that cases and we get **null** result.
-
-
-### Writing DestinationFunction
-
-Now we can write DestinationFunction implementation that prepares DestinationMessage with HTTP request that creates a new Slack Message.
-DestinationFunction must skip all events which types diffe.
-Let's get back to the **src/destination.ts** file and write some code:
-
-```typescript
-function get(obj: any, key: string | string[]) {
-    if (typeof key == 'string')
-        key = key.split('.');
-
-    if (key.length == 1)
-        return obj[key[0]];
-    else if (key.length == 0)
-        return obj;
-    else
-        return get(obj[key[0]], key.slice(1));
-}
-
-function renderTemplateMessage(str, obj) {
-    return str.replace(/\$\{(.+)\}/g, (match, p1) => {
-        return get(obj, p1)
-    })
-}
-
-export const destination: DestinationFunction = (event: DefaultJitsuEvent, dstContext: JitsuDestinationContext<DestinationConfig>) => {
-    const eventTypes = dstContext.config.eventTypes.split(",")
-    if (!eventTypes.includes(event.event_type)) {
-        return null
-    }
-    let messageText = renderTemplateMessage(dstContext.config.messageTemplate, event)
-    if (!messageText) {
-        return null;
-    }
-    //Using Block Kit to build message. See: https://api.slack.com/block-kit
-    let blocks = [];
-    blocks.push({
-        "type": "section",
-        "text": {
-            "type": "plain_text",
-            "text": messageText
-        }
-    })
-    if (event.slack_destinantion_message_blocks) {
-        //extensibility with javascript transformation
-        blocks.push(...event.slack_destinantion_message_blocks)
-    }
-    return {
-        url: dstContext.config.webhookUrl,
-        method: "POST",
-        body: {
-            "blocks": blocks
-        }
-    };
-};
-```
-
-That is it!
-Now let's run tests again to make sure that everything works fine.
-```shell
-yarn test
-```
-Output must contain following line.
+Output must contain the following lines.
 ```text
  PASS  __test__/destination.test.ts
   ✓ proper case (1 ms)
@@ -299,81 +358,36 @@ Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 ```
 
-Ok main logic is ready. But nothing appears on Slack yet. We need Jitsu for that.
-But before we add our plugin to Jitsu lets fill some meta information that will help users to identify plugin, understand its purpose and properly set config parameters.
+One test for "proper case" probably won't be enough in a real plugin for production usage.
+It would be great to add test cases when event_type is not "registration" to make sure that nothing wrong happens in that cases,
+and we get **null** result.
 
-## Providing meta information
-
-Let's open file **src/index.ts**
-Here we can find placeholder object that jitsu-cli made for us.
-Let's fill it with some real data
-
-export type DestinationConfig = {
-  webhookUrl: string, //url of slack webhook https://hooks.slack.com/services/ABC/XYZ/etc
-  eventTypes: string, //comma separated list of event types to trigger Slack message
-  messageTemplate: string //message template that will be filled with data from event e.g. `New event: ${event_type}!`
-}
-```typescript
-const descriptor: ExtensionDescriptor = {
-  id: "jitsu-slack-destination",
-  displayName: "Slack",
-  icon: "<svg enable-background=\"new 0 0 2447.6 2452.5\" viewBox=\"0 0 2447.6 2452.5\" xmlns=\"http:\/\/www.w3.org\/2000\/svg\"><g clip-rule=\"evenodd\" fill-rule=\"evenodd\"><path d=\"m897.4 0c-135.3.1-244.8 109.9-244.7 245.2-.1 135.3 109.5 245.1 244.8 245.2h244.8v-245.1c.1-135.3-109.5-245.1-244.9-245.3.1 0 .1 0 0 0m0 654h-652.6c-135.3.1-244.9 109.9-244.8 245.2-.2 135.3 109.4 245.1 244.7 245.3h652.7c135.3-.1 244.9-109.9 244.8-245.2.1-135.4-109.5-245.2-244.8-245.3z\" fill=\"#36c5f0\"\/><path d=\"m2447.6 899.2c.1-135.3-109.5-245.1-244.8-245.2-135.3.1-244.9 109.9-244.8 245.2v245.3h244.8c135.3-.1 244.9-109.9 244.8-245.3zm-652.7 0v-654c.1-135.2-109.4-245-244.7-245.2-135.3.1-244.9 109.9-244.8 245.2v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.3z\" fill=\"#2eb67d\"\/><path d=\"m1550.1 2452.5c135.3-.1 244.9-109.9 244.8-245.2.1-135.3-109.5-245.1-244.8-245.2h-244.8v245.2c-.1 135.2 109.5 245 244.8 245.2zm0-654.1h652.7c135.3-.1 244.9-109.9 244.8-245.2.2-135.3-109.4-245.1-244.7-245.3h-652.7c-135.3.1-244.9 109.9-244.8 245.2-.1 135.4 109.4 245.2 244.7 245.3z\" fill=\"#ecb22e\"\/><path d=\"m0 1553.2c-.1 135.3 109.5 245.1 244.8 245.2 135.3-.1 244.9-109.9 244.8-245.2v-245.2h-244.8c-135.3.1-244.9 109.9-244.8 245.2zm652.7 0v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.2v-653.9c.2-135.3-109.4-245.1-244.7-245.3-135.4 0-244.9 109.8-244.8 245.1 0 0 0 .1 0 0\" fill=\"#e01e5a\"\/><\/g><\/svg>",
-  description: "Destination that posts messages to Slack Webhook on receiving Jitsu evens with specified event_types",
-  configurationParameters: [
-    {
-      id: "webhookUrl",
-      type: "string",
-      required: true,
-      displayName: "Webhook URL",
-      documentation: "Url of slack webhook https://hooks.slack.com/services/ABC/XYZ/etc"
-    },
-    {
-      id: "eventTypes",
-      type: "string",
-      required: true,
-      displayName: "Event Types",
-      documentation: "comma separated list of event types to trigger Slack message"
-    }
-    {
-      id: "messageTemplate",
-      type: "string",
-      required: true,
-      displayName: "Message Template",
-      documentation: "Template of Slack message.<br/>You can use ${parameter} expressions to add values from incoming event, e.g.:<br/>Welcome ${user.id}<br/>Received event ${event_type}"
-    }
-  ],
-};
-```
-
-if you want Jitsu to display nice graphic icon along with destination name you need to provide svg code of icon to "icon" parameter of ExtensionDescriptor.
 
 ## Adding to Jitsu
 
-To add our plugin to jitsu we need to build it and publish.
+To add our plugin to jitsu we need to build and publish it.
 
 To build plugin code use:
 ```shell
 yarn build
 ```
 
-### publish to npm repository
+### Publishing to NPM Repository
 
-Publishing plugin to public npm repository to make it available for other users..
-You need to have account in https://www.npmjs.com
+Publishing plugin to public npm repository to make it available for other users.
+You need to have an account in https://www.npmjs.com
 
-The following commands in project directory may be used to publish package to npmjs repository.
+The following commands in the project directory will publish the package to the npmjs repository:
 ```shell
 npm login
-```
-```shell
 npm publish
 ```
-npm will ask to provide some additional details to complete publishing
+npm will ask to provide some additional details to complete the publishing.
 
 ### Setting up Jitsu Server
 
-Users of standalone jitsu server can setup destination based on plugin since version 1.38.
-Simply add new destination of type **npm**, information about plugin package and config to `eventnative.yaml` config file:
+Users of a standalone jitsu server can setup a destination based on plugin since version 1.38.
+Add a new destination of type **npm**, information about plugin package, and config to `eventnative.yaml` config file:
 ```yaml
 destinations:
 ...
@@ -389,28 +403,27 @@ destinations:
       messageTemplate: "Important event of type: ${event_type}"
 ```
 
-**package** can be:
- * **npm package name** - in case plugin is published to npm repository. It is recommended to provide package name with version expression,
-to prevent backward compatibility issues when new version of plugin will require some features that current version of server doesn't support,
-e.g.: `jitsu-slack-destination@^1.0.0`
- * **HTTP URL** - e.g.: `https://my-site.com/plugins/jitsu-slack-destination.tgz`
- * **filesystem path** - in case of docker image, provided path need to be reachable inside of docker image filesystem.
-/home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where file jitsu-slack-destination.tgz is located,
+`package` can be:
+ * npm package name - if a plugin is published to npm repository. We recommend providing package name with version expression to prevent backward compatibility issues: `jitsu-slack-destination@^1.0.0`
+ * HTTP URL - e.g.: `https://my-site.com/plugins/jitsu-slack-destination.tgz`
+ * filesystem path - in case of a docker image, provided path needs to be reachable inside of docker image filesystem.
+/home/eventnative/data/plugins/ needs to be mounted to host filesystem directory where plugin's .tgz is located,
 e.g. following param may be added to docker run command: `-v /Users/testaccount/projects/:/home/eventnative/data/plugins/`
 
 ### Setting up Jitsu Joint Image or Configurator UI
 
 UI support for adding plugin based destinations is not ready yet.
-To make your destination plugin appear in Jitsu Configurator UI please create a new ticket or pull request in
+To make your destination plugin appear in Jitsu Configurator UI please create a new ticket or pull request in the
 [jitsu repository](https://github.com/jitsucom/jitsu)
+
 
 ### Publishing plugin locally
 
-In case that there is no intention to publish plugin for other users you can keep it for yourself.
+If there is no intention to publish plugin for other users, you can keep it for yourself.
 
 You need to build .tgz package manually:
 
-Use command like that to make compressed .tgz package of destination project directory:
+Use a command like that to make compressed .tgz package of destination project directory:
 ```shell
 tar -cvzf package_name.tgz -C /workspace_directory/ destination_project_directory
 ```
@@ -418,7 +431,7 @@ In case of our destination command will look like:
 ```shell
 tar -cvzf jitsu-slack-destination.tgz -C /Users/testaccount/projects/ jitsu-slack-destination
 ```
-`jitsu-slack-destination.tgz` file will appear in current directory.
+`jitsu-slack-destination.tgz` file will appear in the current directory.
 
 See [Setting Up Jitsu Server](#setting-up-jitsu-server) to check how to pass local package to Jitsu Server
 

--- a/documentation/extending/index.mdx
+++ b/documentation/extending/index.mdx
@@ -2,9 +2,11 @@
 title: Extending Jitsu
 ---
 
+# Extending Jitsu
+
 With Jitsu SDK you can implement plugins for Jitsu using Typescript language.
 
 Plugin types:
- * Destination
+ * [Destination](/docs/extending/destination-plugins)
  * Transformation (Not implemented yet)
  * Source (Not implemented yet)

--- a/documentation/extending/index.mdx
+++ b/documentation/extending/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Extending Jitsu
+---
+
+With Jitsu SDK you can implement plugins for Jitsu using Typescript language.
+
+Plugin types:
+ * Destination
+ * Transformation (Not implemented yet)
+ * Source (Not implemented yet)

--- a/documentation/index.mdx
+++ b/documentation/index.mdx
@@ -13,7 +13,8 @@ Welcome to **Jitsu** — an open-source web- and app- event collection platform.
 1. [Deployment](docs/deployment/)
 2. [JavaScript Integration](docs/sending-data/js-sdk)
 3. [Configuration](docs/configuration/)
-4. [Segment Compatibility](docs/other-features/segment-compatibility)
+4. [Extending](docs/extending/)
+5. [Segment Compatibility](docs/other-features/segment-compatibility)
 
 
 

--- a/documentation/root.json
+++ b/documentation/root.json
@@ -38,6 +38,12 @@
       ]
     },
     {
+      "name": "Extending Jitsu",
+      "pages": [
+        "extending/destination-plugins"
+      ]
+    },
+    {
       "name": "Configurator UI",
       "pages": [
         "configurator-configuration"

--- a/server-release.Dockerfile
+++ b/server-release.Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /go/src/github.com/jitsucom/jitsu/server
 
 #Caching dependencies
 ADD server/go.mod ./
-RUN go mod tidy && go mod download
+RUN go mod download
 
 #tmp workaround until next version of v8go will be release
 RUN git clone https://github.com/rogchap/v8go.git /tmp/v8go@v0.7.0

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -85,7 +85,7 @@ WORKDIR /go/src/github.com/jitsucom/jitsu/server
 
 #Caching dependencies
 ADD server/go.mod ./
-RUN go mod tidy && go mod download
+RUN go mod download
 
 #tmp workaround until next version of v8go will be release
 RUN git clone https://github.com/rogchap/v8go.git /tmp/v8go@v0.7.0

--- a/server/Makefile
+++ b/server/Makefile
@@ -40,7 +40,7 @@ backend: deps_backend build_backend
 
 deps_backend:
 	echo "Using path $(PATH)"
-	go mod tidy
+	go mod download
 
 build_backend:
 	$(GOBUILD_PREFIX) go build -ldflags "-X main.commit=${commit} -X main.builtAt=${built_at} -X main.tag=${tag}" -o $(APPLICATION)

--- a/server/adapters/npm.go
+++ b/server/adapters/npm.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/mitchellh/mapstructure"
 )
@@ -43,11 +44,23 @@ func (n *NpmRequestFactory) Create(object map[string]interface{}) (req *Request,
 	if err := mapstructure.Decode(object, &envelop); err != nil {
 		return nil, fmt.Errorf("cannot parse DestinationMessage: %v", err)
 	}
+	var body []byte
+	switch b := envelop.Body.(type) {
+	case string:
+		body = []byte(b)
+	case []byte:
+		body = b
+	default:
+		body, err = json.Marshal(b)
+		if err != nil {
+			return nil, fmt.Errorf("cannot marshal DestinationMessage body: %v", err)
+		}
+	}
 
 	return &Request{
 		URL:     envelop.URL,
 		Method:  envelop.Method,
-		Body:    []byte(envelop.Body),
+		Body:    body,
 		Headers: envelop.Headers,
 	}, nil
 }


### PR DESCRIPTION
Documentation of creating Jitsu Destination Plugin using Jitsu SDK.
Allow destination plugins to be loaded from local filesystem
Allow Body to be an object in JITSU_ENVELOPE and DestinationMessage
Use "go mod download" instead of "go mod tidy" in Makefile, Dockerfile-s and CI