### PR TITLE
Prevent goroutine leaks if destination initialization was failed

### DIFF
--- a/server/schema/processor.go
+++ b/server/schema/processor.go
@@ -50,9 +50,10 @@ type Processor struct {
 	jsVariables             map[string]interface{}
 	//indicate that we didn't forget to init JavaScript transform
 	transformInitialized bool
+	MappingStyle         string
 }
 
-func NewProcessor(destinationID string, destinationConfig *config.DestinationConfig, isSQLType bool, tableNameFuncExpression string, fieldMapper events.Mapper, enrichmentRules []enrichment.Rule, flattener Flattener, typeResolver TypeResolver, uniqueIDField *identifiers.UniqueID, maxColumnNameLen int) (*Processor, error) {
+func NewProcessor(destinationID string, destinationConfig *config.DestinationConfig, isSQLType bool, tableNameFuncExpression string, fieldMapper events.Mapper, enrichmentRules []enrichment.Rule, flattener Flattener, typeResolver TypeResolver, uniqueIDField *identifiers.UniqueID, maxColumnNameLen int, mappingStyle string) (*Processor, error) {
 	return &Processor{
 		identifier:              destinationID,
 		destinationConfig:       destinationConfig,
@@ -68,6 +69,7 @@ func NewProcessor(destinationID string, destinationConfig *config.DestinationCon
 		tableNameFuncExpression: tableNameFuncExpression,
 		javaScripts:             []string{},
 		jsVariables:             map[string]interface{}{},
+		MappingStyle:            mappingStyle,
 	}, nil
 }
 

--- a/server/schema/processor_test.go
+++ b/server/schema/processor_test.go
@@ -146,7 +146,7 @@ func TestProcessFilePayload(t *testing.T) {
 	}
 	destination := &config.DestinationConfig{Type: "google_analytics", BreakOnError: false,
 		DataLayout: &config.DataLayout{Transform: ""}}
-	p, err := NewProcessor("test", destination, false, `{{if .event_type}}{{if eq .event_type "skipped"}}{{else}}{{.event_type}}_{{._timestamp.Format "2006_01"}}{{end}}{{else}}{{.event_type}}_{{._timestamp.Format "2006_01"}}{{end}}`, &DummyMapper{}, []enrichment.Rule{}, NewFlattener(), NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 0)
+	p, err := NewProcessor("test", destination, false, `{{if .event_type}}{{if eq .event_type "skipped"}}{{else}}{{.event_type}}_{{._timestamp.Format "2006_01"}}{{end}}{{else}}{{.event_type}}_{{._timestamp.Format "2006_01"}}{{end}}`, &DummyMapper{}, []enrichment.Rule{}, NewFlattener(), NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 0, "new")
 	require.NoError(t, err)
 	err = p.InitJavaScriptTemplates()
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestProcessFact(t *testing.T) {
 
 	destination := &config.DestinationConfig{Type: "google_analytics", BreakOnError: false,
 		DataLayout: &config.DataLayout{Transform: ""}}
-	p, err := NewProcessor("test", destination, false, `events_{{._timestamp.Format "2006_01"}}`, fieldMapper, []enrichment.Rule{uaRule, ipRule}, NewFlattener(), NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 20)
+	p, err := NewProcessor("test", destination, false, `events_{{._timestamp.Format "2006_01"}}`, fieldMapper, []enrichment.Rule{uaRule, ipRule}, NewFlattener(), NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 20, "new")
 	require.NoError(t, err)
 	err = p.InitJavaScriptTemplates()
 	require.NoError(t, err)
@@ -449,7 +449,7 @@ switch ($.event_type) {
 `
 	destination := &config.DestinationConfig{Type: "google_analytics", BreakOnError: false,
 		DataLayout: &config.DataLayout{Transform: transformExpression}}
-	p, err := NewProcessor("test", destination, false, `events`, fieldMapper, []enrichment.Rule{}, NewFlattener(), NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 20)
+	p, err := NewProcessor("test", destination, false, `events`, fieldMapper, []enrichment.Rule{}, NewFlattener(), NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 20, "new")
 	require.NoError(t, err)
 	err = p.InitJavaScriptTemplates()
 	require.NoError(t, err)

--- a/server/storages/abstract.go
+++ b/server/storages/abstract.go
@@ -214,25 +214,25 @@ func (a *Abstract) close() (multiErr error) {
 	return nil
 }
 
-func (a *Abstract) Init(config *Config) (err error) {
+func (a *Abstract) Init(config *Config) error {
 	//Abstract (SQLAdapters and tableHelpers are omitted)
 	a.destinationID = config.destinationID
 	a.eventsCache = config.eventsCache
 	a.uniqueIDField = config.uniqueIDField
 	a.staged = config.destination.Staged
 	a.cachingConfiguration = config.destination.CachingConfiguration
+	var err error
 	a.processor, a.sqlTypes, err = a.setupProcessor(config)
-	return
+	if err != nil {
+		return err
+	}
+	return a.Processor().InitJavaScriptTemplates()
 }
 
 func (a *Abstract) Start(config *Config) error {
 	a.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
 	a.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)
 
-	err := a.Processor().InitJavaScriptTemplates()
-	if err != nil {
-		return err
-	}
 	if a.streamingWorker != nil {
 		a.streamingWorker.start()
 	}

--- a/server/storages/abstract.go
+++ b/server/storages/abstract.go
@@ -2,6 +2,9 @@ package storages
 
 import (
 	"fmt"
+	"github.com/jitsucom/jitsu/server/appconfig"
+	"github.com/jitsucom/jitsu/server/enrichment"
+	"github.com/jitsucom/jitsu/server/typing"
 	"math/rand"
 
 	"github.com/jitsucom/jitsu/server/config"
@@ -30,10 +33,13 @@ type Abstract struct {
 
 	tableHelpers []*TableHelper
 	sqlAdapters  []adapters.SQLAdapter
+	sqlTypes     typing.SQLTypes
 
 	uniqueIDField        *identifiers.UniqueID
 	staged               bool
 	cachingConfiguration *config.CachingConfiguration
+
+	streamingWorker *StreamingWorker
 
 	archiveLogger logging.ObjectLogger
 }
@@ -186,6 +192,11 @@ func (a *Abstract) Clean(tableName string) error {
 }
 
 func (a *Abstract) close() (multiErr error) {
+	if a.streamingWorker != nil {
+		if err := a.streamingWorker.Close(); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing streaming worker: %v", a.ID(), err))
+		}
+	}
 	if a.fallbackLogger != nil {
 		if err := a.fallbackLogger.Close(); err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing fallback logger: %v", a.ID(), err))
@@ -201,6 +212,125 @@ func (a *Abstract) close() (multiErr error) {
 	}
 
 	return nil
+}
+
+func (a *Abstract) Init(config *Config) (err error) {
+	//Abstract (SQLAdapters and tableHelpers are omitted)
+	a.destinationID = config.destinationID
+	a.eventsCache = config.eventsCache
+	a.uniqueIDField = config.uniqueIDField
+	a.staged = config.destination.Staged
+	a.cachingConfiguration = config.destination.CachingConfiguration
+	a.processor, a.sqlTypes, err = a.setupProcessor(config)
+	return
+}
+
+func (a *Abstract) Start(config *Config) error {
+	a.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
+	a.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)
+
+	err := a.Processor().InitJavaScriptTemplates()
+	if err != nil {
+		return err
+	}
+	if a.streamingWorker != nil {
+		a.streamingWorker.start()
+	}
+	return nil
+}
+
+func (a *Abstract) setupProcessor(cfg *Config) (processor *schema.Processor, sqlTypes typing.SQLTypes, err error) {
+	destination := cfg.destination
+	destinationID := cfg.destinationID
+	storageType, ok := StorageTypes[destination.Type]
+	if !ok {
+		return nil, nil, ErrUnknownDestination
+	}
+	var tableName string
+	var oldStyleMappings []string
+	var newStyleMapping *config.Mapping
+	mappingFieldType := config.Default
+	uniqueIDField := appconfig.Instance.GlobalUniqueIDField
+	if destination.DataLayout != nil {
+		mappingFieldType = destination.DataLayout.MappingType
+		oldStyleMappings = destination.DataLayout.Mapping
+		newStyleMapping = destination.DataLayout.Mappings
+		if destination.DataLayout.TableNameTemplate != "" {
+			tableName = destination.DataLayout.TableNameTemplate
+		}
+	}
+
+	if tableName == "" {
+		tableName = storageType.defaultTableName
+	}
+	if tableName == "" {
+		tableName = defaultTableName
+		logging.Infof("[%s] uses default table: %s", destinationID, tableName)
+	}
+
+	if len(destination.Enrichment) == 0 {
+		logging.Warnf("[%s] doesn't have enrichment rules", destinationID)
+	} else {
+		logging.Infof("[%s] configured enrichment rules:", destinationID)
+	}
+
+	//default enrichment rules
+	enrichmentRules := []enrichment.Rule{
+		enrichment.CreateDefaultJsIPRule(cfg.geoService, destination.GeoDataResolverID),
+		enrichment.DefaultJsUaRule,
+	}
+
+	// ** Enrichment rules **
+	for _, ruleConfig := range destination.Enrichment {
+		logging.Infof("[%s] %s", destinationID, ruleConfig.String())
+
+		rule, err := enrichment.NewRule(ruleConfig, cfg.geoService, destination.GeoDataResolverID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error creating enrichment rule [%s]: %v", ruleConfig.String(), err)
+		}
+
+		enrichmentRules = append(enrichmentRules, rule)
+	}
+
+	// ** Mapping rules **
+	if len(oldStyleMappings) > 0 {
+		logging.Warnf("\n\t ** [%s] DEPRECATED mapping configuration. Read more about new configuration schema: https://jitsu.com/docs/configuration/schema-and-mappings **\n", destinationID)
+		var convertErr error
+		newStyleMapping, convertErr = schema.ConvertOldMappings(mappingFieldType, oldStyleMappings)
+		if convertErr != nil {
+			return nil, nil, convertErr
+		}
+	}
+	isSQLType := storageType.isSQLType(destination)
+	enrichAndLogMappings(destinationID, isSQLType, uniqueIDField, newStyleMapping)
+	fieldMapper, sqlTypes, err := schema.NewFieldMapper(newStyleMapping)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var flattener schema.Flattener
+	var typeResolver schema.TypeResolver
+	if isSQLType {
+		flattener = schema.NewFlattener()
+		typeResolver = schema.NewTypeResolver()
+	} else {
+		flattener = schema.NewDummyFlattener()
+		typeResolver = schema.NewDummyTypeResolver()
+	}
+
+	maxColumnNameLength, _ := maxColumnNameLengthByDestinationType[destination.Type]
+	mappingsStyle := ""
+	if len(oldStyleMappings) > 0 {
+		mappingsStyle = "old"
+	} else if newStyleMapping != nil {
+		mappingsStyle = "new"
+	}
+	processor, err = schema.NewProcessor(destinationID, destination, isSQLType, tableName, fieldMapper, enrichmentRules, flattener, typeResolver, uniqueIDField, maxColumnNameLength, mappingsStyle)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return processor, sqlTypes, nil
 }
 
 //assume that adapters quantity == tableHelpers quantity

--- a/server/storages/amplitude.go
+++ b/server/storages/amplitude.go
@@ -28,10 +28,14 @@ func NewAmplitude(config *Config) (Storage, error) {
 		return nil, err
 	}
 
-	config.processor.AddJavaScript(amplitudeTransform)
-	config.processor.SetDefaultUserTransform(`return toAmplitude($)`)
-
 	a := &Amplitude{}
+	err := a.Init(config)
+	if err != nil {
+		return nil, err
+	}
+
+	a.processor.AddJavaScript(amplitudeTransform)
+	a.processor.SetDefaultUserTransform(`return toAmplitude($)`)
 
 	requestDebugLogger := config.loggerFactory.CreateSQLQueryLogger(config.destinationID)
 	aAdapter, err := adapters.NewAmplitude(amplitudeConfig, &adapters.HTTPAdapterConfiguration{
@@ -47,30 +51,11 @@ func NewAmplitude(config *Config) (Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	tableHelper := NewTableHelper("", aAdapter, config.coordinationService, config.pkFields, adapters.DefaultSchemaTypeMappings, 0, AmplitudeType)
-
 	//HTTPStorage
-	a.tableHelper = tableHelper
 	a.adapter = aAdapter
 
-	//Abstract (SQLAdapters and tableHelpers are omitted)
-	a.destinationID = config.destinationID
-	a.processor = config.processor
-	a.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
-	a.eventsCache = config.eventsCache
-	a.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)
-	a.uniqueIDField = config.uniqueIDField
-	a.staged = config.destination.Staged
-	a.cachingConfiguration = config.destination.CachingConfiguration
-
 	//streaming worker (queue reading)
-	a.streamingWorker, err = newStreamingWorker(config.eventQueue, config.processor, a, tableHelper)
-	if err != nil {
-		return nil, err
-	}
-	a.streamingWorker.start()
-
+	a.streamingWorker = newStreamingWorker(config.eventQueue, a)
 	return a, nil
 }
 

--- a/server/storages/http.go
+++ b/server/storages/http.go
@@ -15,9 +15,6 @@ import (
 type HTTPStorage struct {
 	Abstract
 
-	tableHelper     *TableHelper
-	streamingWorker *StreamingWorker
-
 	adapter adapters.Adapter
 }
 
@@ -27,7 +24,7 @@ func (h *HTTPStorage) Insert(eventContext *adapters.EventContext) error {
 }
 
 func (h *HTTPStorage) DryRun(payload events.Event) ([][]adapters.TableField, error) {
-	return dryRun(payload, h.processor, h.tableHelper)
+	return nil, nil
 }
 
 //Store isn't supported
@@ -67,13 +64,15 @@ func (h *HTTPStorage) Type() string {
 
 //Close closes adapter, fallback logger and streaming worker
 func (h *HTTPStorage) Close() (multiErr error) {
-	if err := h.adapter.Close(); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing %s client: %v", h.ID(), h.Type(), err))
-	}
-
 	if h.streamingWorker != nil {
 		if err := h.streamingWorker.Close(); err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing streaming worker: %v", h.ID(), err))
+		}
+	}
+
+	if h.adapter != nil {
+		if err := h.adapter.Close(); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing %s client: %v", h.ID(), h.Type(), err))
 		}
 	}
 

--- a/server/storages/hubspot.go
+++ b/server/storages/hubspot.go
@@ -26,6 +26,10 @@ func NewHubSpot(config *Config) (Storage, error) {
 	}
 
 	h := &HubSpot{}
+	err := h.Init(config)
+	if err != nil {
+		return nil, err
+	}
 
 	requestDebugLogger := config.loggerFactory.CreateSQLQueryLogger(config.destinationID)
 	hAdapter, err := adapters.NewHubSpot(hubspotConfig, &adapters.HTTPAdapterConfiguration{
@@ -42,28 +46,10 @@ func NewHubSpot(config *Config) (Storage, error) {
 		return nil, err
 	}
 
-	tableHelper := NewTableHelper("", hAdapter, config.coordinationService, config.pkFields, adapters.DefaultSchemaTypeMappings, 0, HubSpotType)
-
-	h.tableHelper = tableHelper
 	h.adapter = hAdapter
 
-	//Abstract (SQLAdapters and tableHelpers are omitted)
-	h.destinationID = config.destinationID
-	h.processor = config.processor
-	h.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
-	h.eventsCache = config.eventsCache
-	h.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)
-	h.uniqueIDField = config.uniqueIDField
-	h.staged = config.destination.Staged
-	h.cachingConfiguration = config.destination.CachingConfiguration
-
 	//streaming worker (queue reading)
-	h.streamingWorker, err = newStreamingWorker(config.eventQueue, config.processor, h, tableHelper)
-	if err != nil {
-		return nil, err
-	}
-	h.streamingWorker.start()
-
+	h.streamingWorker = newStreamingWorker(config.eventQueue, h)
 	return h, nil
 }
 

--- a/server/storages/mysql.go
+++ b/server/storages/mysql.go
@@ -20,7 +20,6 @@ type MySQL struct {
 	Abstract
 
 	adapter                       *adapters.MySQL
-	streamingWorker               *StreamingWorker
 	usersRecognitionConfiguration *UserRecognitionConfiguration
 }
 
@@ -29,10 +28,16 @@ func init() {
 }
 
 //NewMySQL returns configured MySQL Destination
-func NewMySQL(config *Config) (Storage, error) {
+func NewMySQL(config *Config) (storage Storage, err error) {
+	defer func() {
+		if err != nil && storage != nil {
+			storage.Close()
+			storage = nil
+		}
+	}()
 	mConfig := &adapters.DataSourceConfig{}
-	if err := config.destination.GetDestConfig(config.destination.DataSource, mConfig); err != nil {
-		return nil, err
+	if err = config.destination.GetDestConfig(config.destination.DataSource, mConfig); err != nil {
+		return
 	}
 	//enrich with default parameters
 	if mConfig.Port == 0 {
@@ -44,41 +49,32 @@ func NewMySQL(config *Config) (Storage, error) {
 	if _, ok := mConfig.Parameters["timeout"]; !ok {
 		mConfig.Parameters["timeout"] = "600s"
 	}
+	m := &MySQL{}
+	err = m.Init(config)
+	if err != nil {
+		return
+	}
+	storage = m
 
 	queryLogger := config.loggerFactory.CreateSQLQueryLogger(config.destinationID)
 	ctx := context.WithValue(config.ctx, adapters.CtxDestinationId, config.destinationID)
-	adapter, err := CreateMySQLAdapter(ctx, *mConfig, queryLogger, config.sqlTypes)
+	adapter, err := CreateMySQLAdapter(ctx, *mConfig, queryLogger, m.sqlTypes)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	tableHelper := NewTableHelper(mConfig.Schema, adapter, config.coordinationService, config.pkFields, adapters.SchemaToMySQL, config.maxColumns, MySQLType)
 
-	m := &MySQL{
-		adapter:                       adapter,
-		usersRecognitionConfiguration: config.usersRecognition,
-	}
+	m.adapter = adapter
+	m.usersRecognitionConfiguration = config.usersRecognition
 
 	//Abstract
-	m.destinationID = config.destinationID
-	m.processor = config.processor
-	m.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
-	m.eventsCache = config.eventsCache
 	m.tableHelpers = []*TableHelper{tableHelper}
 	m.sqlAdapters = []adapters.SQLAdapter{adapter}
-	m.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)
-	m.uniqueIDField = config.uniqueIDField
-	m.staged = config.destination.Staged
-	m.cachingConfiguration = config.destination.CachingConfiguration
 
 	//streaming worker (queue reading)
-	m.streamingWorker, err = newStreamingWorker(config.eventQueue, config.processor, m, tableHelper)
-	if err != nil {
-		return nil, err
-	}
-	m.streamingWorker.start()
-
-	return m, nil
+	m.streamingWorker = newStreamingWorker(config.eventQueue, m, tableHelper)
+	return
 }
 
 //CreateMySQLAdapter creates mysql adapter with database
@@ -242,13 +238,15 @@ func (m *MySQL) Type() string {
 
 //Close closes MySQL adapter, fallback logger and streaming worker
 func (m *MySQL) Close() (multiErr error) {
-	if err := m.adapter.Close(); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing postgres datasource: %v", m.ID(), err))
-	}
-
 	if m.streamingWorker != nil {
 		if err := m.streamingWorker.Close(); err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing streaming worker: %v", m.ID(), err))
+		}
+	}
+
+	if m.adapter != nil {
+		if err := m.adapter.Close(); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing postgres datasource: %v", m.ID(), err))
 		}
 	}
 

--- a/server/storages/proxy.go
+++ b/server/storages/proxy.go
@@ -45,7 +45,10 @@ func (rsp *RetryableProxy) start() {
 
 			storage, err := rsp.factoryMethod(rsp.config)
 			if err == nil {
-				err = storage.Processor().InitJavaScriptTemplates()
+				err = storage.Start(rsp.config)
+				if err != nil {
+					storage.Close()
+				}
 			}
 			if err != nil {
 				//write logs only if new error or write every 20th
@@ -73,7 +76,7 @@ func (rsp *RetryableProxy) start() {
 
 			logging.Infof("[%s] destination has been initialized!", rsp.config.destinationID)
 			telemetry.Destination(rsp.config.destinationID, rsp.config.destination.Type, rsp.config.destination.Mode,
-				rsp.config.mappingsStyle, len(rsp.config.pkFields) > 0, rsp.storage.GetUsersRecognition().IsEnabled())
+				rsp.storage.Processor().MappingStyle, len(rsp.config.pkFields) > 0, rsp.storage.GetUsersRecognition().IsEnabled())
 
 			break
 		}

--- a/server/storages/redshift.go
+++ b/server/storages/redshift.go
@@ -20,7 +20,6 @@ type AwsRedshift struct {
 
 	s3Adapter                     *adapters.S3
 	redshiftAdapter               *adapters.AwsRedshift
-	streamingWorker               *StreamingWorker
 	usersRecognitionConfiguration *UserRecognitionConfiguration
 }
 
@@ -29,10 +28,16 @@ func init() {
 }
 
 //NewAwsRedshift returns AwsRedshift and start goroutine for aws redshift batch storage or for stream consumer depend on destination mode
-func NewAwsRedshift(config *Config) (Storage, error) {
+func NewAwsRedshift(config *Config) (storage Storage, err error) {
+	defer func() {
+		if err != nil && storage != nil {
+			storage.Close()
+			storage = nil
+		}
+	}()
 	redshiftConfig := &adapters.DataSourceConfig{}
-	if err := config.destination.GetDestConfig(config.destination.DataSource, redshiftConfig); err != nil {
-		return nil, err
+	if err = config.destination.GetDestConfig(config.destination.DataSource, redshiftConfig); err != nil {
+		return
 	}
 	//enrich with default parameters
 	if redshiftConfig.Port == 0 {
@@ -49,70 +54,60 @@ func NewAwsRedshift(config *Config) (Storage, error) {
 	}
 
 	dir := adapters.SSLDir(appconfig.Instance.ConfigPath, config.destinationID)
-	if err := adapters.ProcessSSL(dir, redshiftConfig); err != nil {
-		return nil, err
+	if err = adapters.ProcessSSL(dir, redshiftConfig); err != nil {
+		return
 	}
 
 	var s3Adapter *adapters.S3
 	var s3config *adapters.S3Config
 	s3c, err := config.destination.GetConfig(redshiftConfig.S3, config.destination.S3, &adapters.S3Config{})
 	if err != nil {
-		return nil, err
+		return
 	}
 	s3config, ok := s3c.(*adapters.S3Config)
 	if !ok {
 		s3config = &adapters.S3Config{}
 	}
 	if !config.streamMode {
-		var err error
 		s3Adapter, err = adapters.NewS3(s3config)
 		if err != nil {
-			return nil, err
+			return
 		}
 	}
+	ar := &AwsRedshift{}
+	err = ar.Init(config)
+	if err != nil {
+		return
+	}
+	storage = ar
 
 	queryLogger := config.loggerFactory.CreateSQLQueryLogger(config.destinationID)
 	ctx := context.WithValue(config.ctx, adapters.CtxDestinationId, config.destinationID)
-	redshiftAdapter, err := adapters.NewAwsRedshift(ctx, redshiftConfig, s3config, queryLogger, config.sqlTypes)
+	redshiftAdapter, err := adapters.NewAwsRedshift(ctx, redshiftConfig, s3config, queryLogger, ar.sqlTypes)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	//create db schema if doesn't exist
 	err = redshiftAdapter.CreateDbSchema(redshiftConfig.Schema)
 	if err != nil {
 		redshiftAdapter.Close()
-		return nil, err
+		return
 	}
 
 	tableHelper := NewTableHelper(redshiftConfig.Schema, redshiftAdapter, config.coordinationService, config.pkFields, adapters.SchemaToRedshift, config.maxColumns, RedshiftType)
 
-	ar := &AwsRedshift{
-		s3Adapter:                     s3Adapter,
-		redshiftAdapter:               redshiftAdapter,
-		usersRecognitionConfiguration: config.usersRecognition,
-	}
+	ar.s3Adapter = s3Adapter
+	ar.redshiftAdapter = redshiftAdapter
+	ar.usersRecognitionConfiguration = config.usersRecognition
 
 	//Abstract
-	ar.destinationID = config.destinationID
-	ar.processor = config.processor
-	ar.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
-	ar.eventsCache = config.eventsCache
 	ar.tableHelpers = []*TableHelper{tableHelper}
 	ar.sqlAdapters = []adapters.SQLAdapter{redshiftAdapter}
-	ar.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)
-	ar.uniqueIDField = config.uniqueIDField
-	ar.staged = config.destination.Staged
-	ar.cachingConfiguration = config.destination.CachingConfiguration
 
 	//streaming worker (queue reading)
-	ar.streamingWorker, err = newStreamingWorker(config.eventQueue, config.processor, ar, tableHelper)
-	if err != nil {
-		return nil, err
-	}
-	ar.streamingWorker.start()
-
-	return ar, nil
+	ar.streamingWorker = newStreamingWorker(config.eventQueue, ar, tableHelper)
+	return
 }
 
 //Store process events and stores with storeTable() func
@@ -240,8 +235,10 @@ func (ar *AwsRedshift) Type() string {
 
 //Close closes AwsRedshift adapter, fallback logger and streaming worker
 func (ar *AwsRedshift) Close() (multiErr error) {
-	if err := ar.redshiftAdapter.Close(); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing redshift datasource: %v", ar.ID(), err))
+	if ar.redshiftAdapter != nil {
+		if err := ar.redshiftAdapter.Close(); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing redshift datasource: %v", ar.ID(), err))
+		}
 	}
 
 	if ar.streamingWorker != nil {

--- a/server/storages/s3.go
+++ b/server/storages/s3.go
@@ -54,16 +54,10 @@ func NewS3(config *Config) (Storage, error) {
 	s3 := &S3{
 		s3Adapter: s3Adapter,
 	}
-
-	//Abstract (SQLAdapters and tableHelpers and archive logger are omitted)
-	s3.destinationID = config.destinationID
-	s3.processor = config.processor
-	s3.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
-	s3.eventsCache = config.eventsCache
-	s3.uniqueIDField = config.uniqueIDField
-	s3.staged = config.destination.Staged
-	s3.cachingConfiguration = config.destination.CachingConfiguration
-
+	err = s3.Init(config)
+	if err != nil {
+		return nil, err
+	}
 	return s3, nil
 }
 

--- a/server/storages/snowflake.go
+++ b/server/storages/snowflake.go
@@ -22,7 +22,6 @@ type Snowflake struct {
 
 	stageAdapter                  adapters.Stage
 	snowflakeAdapter              *adapters.Snowflake
-	streamingWorker               *StreamingWorker
 	usersRecognitionConfiguration *UserRecognitionConfiguration
 }
 
@@ -31,10 +30,16 @@ func init() {
 }
 
 //NewSnowflake returns Snowflake and start goroutine for Snowflake batch storage or for stream consumer depend on destination mode
-func NewSnowflake(config *Config) (Storage, error) {
+func NewSnowflake(config *Config) (storage Storage, err error) {
+	defer func() {
+		if err != nil && storage != nil {
+			storage.Close()
+			storage = nil
+		}
+	}()
 	snowflakeConfig := &adapters.SnowflakeConfig{}
-	if err := config.destination.GetDestConfig(config.destination.Snowflake, snowflakeConfig); err != nil {
-		return nil, err
+	if err = config.destination.GetDestConfig(config.destination.Snowflake, snowflakeConfig); err != nil {
+		return
 	}
 	if snowflakeConfig.Schema == "" {
 		snowflakeConfig.Schema = "PUBLIC"
@@ -49,16 +54,16 @@ func NewSnowflake(config *Config) (Storage, error) {
 	var googleConfig *adapters.GoogleConfig
 	gc, err := config.destination.GetConfig(snowflakeConfig.Google, config.destination.Google, &adapters.GoogleConfig{})
 	if err != nil {
-		return nil, err
+		return
 	}
 	googleConfig, googleOk := gc.(*adapters.GoogleConfig)
 	if googleOk {
-		if err := googleConfig.Validate(); err != nil {
-			return nil, err
+		if err = googleConfig.Validate(); err != nil {
+			return
 		}
 		if !config.streamMode {
-			if err := googleConfig.ValidateBatchMode(); err != nil {
-				return nil, err
+			if err = googleConfig.ValidateBatchMode(); err != nil {
+				return
 			}
 		}
 
@@ -72,61 +77,46 @@ func NewSnowflake(config *Config) (Storage, error) {
 	var s3config *adapters.S3Config
 	s3c, err := config.destination.GetConfig(snowflakeConfig.S3, config.destination.S3, &adapters.S3Config{})
 	if err != nil {
-		return nil, err
+		return
 	}
 	s3config, s3ok := s3c.(*adapters.S3Config)
 	if !config.streamMode {
-		var err error
 		if s3ok {
 			stageAdapter, err = adapters.NewS3(s3config)
 			if err != nil {
-				return nil, err
+				return
 			}
 		} else {
 			stageAdapter, err = adapters.NewGoogleCloudStorage(config.ctx, googleConfig)
 			if err != nil {
-				return nil, err
+				return
 			}
 		}
 	}
-
-	queryLogger := config.loggerFactory.CreateSQLQueryLogger(config.destinationID)
-	snowflakeAdapter, err := CreateSnowflakeAdapter(config.ctx, s3config, *snowflakeConfig, queryLogger, config.sqlTypes)
+	snowflake := &Snowflake{stageAdapter: stageAdapter}
+	err = snowflake.Init(config)
 	if err != nil {
-		if stageAdapter != nil {
-			stageAdapter.Close()
-		}
-		return nil, err
+		return
+	}
+	storage = snowflake
+	queryLogger := config.loggerFactory.CreateSQLQueryLogger(config.destinationID)
+	snowflakeAdapter, err := CreateSnowflakeAdapter(config.ctx, s3config, *snowflakeConfig, queryLogger, snowflake.sqlTypes)
+	if err != nil {
+		return
 	}
 
 	tableHelper := NewTableHelper(snowflakeConfig.Schema, snowflakeAdapter, config.coordinationService, config.pkFields, adapters.SchemaToSnowflake, config.maxColumns, SnowflakeType)
 
-	snowflake := &Snowflake{
-		stageAdapter:                  stageAdapter,
-		snowflakeAdapter:              snowflakeAdapter,
-		usersRecognitionConfiguration: config.usersRecognition,
-	}
+	snowflake.snowflakeAdapter = snowflakeAdapter
+	snowflake.usersRecognitionConfiguration = config.usersRecognition
 
 	//Abstract
-	snowflake.destinationID = config.destinationID
-	snowflake.processor = config.processor
-	snowflake.fallbackLogger = config.loggerFactory.CreateFailedLogger(config.destinationID)
-	snowflake.eventsCache = config.eventsCache
 	snowflake.tableHelpers = []*TableHelper{tableHelper}
 	snowflake.sqlAdapters = []adapters.SQLAdapter{snowflakeAdapter}
-	snowflake.archiveLogger = config.loggerFactory.CreateStreamingArchiveLogger(config.destinationID)
-	snowflake.uniqueIDField = config.uniqueIDField
-	snowflake.staged = config.destination.Staged
-	snowflake.cachingConfiguration = config.destination.CachingConfiguration
 
 	//streaming worker (queue reading)
-	snowflake.streamingWorker, err = newStreamingWorker(config.eventQueue, config.processor, snowflake, tableHelper)
-	if err != nil {
-		return nil, err
-	}
-	snowflake.streamingWorker.start()
-
-	return snowflake, nil
+	snowflake.streamingWorker = newStreamingWorker(config.eventQueue, snowflake, tableHelper)
+	return
 }
 
 //CreateSnowflakeAdapter creates snowflake adapter with schema
@@ -292,19 +282,19 @@ func (s *Snowflake) Type() string {
 
 //Close closes Snowflake adapter, stage adapter, fallback logger and streaming worker
 func (s *Snowflake) Close() (multiErr error) {
-	if err := s.snowflakeAdapter.Close(); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing snowflake datasource: %v", s.ID(), err))
-	}
-
-	if s.stageAdapter != nil {
-		if err := s.stageAdapter.Close(); err != nil {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing snowflake stage: %v", s.ID(), err))
-		}
-	}
-
 	if s.streamingWorker != nil {
 		if err := s.streamingWorker.Close(); err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing streaming worker: %v", s.ID(), err))
+		}
+	}
+	if s.snowflakeAdapter != nil {
+		if err := s.snowflakeAdapter.Close(); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing snowflake datasource: %v", s.ID(), err))
+		}
+	}
+	if s.stageAdapter != nil {
+		if err := s.stageAdapter.Close(); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("[%s] Error closing snowflake stage: %v", s.ID(), err))
 		}
 	}
 

--- a/server/storages/table_helper_test.go
+++ b/server/storages/table_helper_test.go
@@ -106,7 +106,7 @@ return $
 `
 	destination := &config.DestinationConfig{Type: "google_analytics", BreakOnError: false,
 		DataLayout: &config.DataLayout{Transform: transformExpression}}
-	p, err := schema.NewProcessor("test", destination, false, `events`, fieldMapper, []enrichment.Rule{}, schema.NewFlattener(), schema.NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 20)
+	p, err := schema.NewProcessor("test", destination, false, `events`, fieldMapper, []enrichment.Rule{}, schema.NewFlattener(), schema.NewTypeResolver(), identifiers.NewUniqueID("/eventn_ctx/event_id"), 20, "new")
 	require.NoError(t, err)
 	err = p.InitJavaScriptTemplates()
 	require.NoError(t, err)

--- a/server/storages/types.go
+++ b/server/storages/types.go
@@ -39,6 +39,8 @@ type Storage interface {
 	GetUniqueIDField() *identifiers.UniqueID
 	getAdapters() (adapters.SQLAdapter, *TableHelper)
 	Processor() *schema.Processor
+	Init(config *Config) error
+	Start(config *Config) error
 	ID() string
 	Type() string
 	IsStaging() bool


### PR DESCRIPTION
Prevent goroutine leaks if destination initialization was failed due to transform javascript errors
Refactoring: move goroutine producing calls to Storage.Start methods
Refactoring: reduce code duplication in Storage inits
Refactoring: get rid of table helpers in HTTP based storages