### PR TITLE
feat: make entity select searchable in events browser

### DIFF
--- a/webapps/console/components/DataView/EventsBrowser.tsx
+++ b/webapps/console/components/DataView/EventsBrowser.tsx
@@ -29,6 +29,7 @@ import { ConnectionTitle, ProfileBuilderTitle } from "../../pages/[workspaceId]/
 import { StreamTitle } from "../../pages/[workspaceId]/streams";
 import { trimMiddle } from "../../lib/shared/strings";
 import { countries } from "../../lib/shared/countries";
+import type { RefSelectProps } from "antd/es/select";
 
 import zlib from "zlib";
 import {
@@ -246,6 +247,14 @@ const EventsBrowser0 = ({
               destination={entity[1].destination}
             />
           ),
+        search: (entity[1].type === "stream"
+          ? [entity[1].name]
+          : entity[1].type === "profile-builder"
+          ? [entity[1].name, entity[1].destination?.name]
+          : [entity[1].stream?.name, entity[1].service?.name, entity[1].destination?.name]
+        )
+          .filter(s => s !== undefined)
+          .map(s => s.toLowerCase()),
       }));
     } else {
       return [];
@@ -283,6 +292,8 @@ const EventsBrowser0 = ({
   });
 
   const eventsLogApi = useEventsLogApi();
+
+  const entitySelectRef = React.createRef<RefSelectProps>();
 
   useEffect(() => {
     if (!actorId || !entitiesMap[actorId]) {
@@ -463,6 +474,7 @@ const EventsBrowser0 = ({
             <div>
               <span>{entityType == "stream" ? "Site: " : "Connection: "}</span>
               <Select
+                ref={entitySelectRef}
                 popupMatchSelectWidth={false}
                 notFoundContent={
                   entityType === "stream" ? (
@@ -491,6 +503,9 @@ const EventsBrowser0 = ({
                 }}
                 value={actorId}
                 options={entitiesSelectOptions}
+                showSearch={true}
+                filterOption={(input, option) => option?.search.some(s => s.includes(input.toLowerCase())) || false}
+                onDropdownVisibleChange={o => !o && entitySelectRef.current?.blur()}
               />
             </div>
             <div>

--- a/webapps/console/styles/globals.css
+++ b/webapps/console/styles/globals.css
@@ -41,6 +41,11 @@ body {
   width: 100vw;
   overflow-x: auto;
   overflow-y: auto;
+
+  .ant-select-single.ant-select-open .ant-select-selection-item {
+    opacity: 0.25;
+    color: inherit;
+  }
 }
 
 .debug-border {


### PR DESCRIPTION
- Added search to the entity select on the events browser page.
- Since select values can't be searched as they're elements, I added a search array to entitiesSelectOptions. 
- Used a ref to fix an issue where the input wouldn't blur when an already selected option was picked again. 
- Added CSS adjustment to fix opacity issues where child components were overriding the parent text color.


Ref #1147 