### PR TITLE
refactor: switch plugin export to named export

### DIFF
--- a/libs/jitsu-js/src/analytics-plugin.ts
+++ b/libs/jitsu-js/src/analytics-plugin.ts
@@ -660,7 +660,7 @@ async function send(
 export type JitsuPluginConfig = JitsuOptions & {
   storageWrapper?: (persistentStorage: PersistentStorage) => PersistentStorage;
 };
-const jitsuAnalyticsPlugin = (pluginConfig: JitsuPluginConfig = {}): AnalyticsPlugin => {
+export const jitsuAnalyticsPlugin = (pluginConfig: JitsuPluginConfig = {}): AnalyticsPlugin => {
   const instanceConfig = {
     ...defaultConfig,
     ...pluginConfig,
@@ -775,5 +775,3 @@ function hash(str: string, seed: number = 0): number {
 
   return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 }
-
-export default jitsuAnalyticsPlugin;

--- a/libs/jitsu-js/src/index.ts
+++ b/libs/jitsu-js/src/index.ts
@@ -1,6 +1,6 @@
 import Analytics from "analytics";
 import { AnalyticsInterface, JitsuOptions, PersistentStorage, RuntimeFacade } from "./jitsu";
-import jitsuAnalyticsPlugin, { emptyRuntime, isInBrowser, windowRuntime } from "./analytics-plugin";
+import { jitsuAnalyticsPlugin, emptyRuntime, isInBrowser, windowRuntime } from "./analytics-plugin";
 import { Callback, DispatchedEvent, ID, JSONObject, Options } from "@jitsu/protocols/analytics";
 
 export default function parse(input) {


### PR DESCRIPTION
Using `export * from 'xyz'` only exports named exports and does not export default exports. This is mentioned here https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export#:~:text=This%20re%2Dexports%20all%20named%20exports%20from%20mod%20as%20the%20named%20exports%20of%20the%20current%20module%2C%20but%20the%20default%20export%20of%20mod%20is%20not%20re%2Dexported

This change moves the export of `jitsuAnalyticsPlugin` to a named export, which is then caught by the re-export in `index.ts`