### PR TITLE
Hotfixes UI (#870)

### DIFF
--- a/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeyEditor.tsx
+++ b/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeyEditor.tsx
@@ -209,13 +209,13 @@ const ApiKeyEditorComponent: React.FC = props => {
                   try {
                     setSaving(true)
                     const connectedDestinations: string[] = form.getFieldsValue().connectedDestinations || []
-                    const key = getKey(form.getFieldsValue(), initialApiKey)
+                    let savedKey: ApiKey = getKey(form.getFieldsValue(), initialApiKey)
                     if (id) {
-                      await flowResult(apiKeysStore.replace({ ...key, uid: id }))
+                      await flowResult(apiKeysStore.replace({ ...savedKey, uid: id }))
                     } else {
-                      await flowResult(apiKeysStore.add(key))
+                      savedKey = await flowResult(apiKeysStore.add(savedKey))
                     }
-                    await connectionsHelper.updateDestinationsConnectionsToApiKey(key.uid, connectedDestinations)
+                    await connectionsHelper.updateDestinationsConnectionsToApiKey(savedKey.uid, connectedDestinations)
                     history.push(projectRoute(apiKeysRoutes.listExact))
                   } finally {
                     setSaving(false)

--- a/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeys.tsx
+++ b/configurator/frontend/main/src/lib/components/ApiKeys/ApiKeys.tsx
@@ -20,6 +20,7 @@ import { default as JitsuClientLibraryCard, jitsuClientLibraries } from "../Jits
 import { Code } from "../Code/Code"
 import { ApiKeyCard } from "./ApiKeyCard"
 import { Link } from "react-router-dom"
+import ProjectLink from "../ProjectLink/ProjectLink"
 
 /**
  * What's displayed as loading?
@@ -63,11 +64,11 @@ const ApiKeysComponent: React.FC = () => {
           !
         </div>
         <div className="flex-shrink">
-          <Link to={"/api-keys/new"}>
+          <ProjectLink to={"/api-keys/new"}>
             <Button type="primary" size="large" icon={<PlusOutlined />} loading={"NEW" === loading}>
               Generate New Key
             </Button>
-          </Link>
+          </ProjectLink>
         </div>
       </div>
 

--- a/configurator/frontend/main/src/lib/components/EntityCard/EntityCard.tsx
+++ b/configurator/frontend/main/src/lib/components/EntityCard/EntityCard.tsx
@@ -1,6 +1,7 @@
 import { Card } from "antd"
 import React from "react"
 import { Link } from "react-router-dom"
+import ProjectLink from "../ProjectLink/ProjectLink"
 import styles from "./EntityCard.module.less"
 
 type EntityCardProps = {
@@ -26,9 +27,9 @@ const EntityCardTitle: React.FC = ({ children }) => {
 
 const EntityCardLink: React.FC<EntityCardProps & { link?: string }> = ({ link, ...entityCardProps }) => {
   return link ? (
-    <Link to={link} className="w-full">
+    <ProjectLink to={link} className="w-full">
       <EntityCard {...entityCardProps} />
-    </Link>
+    </ProjectLink>
   ) : (
     <EntityCard {...entityCardProps} />
   )

--- a/configurator/frontend/main/src/stores/_initializeAllStores.ts
+++ b/configurator/frontend/main/src/stores/_initializeAllStores.ts
@@ -1,10 +1,17 @@
+import AnalyticsService from "lib/services/analytics"
 import { flowResult } from "mobx"
 import { apiKeysStore } from "./apiKeys"
 import { destinationsStore } from "./destinations"
+import { connectionsHelper } from "./helpers"
 import { sourcesStore } from "./sources"
 
-export const initializeAllStores = async (): Promise<void> => {
+export const initializeAllStores = async (analyticsService: AnalyticsService): Promise<void> => {
   await initalizeStoresData()
+  try {
+    await connectionsHelper.healConnections()
+  } catch (error) {
+    analyticsService.onGlobalError(new Error(`Failed to heal connections after stores initialization: ${error}`))
+  }
 }
 
 const initalizeStoresData = (): Promise<

--- a/configurator/frontend/main/src/stores/apiKeys.ts
+++ b/configurator/frontend/main/src/stores/apiKeys.ts
@@ -16,7 +16,7 @@ export class ApiKeysStore extends EntitiesStore<ApiKey> {
     })
   }
 
-  public *add(key?: Partial<ApiKey>) {
+  public *add(key?: Partial<ApiKey>): Generator<any, ApiKey, ApiKey> {
     this.resetError()
     this.setStatus(EntitiesStoreStatus.BACKGROUND_LOADING)
     const newApiKey: ApiKey = { ...this.generateApiKey(key.comment), ...(key ?? {}) }
@@ -26,6 +26,7 @@ export class ApiKeysStore extends EntitiesStore<ApiKey> {
         throw new Error(`API keys store failed to add a new key: ${newApiKey}`)
       }
       this._entities.push(addedApiKey)
+      return addedApiKey
     } finally {
       this.setStatus(EntitiesStoreStatus.IDLE)
     }

--- a/configurator/frontend/main/src/ui/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/configurator/frontend/main/src/ui/components/Breadcrumbs/Breadcrumbs.tsx
@@ -50,7 +50,7 @@ const BreadcrumbsComponent: React.FC<{}> = () => {
         </>
       )}
       {join(
-        currentPageHeaderStore.getBreadcrumbs().map((element, index) => (
+        currentPageHeaderStore.breadcrumbs.map((element, index) => (
           <div className={`${element.link && "hover:bg-bgSecondary"} px-3 py-1 rounded-lg`} key={`element-${index}`}>
             {element.link ? (
               element.absolute || element.link.indexOf("/prj-") >= 0 ? (

--- a/configurator/frontend/main/src/ui/pages/ConnectionsPage/ConnectionsPage.tsx
+++ b/configurator/frontend/main/src/ui/pages/ConnectionsPage/ConnectionsPage.tsx
@@ -1,6 +1,7 @@
 // @Libs
 import { Badge, Button, Dropdown, Empty, Typography } from "antd"
 import React, { useCallback, useEffect, useRef } from "react"
+import { useHistory } from "react-router-dom"
 import { observer } from "mobx-react-lite"
 import LeaderLine from "leader-line-new"
 // @Store
@@ -11,20 +12,19 @@ import { destinationsStore } from "stores/destinations"
 import { EntityCard } from "lib/components/EntityCard/EntityCard"
 import { EntityIcon } from "lib/components/EntityIcon/EntityIcon"
 import { DropDownList } from "ui/components/DropDownList/DropDownList"
+// @Hooks
+import { useServices } from "hooks/useServices"
 // @Icons
 import { PlusOutlined } from "@ant-design/icons"
 // @Utils
-import { useHistory } from "react-router-dom"
+import { APIKeyUtil } from "utils/apiKeys.utils"
+import { DestinationsUtils } from "utils/destinations.utils"
+import { SourcesUtils } from "utils/sources.utils"
+import { projectRoute } from "lib/components/ProjectLink/ProjectLink"
 // @Reference
-import { destinationsReferenceList } from "@jitsu/catalog/destinations/lib"
 import { destinationPageRoutes } from "../DestinationsPage/DestinationsPage.routes"
 // @Styles
 import styles from "./ConnectionsPage.module.less"
-import { useServices } from "hooks/useServices"
-import { APIKeyUtil } from "../../../utils/apiKeys.utils"
-import { DestinationsUtils } from "../../../utils/destinations.utils"
-import { SourcesUtils } from "../../../utils/sources.utils"
-import { projectRoute } from "../../../lib/components/ProjectLink/ProjectLink"
 
 const CONNECTION_LINE_SIZE = 3
 const CONNECTION_LINE_COLOR = "#415969"
@@ -210,12 +210,12 @@ const AddSourceDropdownOverlay: React.FC = () => {
         {
           id: "api_key",
           title: "Add JS Events API Key",
-          link: "/api-keys/new",
+          link: projectRoute("/api-keys/new"),
         },
         {
           id: "connectors",
           title: "Add Connector Source",
-          link: "/sources/add",
+          link: projectRoute("/sources/add"),
         },
       ]}
     />

--- a/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationEditor/DestinationEditor.tsx
+++ b/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationEditor/DestinationEditor.tsx
@@ -338,22 +338,27 @@ const DestinationEditor = ({
         try {
           await destinationEditorUtils.testConnection(destinationData.current, true)
 
-          if (editorMode === "add") await flowResult(destinationsStore.add(destinationData.current))
-          if (editorMode === "edit") await flowResult(destinationsStore.replace(destinationData.current))
+          let savedDestinationData: DestinationData = destinationData.current
+          if (editorMode === "add") {
+            savedDestinationData = await flowResult(destinationsStore.add(destinationData.current))
+          }
+          if (editorMode === "edit") {
+            await flowResult(destinationsStore.replace(destinationData.current))
+          }
           await connectionsHelper.updateSourcesConnectionsToDestination(
-            destinationData.current._uid,
-            destinationData.current._sources || []
+            savedDestinationData._uid,
+            savedDestinationData._sources || []
           )
 
           destinationsTabs.forEach((tab: Tab) => (tab.touched = false))
 
-          if (destinationData.current._connectionTestOk) {
-            if (editorMode === "add") actionNotification.success(`New ${destinationData.current._type} has been added!`)
-            if (editorMode === "edit") actionNotification.success(`${destinationData.current._type} has been saved!`)
+          if (savedDestinationData._connectionTestOk) {
+            if (editorMode === "add") actionNotification.success(`New ${savedDestinationData._type} has been added!`)
+            if (editorMode === "edit") actionNotification.success(`${savedDestinationData._type} has been saved!`)
           } else {
             actionNotification.warn(
-              `${destinationData.current._type} has been saved, but test has failed with '${firstToLower(
-                destinationData.current._connectionErrorMessage
+              `${savedDestinationData._type} has been saved, but test has failed with '${firstToLower(
+                savedDestinationData._connectionErrorMessage
               )}'. Data will not be piped to this destination`
             )
           }

--- a/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationStatistics/DestinationStatistics.tsx
+++ b/configurator/frontend/main/src/ui/pages/DestinationsPage/partials/DestinationStatistics/DestinationStatistics.tsx
@@ -68,7 +68,7 @@ export const DestinationStatistics: React.FC<CommonDestinationPageProps> = () =>
   const history = useHistory()
   const services = useServices()
   const params = useParams<StatisticsPageParams>()
-  const destination = destinationsStore.get(params.id)
+  const destination = destinationsStore.list.find(d => d._id === params.id)
   const destinationUid = destination?._uid
   const destinationReference = destinationsStore.getDestinationReferenceById(params.id)
   const statisticsService = useMemo<IStatisticsService>(

--- a/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorView.tsx
+++ b/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorView.tsx
@@ -123,6 +123,7 @@ export const SourceEditorView: React.FC<SourceEditorViewProps> = ({
         />
       ) : (
         <SourceEditorViewTabs
+          sourceId={initialSourceData.sourceId}
           tabs={forms}
           tabsDisabled={tabsDisabled}
           sourceDataFromCatalog={sourceDataFromCatalog}

--- a/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorViewTabs.tsx
+++ b/configurator/frontend/main/src/ui/pages/SourcesPage/partials/SourceEditor/SourceEditor/SourceEditorViewTabs.tsx
@@ -24,6 +24,7 @@ type Tab = {
 }
 
 type SourceEditorViewTabsProps = {
+  sourceId: string
   tabs: Tab[]
   tabsDisabled: SourceEditorDisabledTabs
   sourceDataFromCatalog: SourceConnector
@@ -35,6 +36,7 @@ type SourceEditorViewTabsProps = {
 }
 
 export const SourceEditorViewTabs: React.FC<SourceEditorViewTabsProps> = ({
+  sourceId,
   tabs,
   tabsDisabled,
   sourceDataFromCatalog,
@@ -116,6 +118,7 @@ export const SourceEditorViewTabs: React.FC<SourceEditorViewTabsProps> = ({
         activeKey={currentTab}
         tabBarExtraContent={
           <TabsExtra
+            sourceId={sourceId}
             sourceDataFromCatalog={sourceDataFromCatalog}
             setShowDocumentationDrawer={setShowDocumentationDrawer}
           />
@@ -161,14 +164,15 @@ export const SourceEditorViewTabs: React.FC<SourceEditorViewTabsProps> = ({
 }
 
 const TabsExtra: React.FC<{
+  sourceId: string
   sourceDataFromCatalog: SourceConnector
   setShowDocumentationDrawer: (value: boolean) => void
-}> = ({ sourceDataFromCatalog, setShowDocumentationDrawer }) => {
+}> = ({ sourceId, sourceDataFromCatalog, setShowDocumentationDrawer }) => {
   return (
     <span className="uppercase">
       <NavLink
         to={projectRoute(sourcesPageRoutes.logs, {
-          sourceId: sourceDataFromCatalog.id ?? "not_found",
+          sourceId: sourceId ?? "not_found",
         })}
       >
         View Logs


### PR DESCRIPTION
* fixed occasional `[MobX] Dynamic observable objects cannot be frozen` error

* fixes some nav links on connections and source editor pages

* fixed prominent inconsistency of ids of connected entities

  On adding a new entity, the UI generates a temporary UID for it.
  The API then returns the added entity with a (possibly) different UID.
  If the entity to be connected to other entities, the UI in some cases
  used UI-generated UIDs instead of API-generated ones. So far, those,
  UIDs were the same but this might change in the future leading to storing
  non-existent (ui-generated) UIDs to the arrays of connected entities.
  
  The fix changed the behaviour of UI so that it always uses API-generated
  UIDs.

* adds healConnections() that helps keep connections consistent

  healConnections() finds and unconnects non-existent entities that
  may exist due to connections management errors in UI

* enables UI to remember the last used project

  UI restores the last successfully initialized project id from either
  the session storage or the local storage - this makes it more stable
  in cross-tabs user workflows.

* adds project re-initialization on project id change in URL

* fixes the DestinationStatistics page

* makes healConnections() a bit more safe