### PR TITLE
#864 Fixed delimiter escaping in CSVMarshaller

### DIFF
--- a/server/adapters/snowflake.go
+++ b/server/adapters/snowflake.go
@@ -20,7 +20,7 @@ import (
 const (
 	tableExistenceSFQuery   = `SELECT count(*) from INFORMATION_SCHEMA.COLUMNS where TABLE_SCHEMA = ? and TABLE_NAME = ?`
 	descSchemaSFQuery       = `desc table %s.%s`
-	copyStatementFileFormat = ` FILE_FORMAT=(TYPE= 'CSV', FIELD_DELIMITER = '||' SKIP_HEADER = 1 EMPTY_FIELD_AS_NULL = true) `
+	copyStatementFileFormat = ` FILE_FORMAT=(TYPE= 'CSV', FIELD_OPTIONALLY_ENCLOSED_BY = '"' SKIP_HEADER = 1 EMPTY_FIELD_AS_NULL = true) `
 	gcpFrom                 = `FROM @%s
    							   %s
                                PATTERN = '%s'`

--- a/server/schema/batch_header.go
+++ b/server/schema/batch_header.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"github.com/jitsucom/jitsu/server/logging"
 	"github.com/jitsucom/jitsu/server/typing"
+	"sort"
 )
 
 type Fields map[string]Field
@@ -76,6 +77,7 @@ func (f Fields) Header() (header []string) {
 	for fieldName := range f {
 		header = append(header, fieldName)
 	}
+	sort.Strings(header)
 	return
 }
 

--- a/server/schema/processed_file.go
+++ b/server/schema/processed_file.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"bytes"
-	"github.com/jitsucom/jitsu/server/logging"
+	"fmt"
 	"strings"
 )
 
@@ -11,10 +11,10 @@ type ProcessedFile struct {
 	FileName    string
 	BatchHeader *BatchHeader
 
-	payload           []map[string]interface{}
+	payload            []map[string]interface{}
 	RecognitionPayload bool
-	originalRawEvents []string
-	eventsSrc         map[string]int
+	originalRawEvents  []string
+	eventsSrc          map[string]int
 }
 
 //GetOriginalRawEvents return payload as is
@@ -34,9 +34,9 @@ func (pf *ProcessedFile) GetPayloadLen() int {
 
 //GetPayloadBytes returns marshaling by marshaller func, joined with \n,  bytes
 //assume that payload can't be empty
-func (pf *ProcessedFile) GetPayloadBytes(marshaller Marshaller) []byte {
-	b, _ := pf.GetPayloadBytesWithHeader(marshaller)
-	return b
+func (pf *ProcessedFile) GetPayloadBytes(marshaller Marshaller) ([]byte, error) {
+	b, _, err := pf.GetPayloadBytesWithHeader(marshaller)
+	return b, err
 }
 
 //GetPayloadUsingStronglyTypedMarshaller returns bytes, containing marshalled payload
@@ -47,31 +47,30 @@ func (pf *ProcessedFile) GetPayloadUsingStronglyTypedMarshaller(stm StronglyType
 
 //GetPayloadBytesWithHeader returns marshaling by marshaller func, joined with \n,  bytes
 //assume that payload can't be empty
-func (pf *ProcessedFile) GetPayloadBytesWithHeader(marshaller Marshaller) ([]byte, []string) {
+func (pf *ProcessedFile) GetPayloadBytesWithHeader(marshaller Marshaller) ([]byte, []string, error) {
 	var buf *bytes.Buffer
 
 	var fields []string
-	//for csv writers using || delimiter
+	//for csv writers using , delimiter
 	if marshaller.NeedHeader() {
 		fields = pf.BatchHeader.Fields.Header()
-		buf = bytes.NewBuffer([]byte(strings.Join(fields, "||")))
+		buf = bytes.NewBuffer([]byte(strings.Join(fields, ",")))
+		_, err := buf.Write([]byte("\n"))
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error marshaling object in processed file: %v", err)
+		}
+	} else {
+		buf = &bytes.Buffer{}
 	}
 
 	for _, object := range pf.payload {
-		objectBytes, err := marshaller.Marshal(fields, object)
+		err := marshaller.Marshal(fields, object, buf)
 		if err != nil {
-			logging.Error("Error marshaling object in processed file:", err)
-		} else {
-			if buf == nil {
-				buf = bytes.NewBuffer(objectBytes)
-			} else {
-				buf.Write([]byte("\n"))
-				buf.Write(objectBytes)
-			}
+			return nil, nil, fmt.Errorf("Error marshaling object in processed file: %v", err)
 		}
 	}
 
-	return buf.Bytes(), fields
+	return buf.Bytes(), fields, nil
 }
 
 //GetEventsPerSrc returns events quantity per src

--- a/server/storages/bigquery.go
+++ b/server/storages/bigquery.go
@@ -111,7 +111,10 @@ func (bq *BigQuery) storeTable(fdata *schema.ProcessedFile) (*adapters.Table, er
 		if fileName == "" {
 			fileName = dbTable.Name + "_" + uuid.NewLettersNumbers()
 		}
-		b := fdata.GetPayloadBytes(schema.JSONMarshallerInstance)
+		b, err := fdata.GetPayloadBytes(schema.JSONMarshallerInstance)
+		if err != nil {
+			return dbTable, err
+		}
 		if err := bq.gcsAdapter.UploadBytes(fileName, b); err != nil {
 			return dbTable, err
 		}

--- a/server/storages/redshift.go
+++ b/server/storages/redshift.go
@@ -121,7 +121,10 @@ func (ar *AwsRedshift) storeTable(fdata *schema.ProcessedFile) (*adapters.Table,
 			return table, err
 		}
 
-		b := fdata.GetPayloadBytes(schema.JSONMarshallerInstance)
+		b, err := fdata.GetPayloadBytes(schema.JSONMarshallerInstance)
+		if err != nil {
+			return dbTable, err
+		}
 		if err := ar.s3Adapter.UploadBytes(fdata.FileName, b); err != nil {
 			return dbTable, err
 		}

--- a/server/storages/s3.go
+++ b/server/storages/s3.go
@@ -124,9 +124,9 @@ func (s3 *S3) marshall(fdata *schema.ProcessedFile) ([]byte, error) {
 	encodingFormat := s3.s3Adapter.Format()
 	switch encodingFormat {
 	case adapters.S3FormatCSV:
-		return fdata.GetPayloadBytes(schema.CSVMarshallerInstance), nil
+		return fdata.GetPayloadBytes(schema.CSVMarshallerInstance)
 	case adapters.S3FormatFlatJSON, adapters.S3FormatJSON:
-		return fdata.GetPayloadBytes(schema.JSONMarshallerInstance), nil
+		return fdata.GetPayloadBytes(schema.JSONMarshallerInstance)
 	case adapters.S3FormatParquet:
 		pm := schema.NewParquetMarshaller(s3.s3Adapter.Compression() == adapters.S3CompressionGZIP)
 		return fdata.GetPayloadUsingStronglyTypedMarshaller(pm)

--- a/server/storages/snowflake.go
+++ b/server/storages/snowflake.go
@@ -167,7 +167,10 @@ func (s *Snowflake) storeTable(fdata *schema.ProcessedFile) (*adapters.Table, er
 			return table, err
 		}
 
-		b, header := fdata.GetPayloadBytesWithHeader(schema.VerticalBarSeparatedMarshallerInstance)
+		b, header, err := fdata.GetPayloadBytesWithHeader(schema.CSVMarshallerInstance)
+		if err != nil {
+			return dbTable, err
+		}
 		if err := s.stageAdapter.UploadBytes(fdata.FileName, b); err != nil {
 			return dbTable, err
 		}


### PR DESCRIPTION
#864 Fixed for delimiter escaping in CSVMarshaller. Showflake switched to default CSV delimiter ','
preventing failure and data corruption on batch upload to Snowflakes

Fails to marshall single event during batch upload to cloud storages now causes error and fails entire batch.

Small tweaks