### PR TITLE
meta: fix redis lua script

### DIFF
--- a/server/meta/scripts.go
+++ b/server/meta/scripts.go
@@ -8,7 +8,7 @@ if redis.call('exists',KEYS[1]) == 1 then
   redis.call('hmset', KEYS[1], KEYS[2], KEYS[3], KEYS[4], KEYS[5]) 
 elseif KEYS[1] ~= KEYS[9] then
   local orig = unpack(redis.call('hmget', KEYS[9], 'original'))
-  if orig ~= nil then 
+  if orig then 
     redis.call('hmset', KEYS[1], KEYS[2], KEYS[3], KEYS[4], KEYS[5], 'original', orig)
     redis.call('ZADD', KEYS[6], KEYS[7], KEYS[8])
   end
@@ -19,7 +19,7 @@ if redis.call('exists',KEYS[1]) == 1 then
   redis.call('hmset', KEYS[1], KEYS[2], KEYS[3], KEYS[4], KEYS[5], KEYS[6], KEYS[7])
 elseif KEYS[1] ~= KEYS[11] then
   local orig = unpack(redis.call('hmget', KEYS[11], 'original'))
-  if orig ~= nil then 
+  if orig then 
   	redis.call('hmset', KEYS[1], KEYS[2], KEYS[3], KEYS[4], KEYS[5], KEYS[6], KEYS[7], 'original', orig)
   	redis.call('ZADD', KEYS[8], KEYS[9], KEYS[10])
   end


### PR DESCRIPTION
This PR fixes the issue in the Redis script. Basically, the `orig` is converted to `false` when it is passed to Lua 

Reference: https://github.com/redis/redis-doc/blob/6b96d367f63612d9d7fecd158134557f837d9605/commands/eval.md#conversion-between-lua-and-redis-data-types

Closes #787 