### PR TITLE
Update auth0.go to a more genereic version.

### DIFF
--- a/configurator/backend/authorization/auth0.go
+++ b/configurator/backend/authorization/auth0.go
@@ -37,7 +37,14 @@ func NewAuth0(ssoConfig *SSOConfig) (*Auth0, error) {
 	)
 
 	if err != nil {
-		return nil, err
+		provider, err = oidc.NewProvider(
+			context.Background(),
+			"https://"+ssoConfig.Domain,
+		)
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	conf := oauth2.Config{


### PR DESCRIPTION
With this little simple change, we will be able to implements others OICD providers and not only auth0.