### PR TITLE
posthog-destination: support $screen_name for screen events

### DIFF
--- a/libs/core-functions/src/functions/posthog-destination.ts
+++ b/libs/core-functions/src/functions/posthog-destination.ts
@@ -40,6 +40,7 @@ function getEventProperties(event: AnalyticsServerEvent) {
     $current_url: event.context?.page?.url,
     $host: event.context?.page?.host || getHostFromUrl(event.context?.page?.url),
     $pathname: event.context?.page?.path || getPathFromUrl(event.context?.page?.url),
+    $screen_name: event.type === 'screen' ? event.name : undefined,
 
     $browser: browser?.name,
     $device: browser?.deviceType,


### PR DESCRIPTION
Currently, the `$screen_name` property isn't being passed properly to posthog on `screen` events. You can see that being done in [posthog's native integration here](https://github.com/PostHog/posthog-js-lite/blob/main/posthog-react-native/src/posthog-rn.ts#L155)