### PR TITLE
Allow context overrides through `options` argument

### DIFF
--- a/libs/jitsu-js/src/analytics-plugin.ts
+++ b/libs/jitsu-js/src/analytics-plugin.ts
@@ -424,7 +424,7 @@ function adjustPayload(
     properties.path = fixPath(urlPath(targetUrl));
   }
 
-  const customContext = payload.properties?.context || {};
+  const customContext = payload.properties?.context || payload.options?.context || {};
   delete payload.properties?.context;
   const referrer = runtime.referrer();
   const context: AnalyticsClientEvent["context"] = {


### PR DESCRIPTION
Similar to https://github.com/jitsucom/jitsu/pull/1135 but specifically for `context.page` overrides support on `identify` events. We want to make sure identify events sent from a Shopify sandbox pixel environment have the right url. e.g. `example.com/pages/our-story` instead of `example.com/wpm@453iu6h3u456ho3hu3i45h/custom/web-pixel-4564563@33/sandbox/modern/pages/our-story`.

I understand this is already possible by providing a `context` object within `properties` however `identify` events don't have a `payload.properties` set. So it could fallback to `payload .options` instead which is an argument available on `analytics.identify`.

See related code on analytics js: https://github.com/DavidWells/analytics/blob/505f0776845c07f1b15330e2c72db03c0bccbb99/packages/analytics-core/src/index.js#L350-L359

Segment analytics js has a similar approach where we can override `context` properties through the `options` argument:
https://github.com/segmentio/analytics-next/blob/5caf4d6211f54f317080b4ff3f03417095a2b369/packages/core/src/events/index.ts#L240-L241 and https://github.com/segmentio/analytics-next/blob/5caf4d6211f54f317080b4ff3f03417095a2b369/packages/core/src/events/interfaces.ts#L29-L33 