### PR TITLE
fix: handle error responses from bulker in log endpoint

### DIFF
--- a/webapps/console/pages/api/[workspaceId]/log/[type]/[actorId].ts
+++ b/webapps/console/pages/api/[workspaceId]/log/[type]/[actorId].ts
@@ -62,6 +62,9 @@ export const api: Api = {
           }`,
           options
         );
+        if (!response.ok) {
+          throw new Error(`${response.status} ${response.statusText}`);
+        }
         const json = await response.json();
         return json;
       } catch (e) {


### PR DESCRIPTION
Without this the API returns a 200 containing the error from the Bulker (including the token used for authentication if it's rejected by the Bulker), and an authentication failure between the console and Bulker results in a somewhat cryptic error from https://github.com/jitsucom/jitsu/blob/fb73e5921cfdaf94e487e9cbf7978279b614360d/webapps/console/components/DataView/EventsBrowser.tsx#L974 (evs.map is not a function).