### PR TITLE
Allow overriding properties url and path for page events

### DIFF
--- a/libs/jitsu-js/src/analytics-plugin.ts
+++ b/libs/jitsu-js/src/analytics-plugin.ts
@@ -416,8 +416,9 @@ function adjustPayload(
   const properties = payload.properties || {};
 
   if (payload.type === "page" && url) {
-    properties.url = url.replace(hashRegex, "");
-    properties.path = fixPath(urlPath(url));
+    const targetUrl = properties.url || url;
+    properties.url = targetUrl.replace(hashRegex, "");
+    properties.path = fixPath(urlPath(targetUrl));
   }
 
   const customContext = payload.properties?.context || {};


### PR DESCRIPTION
I was a bit surprised that we weren't able to set overrides for page url and path as per analytics.js documentation at https://getanalytics.io/api/#analyticspage.

This is a suggestion to pull a page `url` from provided properties first.

We have a situation where pixels running within shopify sandbox iframes report events with weird urls and paths so we need to manually override the page url and path, e.g. example.com/wpm@453iu6h3u456ho3hu3i45h/custom/web-pixel-4564563@33/sandbox/modern/pages/our-story when it should be just example.com/pages/our-story

see related shopify docs https://help.shopify.com/en/manual/promoting-marketing/pixels/custom-pixels/gtm-tutorial#Cleaner%20page%20URLs