### PR TITLE
Fix incorrect path for importing sdk-js module

### DIFF
--- a/javascript-sdk/package.json
+++ b/javascript-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.5",
   "description": "Jitsu JavaScript SDK (more at http://jitsu.com/docs/js-sdk)",
   "main": "dist/npm/jitsu.cjs.js",
-  "module": "dist/npm/dist/jitsu.es.js",
+  "module": "dist/npm/jitsu.es.js",
   "types": "dist/npm/jitsu.d.ts",
   "files": [
     "dist/npm/*",


### PR DESCRIPTION
The NPM module does not currently allow `import "@jitsu/sdk-js"` due to the incorrect path. This fixes it.