### PR TITLE
Add custom header to @jitsu/sdk-js

### DIFF
--- a/javascript-sdk/__tests__/npm-browser.test.ts
+++ b/javascript-sdk/__tests__/npm-browser.test.ts
@@ -49,9 +49,14 @@ beforeAll(() => {
 });
 
 test("test browser", async () => {
+  let counter = 0;
   let jitsu: JitsuClient = jitsuClient({
     key: "Test",
     tracking_host: "https://test-host.com",
+    custom_headers: () => ({
+      "test1": "val1",
+      "test2": "val" + (counter++)
+    })
   });
   await jitsu.id({ email: "john.doe@gmail.com", id: "1212" });
   await jitsu.track("page_view", { test: 1 });
@@ -59,6 +64,12 @@ test("test browser", async () => {
   console.log("Requests", requestLog)
   const event1 = JSON.parse(requestLog[0].payload)
   const event2 = JSON.parse(requestLog[1].payload)
+
+  expect(requestLog[0].headers?.test2).toBe("val0")
+  expect(requestLog[1].headers?.test2).toBe("val1")
+
+  expect(requestLog[0].headers?.test1).toBe("val1")
+  expect(requestLog[1].headers?.test1).toBe("val1")
 
   expect(event1?.user?.anonymous_id).toBe(event2?.user?.anonymous_id)
   expect(event1?.user?.email).toBe('john.doe@gmail.com')

--- a/javascript-sdk/package.json
+++ b/javascript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jitsu/sdk-js",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Jitsu JavaScript SDK (more at http://jitsu.com/docs/js-sdk)",
   "main": "dist/npm/jitsu.cjs.js",
   "module": "dist/npm/dist/jitsu.es.js",

--- a/javascript-sdk/src/browser.ts
+++ b/javascript-sdk/src/browser.ts
@@ -7,7 +7,7 @@ const jsFileName = "lib.js"
 const jitsuProps = [
   'use_beacon_api', 'cookie_domain', 'tracking_host', 'cookie_name',
   'key', 'ga_hook', 'segment_hook', 'randomize_url', 'capture_3rd_party_cookies',
-  'id_method', 'log_level', 'compat_mode','privacy_policy', 'cookie_policy', 'ip_policy'
+  'id_method', 'log_level', 'compat_mode','privacy_policy', 'cookie_policy', 'ip_policy', 'custom_headers'
 ];
 
 

--- a/javascript-sdk/src/interface.d.ts
+++ b/javascript-sdk/src/interface.d.ts
@@ -26,7 +26,7 @@ export type JitsuClient = {
   //  * additional detection (user-agent, url and so on will be done). No payload structure is enforced
   //  * @param payload
   //  */
-  rawTrack: (payload: any) => void
+  rawTrack: (payload: any) => Promise<void>
 
   /**
    * Sets a user data
@@ -196,6 +196,11 @@ export type JitsuOptions = {
    * Log level. 'WARN' if not set
    */
   log_level?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'NONE';
+
+  /**
+   * Headers that should be added to each request. Could be either static dict or function that returns the dict
+   */
+  custom_headers?: Record<string, string> | (() => Record<string, string>)
 
   //NOTE: If any property is added here, please make sure it's added to browser.ts jitsuProps as well
 };


### PR DESCRIPTION
This PR implements #794. `A custom_headers` parameter has been added to `@jitsu/sdk-js` and the version has been bumped to `2.4.0`. Documentation is yet to be updated via a separate commit