### PR TITLE
Hotfixes UI

### DIFF
--- a/configurator/frontend/main/src/App.tsx
+++ b/configurator/frontend/main/src/App.tsx
@@ -317,6 +317,7 @@ const ProjectRoute: React.FC<{ projects: Project[] }> = ({ projects }) => {
   const { projectId } = useParams<{ projectId: string }>()
 
   useEffect(() => {
+    setInitialized(false)
     ;(async () => {
       let project = await initializeProject(projectId, projects)
       if (!project) {
@@ -328,13 +329,13 @@ const ProjectRoute: React.FC<{ projects: Project[] }> = ({ projects }) => {
       }
       setProject(project)
       try {
-        await initializeAllStores()
+        await initializeAllStores(services.analyticsService)
         setInitialized(true)
       } catch (e) {
         setError(e)
       }
     })()
-  }, [])
+  }, [projectId])
 
   /** Show a message to user if they were redirected from a different project */
   useEffect(() => {
@@ -353,7 +354,6 @@ const ProjectRoute: React.FC<{ projects: Project[] }> = ({ projects }) => {
   useEffect(() => {
     if (initialized && !error && project?.id) {
       setLastUsedProjectId(project.id)
-      debugger
     }
   }, [error, initialized, project?.id])
 

--- a/configurator/frontend/main/src/App.tsx
+++ b/configurator/frontend/main/src/App.tsx
@@ -139,7 +139,7 @@ export const Application: React.FC = function () {
         setError(e)
       }
     })()
-  }, [])
+  }, [projectId])
 
   if (!error && !initialized) {
     return <Preloader />
@@ -320,9 +320,10 @@ const ProjectRoute: React.FC<{ projects: Project[] }> = ({ projects }) => {
     ;(async () => {
       let project = await initializeProject(projectId, projects)
       if (!project) {
-        if (projects.length === 0) services.userService.removeAuth(reloadPage)
-        window.sessionStorage.setItem("redirectedFromProjectId", projectId)
-        window.location.replace(window.location.href.replace(projectId, projects[0].id))
+        if (!projects || projects.length === 0) services.userService.removeAuth(reloadPage)
+        const lastUsedProject = getLastUsedProjectId(projects)
+        setProjectIdRedirectedFrom(projectId)
+        window.location.replace(window.location.href.replace(projectId, lastUsedProject))
         return
       }
       setProject(project)
@@ -335,8 +336,9 @@ const ProjectRoute: React.FC<{ projects: Project[] }> = ({ projects }) => {
     })()
   }, [])
 
+  /** Show a message to user if they were redirected from a different project */
   useEffect(() => {
-    const redirectedFromProjectId = window.sessionStorage.getItem("redirectedFromProjectId")
+    const redirectedFromProjectId = getProjectIdRedirectedFrom()
     if (redirectedFromProjectId && project?.name) {
       window.sessionStorage.removeItem("redirectedFromProjectId")
       actionNotification.warn(
@@ -345,7 +347,15 @@ const ProjectRoute: React.FC<{ projects: Project[] }> = ({ projects }) => {
         </>
       )
     }
-  }, [project?.name])
+  }, [])
+
+  /** Saves the last successfully initialized project to local storage */
+  useEffect(() => {
+    if (initialized && !error && project?.id) {
+      setLastUsedProjectId(project.id)
+      debugger
+    }
+  }, [error, initialized, project?.id])
 
   if (!error && !initialized) {
     return <Preloader text="Loading project data..." />
@@ -389,8 +399,39 @@ const ProjectRoute: React.FC<{ projects: Project[] }> = ({ projects }) => {
 
 const ProjectRedirect: React.FC<{ projects: Project[] }> = ({ projects }) => {
   const location = useLocation()
+  const lastUsedProject = getLastUsedProjectId(projects)
   if (!projects?.length) {
     return <ErrorCard title="Invalid state" description="projects.length should be greater than zero" />
   }
-  return <Redirect to={`/prj-${projects[0].id}${location.pathname}`} />
+  return <Redirect to={`/prj-${lastUsedProject ?? projects[0].id}${location.pathname}`} />
+}
+
+/**
+ * Finds the last successfully initialized project id.
+ * First, checks the session storage, then checks the local storage - this makes it more stable
+ * in cross-tabs user workflows.
+ */
+function getLastUsedProjectId(projects: Project[]): string {
+  const [lastUsedProjectIdInCurrentTab, lastUsedProjectIdGlobally] = [window.sessionStorage, window.localStorage].map(
+    storage => storage.getItem("JITSU_LAST_USED_PROJECT")
+  )
+  if (lastUsedProjectIdInCurrentTab && projects.find(prj => prj.id === lastUsedProjectIdInCurrentTab)) {
+    return lastUsedProjectIdInCurrentTab
+  }
+  if (lastUsedProjectIdGlobally && projects.find(prj => prj.id === lastUsedProjectIdGlobally)) {
+    return lastUsedProjectIdGlobally
+  }
+  return projects?.[0]?.id ?? null
+}
+
+function setLastUsedProjectId(id: string): void {
+  ;[window.sessionStorage, window.localStorage].forEach(storage => storage.setItem("JITSU_LAST_USED_PROJECT", id))
+}
+
+function getProjectIdRedirectedFrom(): string | null | undefined {
+  return window.sessionStorage.getItem("redirectedFromProjectId")
+}
+
+function setProjectIdRedirectedFrom(id: string): void {
+  window.sessionStorage.setItem("redirectedFromProjectId", id)
 }

--- a/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeyEditor.tsx
+++ b/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeyEditor.tsx
@@ -209,13 +209,13 @@ const ApiKeyEditorComponent: React.FC = props => {
                   try {
                     setSaving(true)
                     const connectedDestinations: string[] = form.getFieldsValue().connectedDestinations || []
-                    const key = getKey(form.getFieldsValue(), initialApiKey)
+                    let savedKey: ApiKey = getKey(form.getFieldsValue(), initialApiKey)
                     if (id) {
-                      await flowResult(apiKeysStore.replace({ ...key, uid: id }))
+                      await flowResult(apiKeysStore.replace({ ...savedKey, uid: id }))
                     } else {
-                      await flowResult(apiKeysStore.add(key))
+                      savedKey = await flowResult(apiKeysStore.add(savedKey))
                     }
-                    await connectionsHelper.updateDestinationsConnectionsToApiKey(key.uid, connectedDestinations)
+                    await connectionsHelper.updateDestinationsConnectionsToApiKey(savedKey.uid, connectedDestinations)
                     history.push(projectRoute(apiKeysRoutes.listExact))
                   } finally {
                     setSaving(false)

--- a/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeys.tsx
+++ b/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeys.tsx
@@ -20,6 +20,7 @@ import { default as JitsuClientLibraryCard, jitsuClientLibraries } from "../Jits
 import { Code } from "../Code/Code"
 import { ApiKeyCard } from "./ApiKeyCard"
 import { Link } from "react-router-dom"
+import ProjectLink from "../ProjectLink/ProjectLink"
 
 /**
  * What's displayed as loading?
@@ -63,11 +64,11 @@ const ApiKeysComponent: React.FC = () => {
           !
         </div>
         <div className="flex-shrink">
-          <Link to={"/api-keys/new"}>
+          <ProjectLink to={"/api-keys/new"}>
             <Button type="primary" size="large" icon={<PlusOutlined />} loading={"NEW" === loading}>
               Generate New Key
             </Button>
-          </Link>
+          </ProjectLink>
         </div>
       </div>
 

--- a/configurator/frontend/main/src/lib/components/EntityCard/EntityCard.tsx
+++ b/configurator/frontend/main/src/lib/components/EntityCard/EntityCard.tsx
@@ -1,6 +1,7 @@
 import { Card } from "antd"
 import React from "react"
 import { Link } from "react-router-dom"
+import ProjectLink from "../ProjectLink/ProjectLink"
 import styles from "./EntityCard.module.less"
 
 type EntityCardProps = {
@@ -26,9 +27,9 @@ const EntityCardTitle: React.FC = ({ children }) => {
 
 const EntityCardLink: React.FC<EntityCardProps & { link?: string }> = ({ link, ...entityCardProps }) => {
   return link ? (
-    <Link to={link} className="w-full">
+    <ProjectLink to={link} className="w-full">
       <EntityCard {...entityCardProps} />
-    </Link>
+    </ProjectLink>
   ) : (
     <EntityCard {...entityCardProps} />
   )

--- a/configurator/frontend/main/src/stores/_initializeAllStores.ts
+++ b/configurator/frontend/main/src/stores/_initializeAllStores.ts
@@ -1,10 +1,12 @@
 import { flowResult } from "mobx"
 import { apiKeysStore } from "./apiKeys"
 import { destinationsStore } from "./destinations"
+import { connectionsHelper } from "./helpers"
 import { sourcesStore } from "./sources"
 
 export const initializeAllStores = async (): Promise<void> => {
   await initalizeStoresData()
+  await connectionsHelper.healConnections()
 }
 
 const initalizeStoresData = (): Promise<

--- a/configurator/frontend/main/src/stores/_initializeAllStores.ts
+++ b/configurator/frontend/main/src/stores/_initializeAllStores.ts
@@ -1,12 +1,17 @@
+import AnalyticsService from "lib/services/analytics"
 import { flowResult } from "mobx"
 import { apiKeysStore } from "./apiKeys"
 import { destinationsStore } from "./destinations"
 import { connectionsHelper } from "./helpers"
 import { sourcesStore } from "./sources"
 
-export const initializeAllStores = async (): Promise<void> => {
+export const initializeAllStores = async (analyticsService: AnalyticsService): Promise<void> => {
   await initalizeStoresData()
-  await connectionsHelper.healConnections()
+  try {
+    await connectionsHelper.healConnections()
+  } catch (error) {
+    analyticsService.onGlobalError(new Error(`Failed to heal connections after stores initialization: ${error}`))
+  }
 }
 
 const initalizeStoresData = (): Promise<

--- a/configurator/frontend/main/src/stores/apiKeys.ts
+++ b/configurator/frontend/main/src/stores/apiKeys.ts
@@ -16,7 +16,7 @@ export class ApiKeysStore extends EntitiesStore<ApiKey> {
     })
   }
 
-  public *add(key?: Partial<ApiKey>) {
+  public *add(key?: Partial<ApiKey>): Generator<any, ApiKey, ApiKey> {
     this.resetError()
     this.setStatus(EntitiesStoreStatus.BACKGROUND_LOADING)
     const newApiKey: ApiKey = { ...this.generateApiKey(key.comment), ...(key ?? {}) }
@@ -26,6 +26,7 @@ export class ApiKeysStore extends EntitiesStore<ApiKey> {
         throw new Error(`API keys store failed to add a new key: ${newApiKey}`)
       }
       this._entities.push(addedApiKey)
+      return addedApiKey
     } finally {
       this.setStatus(EntitiesStoreStatus.IDLE)
     }

--- a/configurator/frontend/main/src/stores/entitiesStore.ts
+++ b/configurator/frontend/main/src/stores/entitiesStore.ts
@@ -51,6 +51,7 @@ const services = ApplicationServices.get()
  * }
  **/
 export class EntitiesStore<T extends EntityData> {
+  protected _initialized: boolean = false
   protected _state: { status: EntitiesStoreStatus; errorMessage: string } = observable({
     status: IDLE,
     errorMessage: "",
@@ -115,6 +116,10 @@ export class EntitiesStore<T extends EntityData> {
     return this._state.status
   }
 
+  public get isInitialized(): boolean {
+    return this._initialized
+  }
+
   public get errorMessage() {
     return this._state.errorMessage
   }
@@ -130,6 +135,7 @@ export class EntitiesStore<T extends EntityData> {
     try {
       const entities = yield services.storageService.table<T>(this.type).getAll()
       this._entities = entities ?? []
+      this._initialized = true
     } catch (error) {
       this.setError(`Failed to fetch ${this.type}: ${error.message || error}`)
     } finally {

--- a/configurator/frontend/main/src/stores/entitiesStore.ts
+++ b/configurator/frontend/main/src/stores/entitiesStore.ts
@@ -137,7 +137,7 @@ export class EntitiesStore<T extends EntityData> {
     }
   }
 
-  public *add(entityToAdd: T) {
+  public *add(entityToAdd: T): Generator<any, T | null, T | null> {
     this.resetError()
     this.setStatus(BACKGROUND_LOADING)
     try {
@@ -146,6 +146,7 @@ export class EntitiesStore<T extends EntityData> {
         throw new Error(`Error: '${this.type}' store failed to add an entity ${entityToAdd}`)
       }
       this._entities.push(addedEntity)
+      return addedEntity
     } finally {
       this.setStatus(IDLE)
     }

--- a/configurator/frontend/main/src/stores/helpers.ts
+++ b/configurator/frontend/main/src/stores/helpers.ts
@@ -57,6 +57,10 @@ class ConnectionsHelper {
    * to connections management errors in UI
    */
   public async healConnections() {
+    if ([this.sourcesStore, this.destinationsStore, this.apiKeysStore].some(store => !store.isInitialized)) {
+      return
+    }
+
     const destinations = this.destinationsStore.listIncludeHidden
     const sources = this.sourcesStore.listIncludeHidden
     const apiKeys = this.apiKeysStore.listIncludeHidden

--- a/configurator/frontend/main/src/stores/helpers.ts
+++ b/configurator/frontend/main/src/stores/helpers.ts
@@ -82,11 +82,11 @@ class ConnectionsHelper {
       })
     })
 
-    // await Promise.all([
-    //   ...nonExistentApiKeys.map(nonExistentKey => this.unconnectDeletedApiKey(nonExistentKey)),
-    //   ...nonExistentSources.map(nonExistentSrc => this.unconnectDeletedSource(nonExistentSrc)),
-    //   ...nonExistentDestinations.map(nonExistentKey => this.unconnectDeletedDestination(nonExistentKey)),
-    // ])
+    await Promise.all([
+      ...nonExistentApiKeys.map(nonExistentKey => this.unconnectDeletedApiKey(nonExistentKey)),
+      ...nonExistentSources.map(nonExistentSrc => this.unconnectDeletedSource(nonExistentSrc)),
+      ...nonExistentDestinations.map(nonExistentKey => this.unconnectDeletedDestination(nonExistentKey)),
+    ])
   }
 
   /**

--- a/configurator/frontend/main/src/stores/helpers.ts
+++ b/configurator/frontend/main/src/stores/helpers.ts
@@ -82,11 +82,11 @@ class ConnectionsHelper {
       })
     })
 
-    await Promise.all([
-      ...nonExistentApiKeys.map(nonExistentKey => this.unconnectDeletedApiKey(nonExistentKey)),
-      ...nonExistentSources.map(nonExistentSrc => this.unconnectDeletedSource(nonExistentSrc)),
-      ...nonExistentDestinations.map(nonExistentKey => this.unconnectDeletedDestination(nonExistentKey)),
-    ])
+    // await Promise.all([
+    //   ...nonExistentApiKeys.map(nonExistentKey => this.unconnectDeletedApiKey(nonExistentKey)),
+    //   ...nonExistentSources.map(nonExistentSrc => this.unconnectDeletedSource(nonExistentSrc)),
+    //   ...nonExistentDestinations.map(nonExistentKey => this.unconnectDeletedDestination(nonExistentKey)),
+    // ])
   }
 
   /**

--- a/configurator/frontend/main/src/stores/helpers.ts
+++ b/configurator/frontend/main/src/stores/helpers.ts
@@ -1,16 +1,31 @@
-import { sourcesStore, SourcesStore } from "stores/sources"
-import { destinationsStore, DestinationsStore } from "stores/destinations"
 import { without } from "lodash"
 import { EntitiesStore, EntityData } from "stores/entitiesStore"
+import { ApiKeysStore, apiKeysStore } from "stores/apiKeys"
+import { sourcesStore, SourcesStore } from "stores/sources"
+import { destinationsStore, DestinationsStore } from "stores/destinations"
 import { flowResult } from "mobx"
 
 class ConnectionsHelper {
   private readonly sourcesStore: SourcesStore
   private readonly destinationsStore: DestinationsStore
+  private readonly apiKeysStore: ApiKeysStore
 
-  constructor(stores: { sources: SourcesStore; destinations: DestinationsStore }) {
+  constructor(stores: { sources: SourcesStore; destinations: DestinationsStore; apiKeysStore: ApiKeysStore }) {
     this.sourcesStore = stores.sources
     this.destinationsStore = stores.destinations
+    this.apiKeysStore = stores.apiKeysStore
+  }
+
+  public async unconnectDeletedApiKey(apiKeyId: string) {
+    await this.updateDestinationsConnectionsToApiKey(apiKeyId, [])
+  }
+
+  public async unconnectDeletedSource(sourceId: string) {
+    await this.updateDestinationsConnectionsToSource(sourceId, [])
+  }
+
+  public async unconnectDeletedDestination(destinationId: string) {
+    await this.updateSourcesConnectionsToDestination(destinationId, [])
   }
 
   public async updateSourcesConnectionsToDestination(destinationId: string, connectedSourcesIds: string[]) {
@@ -37,18 +52,67 @@ class ConnectionsHelper {
     })
   }
 
-  public unconnectDeletedApiKey(apiKeyId: string) {
-    this.updateDestinationsConnectionsToApiKey(apiKeyId, [])
+  /**
+   * Finds and unconnects non-existent entities that may exist due
+   * to connections management errors in UI
+   */
+  public async healConnections() {
+    const destinations = this.destinationsStore.listIncludeHidden
+    const sources = this.sourcesStore.listIncludeHidden
+    const apiKeys = this.apiKeysStore.listIncludeHidden
+
+    const nonExistentApiKeys: string[] = []
+    const nonExistentSources: string[] = []
+    const existingApiKeys = apiKeys.map(key => key.uid)
+    const existingSources = sources.map(src => src.sourceId)
+    destinations.forEach(destination => {
+      destination._onlyKeys?.forEach(key => {
+        if (!existingApiKeys.includes(key)) nonExistentApiKeys.push(key)
+      })
+      destination._sources?.forEach(src => {
+        if (!existingSources.includes(src)) nonExistentSources.push(src)
+      })
+    })
+
+    const nonExistentDestinations: string[] = []
+    const existingDestinations = destinations.map(key => key._uid)
+    sources.forEach(source => {
+      source.destinations.forEach(dst => {
+        if (!existingDestinations.includes(dst)) nonExistentDestinations.push(dst)
+      })
+    })
+
+    await Promise.all([
+      ...nonExistentApiKeys.map(nonExistentKey => this.unconnectDeletedApiKey(nonExistentKey)),
+      ...nonExistentSources.map(nonExistentSrc => this.unconnectDeletedSource(nonExistentSrc)),
+      ...nonExistentDestinations.map(nonExistentKey => this.unconnectDeletedDestination(nonExistentKey)),
+    ])
   }
 
-  public unconnectDeletedSource(sourceId: string) {
-    this.updateDestinationsConnectionsToSource(sourceId, [])
-  }
-
-  public unconnectDeletedDestination(destinationId: string) {
-    this.updateSourcesConnectionsToDestination(destinationId, [])
-  }
-
+  /**
+   * Updates entities specified in `connectedEntitiesIds` by an entity to the other entities in the list (if not already connected) or disconnects
+   * this entity from all entities that are not in the list (if there are ones that connected)
+   * @param entityId - entity that will be connected to the every entity in the following list
+   * @param connectedEntitiesIds - list of entities that will be connected to the entity specified as the first parameter
+   * @param connectedEntitiesSchema - schema of the entities in the list
+   *
+   * @example
+   *
+   * // will disconnect all connected destinations from source with `sourceId`
+   * await this.updateEntitiesConnections(sourceId, [], {
+   *   store: this.destinationsStore,
+   *   idField: "_uid",
+   *   connectedEntitiesIdsField: "_sources",
+   * })
+   *
+   * // will connect source with id `sourceId` to all destination with `connectedDestinationsIds` and will de
+   * // will disconnect all non-listed destinations in `connectedDestinationsIds` from source with `sourceId`
+   * await this.updateEntitiesConnections(sourceId, connectedDestinationsIds, {
+   *   store: this.destinationsStore,
+   *   idField: "_uid",
+   *   connectedEntitiesIdsField: "_sources",
+   * })
+   */
   private async updateEntitiesConnections<T extends EntityData>(
     entityId: string,
     connectedEntitiesIds: string[],
@@ -80,4 +144,8 @@ class ConnectionsHelper {
   }
 }
 
-export const connectionsHelper = new ConnectionsHelper({ sources: sourcesStore, destinations: destinationsStore })
+export const connectionsHelper = new ConnectionsHelper({
+  sources: sourcesStore,
+  destinations: destinationsStore,
+  apiKeysStore: apiKeysStore,
+})

--- a/configurator/frontend/main/src/ui/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/configurator/frontend/main/src/ui/components/Breadcrumbs/Breadcrumbs.tsx
@@ -50,7 +50,7 @@ const BreadcrumbsComponent: React.FC<{}> = () => {
         </>
       )}
       {join(
-        currentPageHeaderStore.getBreadcrumbs().map((element, index) => (
+        currentPageHeaderStore.breadcrumbs.map((element, index) => (
           <div className={`${element.link && "hover:bg-bgSecondary"} px-3 py-1 rounded-lg`} key={`element-${index}`}>
             {element.link ? (
               element.absolute || element.link.indexOf("/prj-") >= 0 ? (

--- a/configurator/frontend/main/src/ui/pages/ConnectionsPage/ConnectionsPage.tsx
+++ b/configurator/frontend/main/src/ui/pages/ConnectionsPage/ConnectionsPage.tsx
@@ -1,6 +1,7 @@
 // @Libs
 import { Badge, Button, Dropdown, Empty, Typography } from "antd"
 import React, { useCallback, useEffect, useRef } from "react"
+import { useHistory } from "react-router-dom"
 import { observer } from "mobx-react-lite"
 import LeaderLine from "leader-line-new"
 // @Store
@@ -11,20 +12,19 @@ import { destinationsStore } from "stores/destinations"
 import { EntityCard } from "lib/components/EntityCard/EntityCard"
 import { EntityIcon } from "lib/components/EntityIcon/EntityIcon"
 import { DropDownList } from "ui/components/DropDownList/DropDownList"
+// @Hooks
+import { useServices } from "hooks/useServices"
 // @Icons
 import { PlusOutlined } from "@ant-design/icons"
 // @Utils
-import { useHistory } from "react-router-dom"
+import { APIKeyUtil } from "utils/apiKeys.utils"
+import { DestinationsUtils } from "utils/destinations.utils"
+import { SourcesUtils } from "utils/sources.utils"
+import { projectRoute } from "lib/components/ProjectLink/ProjectLink"
 // @Reference
-import { destinationsReferenceList } from "@jitsu/catalog/destinations/lib"
 import { destinationPageRoutes } from "../DestinationsPage/DestinationsPage.routes"
 // @Styles
 import styles from "./ConnectionsPage.module.less"
-import { useServices } from "hooks/useServices"
-import { APIKeyUtil } from "../../../utils/apiKeys.utils"
-import { DestinationsUtils } from "../../../utils/destinations.utils"
-import { SourcesUtils } from "../../../utils/sources.utils"
-import { projectRoute } from "../../../lib/components/ProjectLink/ProjectLink"
 
 const CONNECTION_LINE_SIZE = 3
 const CONNECTION_LINE_COLOR = "#415969"
@@ -210,12 +210,12 @@ const AddSourceDropdownOverlay: React.FC = () => {
         {
           id: "api_key",
           title: "Add JS Events API Key",
-          link: "/api-keys/new",
+          link: projectRoute("/api-keys/new"),
         },
         {
           id: "connectors",
           title: "Add Connector Source",
-          link: "/sources/add",
+          link: projectRoute("/sources/add"),
         },
       ]}
     />

--- a/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationEditor/DestinationEditor.tsx
+++ b/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationEditor/DestinationEditor.tsx
@@ -338,22 +338,27 @@ const DestinationEditor = ({
         try {
           await destinationEditorUtils.testConnection(destinationData.current, true)
 
-          if (editorMode === "add") await flowResult(destinationsStore.add(destinationData.current))
-          if (editorMode === "edit") await flowResult(destinationsStore.replace(destinationData.current))
+          let savedDestinationData: DestinationData = destinationData.current
+          if (editorMode === "add") {
+            savedDestinationData = await flowResult(destinationsStore.add(destinationData.current))
+          }
+          if (editorMode === "edit") {
+            await flowResult(destinationsStore.replace(destinationData.current))
+          }
           await connectionsHelper.updateSourcesConnectionsToDestination(
-            destinationData.current._uid,
-            destinationData.current._sources || []
+            savedDestinationData._uid,
+            savedDestinationData._sources || []
           )
 
           destinationsTabs.forEach((tab: Tab) => (tab.touched = false))
 
-          if (destinationData.current._connectionTestOk) {
-            if (editorMode === "add") actionNotification.success(`New ${destinationData.current._type} has been added!`)
-            if (editorMode === "edit") actionNotification.success(`${destinationData.current._type} has been saved!`)
+          if (savedDestinationData._connectionTestOk) {
+            if (editorMode === "add") actionNotification.success(`New ${savedDestinationData._type} has been added!`)
+            if (editorMode === "edit") actionNotification.success(`${savedDestinationData._type} has been saved!`)
           } else {
             actionNotification.warn(
-              `${destinationData.current._type} has been saved, but test has failed with '${firstToLower(
-                destinationData.current._connectionErrorMessage
+              `${savedDestinationData._type} has been saved, but test has failed with '${firstToLower(
+                savedDestinationData._connectionErrorMessage
               )}'. Data will not be piped to this destination`
             )
           }

--- a/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationStatistics/DestinationStatistics.tsx
+++ b/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationStatistics/DestinationStatistics.tsx
@@ -68,7 +68,7 @@ export const DestinationStatistics: React.FC<CommonDestinationPageProps> = () =>
   const history = useHistory()
   const services = useServices()
   const params = useParams<StatisticsPageParams>()
-  const destination = destinationsStore.get(params.id)
+  const destination = destinationsStore.list.find(d => d._id === params.id)
   const destinationUid = destination?._uid
   const destinationReference = destinationsStore.getDestinationReferenceById(params.id)
   const statisticsService = useMemo<IStatisticsService>(

--- a/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorView.tsx
+++ b/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorView.tsx
@@ -123,6 +123,7 @@ export const SourceEditorView: React.FC<SourceEditorViewProps> = ({
         />
       ) : (
         <SourceEditorViewTabs
+          sourceId={initialSourceData.sourceId}
           tabs={forms}
           tabsDisabled={tabsDisabled}
           sourceDataFromCatalog={sourceDataFromCatalog}

--- a/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorViewTabs.tsx
+++ b/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorViewTabs.tsx
@@ -24,6 +24,7 @@ type Tab = {
 }
 
 type SourceEditorViewTabsProps = {
+  sourceId: string
   tabs: Tab[]
   tabsDisabled: SourceEditorDisabledTabs
   sourceDataFromCatalog: SourceConnector
@@ -35,6 +36,7 @@ type SourceEditorViewTabsProps = {
 }
 
 export const SourceEditorViewTabs: React.FC<SourceEditorViewTabsProps> = ({
+  sourceId,
   tabs,
   tabsDisabled,
   sourceDataFromCatalog,
@@ -116,6 +118,7 @@ export const SourceEditorViewTabs: React.FC<SourceEditorViewTabsProps> = ({
         activeKey={currentTab}
         tabBarExtraContent={
           <TabsExtra
+            sourceId={sourceId}
             sourceDataFromCatalog={sourceDataFromCatalog}
             setShowDocumentationDrawer={setShowDocumentationDrawer}
           />
@@ -161,14 +164,15 @@ export const SourceEditorViewTabs: React.FC<SourceEditorViewTabsProps> = ({
 }
 
 const TabsExtra: React.FC<{
+  sourceId: string
   sourceDataFromCatalog: SourceConnector
   setShowDocumentationDrawer: (value: boolean) => void
-}> = ({ sourceDataFromCatalog, setShowDocumentationDrawer }) => {
+}> = ({ sourceId, sourceDataFromCatalog, setShowDocumentationDrawer }) => {
   return (
     <span className="uppercase">
       <NavLink
         to={projectRoute(sourcesPageRoutes.logs, {
-          sourceId: sourceDataFromCatalog.id ?? "not_found",
+          sourceId: sourceId ?? "not_found",
         })}
       >
         View Logs


### PR DESCRIPTION
- fixed occasional `[MobX] Dynamic observable objects cannot be frozen` error
- fixed some nav links on connections and source editor pages
- enabled UI to restore the last successfully initialised project id from local storage (useful for old or broken links where `prj-*` is missing)
- added `healConnections()` that removes non-existing entities from connections of another entities (might occur due to connections management errors in UI and lack of checks in the objects API