### PR TITLE
Snowflake typecast

### DIFF
--- a/server/adapters/snowflake.go
+++ b/server/adapters/snowflake.go
@@ -747,7 +747,7 @@ func (s *Snowflake) getCastClause(name string, column typing.SQLColumn) string {
 		return "::" + castType.Type
 	}
 
-	return ""
+	return "::" + column.DDLType()
 }
 
 //columnDDL returns column DDL (column name, mapped sql type)

--- a/server/adapters/snowflake.go
+++ b/server/adapters/snowflake.go
@@ -588,6 +588,13 @@ func (s *Snowflake) bulkMergeInTransaction(wrappedTx *Transaction, table *Table,
 		return errorj.Decorate(err, "failed to create temporary table")
 	}
 
+	defer func() {
+		//delete tmp table
+		if err := s.dropTableInTransaction(wrappedTx, tmpTable); err != nil {
+			logging.Warnf("[snowflake] Failed to drop temporary table '%s': %v", tmpTable.Name, err)
+		}
+	}()
+
 	err = s.bulkInsertInTransaction(wrappedTx, tmpTable, objects)
 	if err != nil {
 		return errorj.Decorate(err, "failed to insert into temporary table").
@@ -624,11 +631,6 @@ func (s *Snowflake) bulkMergeInTransaction(wrappedTx *Transaction, table *Table,
 				Table:     table.Name,
 				Statement: insertFromSelectStatement,
 			})
-	}
-
-	//delete tmp table
-	if err := s.dropTableInTransaction(wrappedTx, tmpTable); err != nil {
-		return errorj.Decorate(err, "failed to drop temporary table")
 	}
 
 	return nil


### PR DESCRIPTION
* Perform explicit type cast for Snowflake since it seems confused about the same field being of multiple types in batch.
* Drop temporary table in `defer` since Snowflake seems not to remove it after transaction rollback.