### PR TITLE
Increased max airbyte output buffer size

### DIFF
--- a/server/airbyte/async_parser.go
+++ b/server/airbyte/async_parser.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/schema"
 	"io"
+	"math"
 )
 
 const (
@@ -43,7 +44,7 @@ func (ap *asynchronousParser) parse(stdout io.Reader) error {
 
 	scanner := bufio.NewScanner(stdout)
 	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner.Buffer(buf, math.MaxInt/2)
 
 	records := 0
 	for scanner.Scan() {

--- a/server/airbyte/runner.go
+++ b/server/airbyte/runner.go
@@ -169,7 +169,7 @@ func (r *Runner) Read(dataConsumer base.CLIDataConsumer, streamsRepresentation m
 
 		err := asyncParser.parse(stdout)
 		if err != nil {
-			taskCloser.CloseWithError(fmt.Sprintf("Process error: %v. Process will be killed", err), false)
+			taskCloser.CloseWithError(fmt.Sprintf("Airbyte output line process error: %v. Process will be killed", err), false)
 			if killErr := r.Close(); killErr != nil && killErr != runner.ErrAirbyteAlreadyTerminated {
 				taskLogger.ERROR("Error closing airbyte runner: %v", killErr)
 				logging.Errorf("[%s] closing airbyte runner: %v", taskCloser.TaskID(), killErr)

--- a/server/drivers/singer/parser.go
+++ b/server/drivers/singer/parser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jitsucom/jitsu/server/schema"
 	"github.com/jitsucom/jitsu/server/singer"
 	"io"
+	"math"
 )
 
 const (
@@ -47,7 +48,7 @@ func (sop *streamOutputParser) Parse(stdout io.ReadCloser) error {
 
 	scanner := bufio.NewScanner(stdout)
 	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner.Buffer(buf, math.MaxInt/2)
 
 	records := 0
 	streamCleaned := map[string]bool{}


### PR DESCRIPTION
This PR fixes #806 by setting max token size = MAX_INTEGER / 2