### PR TITLE
feat: remove write key from payload event when sending it to segment

### DIFF
--- a/libs/core-functions/src/functions/segment-destination.ts
+++ b/libs/core-functions/src/functions/segment-destination.ts
@@ -25,9 +25,12 @@ const SegmentDestination: JitsuFunction<AnalyticsServerEvent, SegmentCredentials
   if (apiBase.charAt(apiBase.length - 1) === "/") {
     apiBase = apiBase.substring(0, apiBase.length - 1);
   }
+
+  const eventWithoutWriteKey = { ...event, writeKey: null };
+
   let httpRequest: HttpRequest = {
     url: `${apiBase}/${event.type}`,
-    payload: event,
+    payload: eventWithoutWriteKey,
     method: "POST",
     headers: {
       "Content-type": "application/json",


### PR DESCRIPTION
This pull request includes a change to the `SegmentDestination` function in `libs/core-functions/src/functions/segment-destination.ts`. The change ensures that the `writeKey` is removed from the event payload before sending the HTTP request.

* [`libs/core-functions/src/functions/segment-destination.ts`](diffhunk://#diff-8e301b7294aff2c1a565657a32d05a1fce7c7c10c2508dba509d63c6bba4ddc1R28-R33): Added a new constant `eventWithoutWriteKey` to create a copy of the event with the `writeKey` set to `null` and updated the `httpRequest` payload to use this new constant.

### Why?

We are moving away from Segment API and using jitsu to send our events on our website, but we had to create a function to remove the write key that jitsu tries to send to segment, because it's unnecessary and does not work without the function.

Function:
![image](https://github.com/user-attachments/assets/3cd34e45-8695-4199-aba1-4e197a85e9c6)

Example of what happens if we don't use that function:
![image](https://github.com/user-attachments/assets/5edda84c-cff0-419f-8f76-45ed88a52eac)
![image](https://github.com/user-attachments/assets/e472c062-b6d8-4228-885c-5c28cc129041)

```
  "status":400
  "statusText":"Bad Request"
  "elapsedMs":273
  "response": {
    "success":false
    "message":"An invalid write key was provided"
    "code":"invalid_request"
  }
```