### PR TITLE
Introducing Jitsu Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <b><a href="https://jitsu.com">Learn more »</a></b> 
 </p>
 <p align="center">
-<a href="https://jitsu.com/slack">Slack</a> · <a href="https://jitsu.com/">Website</a> · <a href="https://docs.jitsu.com">Docs</a> · <a href="https://github.com/jitsucom/jitsu/blob/newjitsu/LICENSE">MIT License</a> · <b><a href="https://docs.jitsu.com/self-hosting">Self-hosting</a></b>
+<a href="https://jitsu.com/slack">Slack</a> · <a href="https://jitsu.com/">Website</a> · <a href="https://docs.jitsu.com">Docs</a> · <a href="https://gurubase.io/g/jitsu">Ask Jitsu Guru</a> · <a href="https://github.com/jitsucom/jitsu/blob/newjitsu/LICENSE">MIT License</a> · <b><a href="https://docs.jitsu.com/self-hosting">Self-hosting</a></b>
 </p>
 
 ---
@@ -26,7 +26,6 @@
   />
 </a>
 <a href="https://www.producthunt.com/posts/jitsu-2?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-jitsu&#0045;2" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=297526&theme=neutral" alt="Jitsu - Open&#0045;source&#0032;real&#0045;time&#0032;data&#0032;collection&#0032;platform | Product Hunt" style="width: 200px; height: 43px;" width="200" height="43" /></a>
-<a href="https://gurubase.io/g/jitsu"><img src="https://img.shields.io/badge/Gurubase-Ask%20Jitsu%20Guru-006BFF" alt="Gurubase" style="width: 200px; height: 43px;" width="200" height="43" /></a>
 </p>
 
 # What is Jitsu?

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   />
 </a>
 <a href="https://www.producthunt.com/posts/jitsu-2?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-jitsu&#0045;2" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=297526&theme=neutral" alt="Jitsu - Open&#0045;source&#0032;real&#0045;time&#0032;data&#0032;collection&#0032;platform | Product Hunt" style="width: 200px; height: 43px;" width="200" height="43" /></a>
+<a href="https://gurubase.io/g/jitsu"><img src="https://img.shields.io/badge/Gurubase-Ask%20Jitsu%20Guru-006BFF" alt="Gurubase" style="width: 200px; height: 43px;" width="200" height="43" /></a>
 </p>
 
 # What is Jitsu?


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Jitsu Guru](https://gurubase.io/g/jitsu) to Gurubase. Jitsu Guru uses the data from this repo and data from the [docs](https://docs.jitsu.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "Jitsu Guru", which highlights that Jitsu now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Jitsu Guru in Gurubase, just let me know that's totally fine.
