### PR TITLE
build: copy build output to the correct paths

### DIFF
--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -30,8 +30,8 @@ RUN npm -g install prisma@$(cat webapps/console/package.json | jq -r '.dependenc
 COPY --from=builder /app/docker-start-console.sh ./
 COPY --from=builder /app/webapps/console/prisma/schema.prisma ./
 COPY --from=builder /app/webapps/console/.next/standalone ./
-COPY --from=builder /app/webapps/console/.next/static /app/webapps/console/.next/standalone/webapps/console/.next/static
-COPY --from=builder /app/webapps/console/public /app/webapps/console/.next/standalone/webapps/console/public
+COPY --from=builder /app/webapps/console/.next/static ./webapps/console/.next/static
+COPY --from=builder /app/webapps/console/public ./webapps/console/public
 
 
 EXPOSE 3000


### PR DESCRIPTION
Using `console.Dockerfile` as it was resulted in a blank page and lots of 404s. Updated paths are the same as in `all.Dockerfile`:
https://github.com/jitsucom/jitsu/blob/fb73e5921cfdaf94e487e9cbf7978279b614360d/all.Dockerfile#L38-L39