### PR TITLE
feat (@jitsu/js): Add support for tracking additional cookies via `cookieCapture` config

### DIFF
--- a/libs/jitsu-js/__tests__/playwright/cases/basic.html
+++ b/libs/jitsu-js/__tests__/playwright/cases/basic.html
@@ -7,6 +7,11 @@
 
     <title>Tracking page</title>
     <script>
+      window.jitsuConfig = {
+        cookieCapture: {
+          ttp: "_ttp",
+        }
+      };
       window.testOnload = async j => {
         j.identify("john-doe-id-1", { email: "john.doe@gmail.com" });
         j.track("pageLoaded", { trackParam: "trackValue" });

--- a/libs/jitsu-js/__tests__/playwright/integration.test.ts
+++ b/libs/jitsu-js/__tests__/playwright/integration.test.ts
@@ -453,6 +453,11 @@ test("disable-user-ids-then-consent", async ({ browser }) => {
 test("basic", async ({ browser }) => {
   clearRequestLog();
   const browserContext = await browser.newContext();
+  await browserContext.addCookies([
+    { name: "_fbc", value: "fbc-id", url: server.baseUrl },
+    { name: "_fbp", value: "fbp-id", url: server.baseUrl },
+    { name: "_ttp", value: "ttp-id", url: server.baseUrl },
+  ]);
 
   const { page: firstPage, uncaughtErrors: firstPageErrors } = await createLoggingPage(browserContext);
   const [pageResult] = await Promise.all([
@@ -498,6 +503,9 @@ test("basic", async ({ browser }) => {
   console.log(chalk.bold("📝 Checking track event"), JSON.stringify(track, null, 3));
   expect(track.properties.trackParam).toEqual("trackValue");
   expect(track.type).toEqual("track");
+  expect(track.context.clientIds).toHaveProperty("fbc", "fbc-id");
+  expect(track.context.clientIds).toHaveProperty("fbp", "fbp-id");
+  expect(track.context.clientIds).toHaveProperty("ttp", "ttp-id");
   expect(track.context.traits.email).toEqual("john.doe@gmail.com");
   expect(track.userId).toEqual("john-doe-id-1");
   expect(track.event).toEqual("pageLoaded");
@@ -509,6 +517,9 @@ test("basic", async ({ browser }) => {
 
   console.log(chalk.bold("📝 Checking page event"), JSON.stringify(page, null, 3));
   expect(page.anonymousId).toEqual(anonymousId);
+  expect(page.context.clientIds).toHaveProperty("fbc", "fbc-id");
+  expect(page.context.clientIds).toHaveProperty("fbp", "fbp-id");
+  expect(page.context.clientIds).toHaveProperty("ttp", "ttp-id");
   expect(page.context.traits.email).toEqual("john.doe@gmail.com");
   expect(page.userId).toEqual("john-doe-id-1");
 

--- a/types/protocols/analytics.d.ts
+++ b/types/protocols/analytics.d.ts
@@ -339,6 +339,14 @@ export type JitsuOptions = {
    */
   cookieDomain?: string;
   /**
+   * Additional cookies to capture, where the keys are cookie names and
+   * the values are the corresponding cookie values. By default, the following cookies are captured:
+   * - Facebook: `_fbc`, `_fbp`
+   * - Google Analytics 4: GA4 client ID
+   * This property allows you to capture additional cookies beyond the defaults.
+   */
+  cookieCapture?: Record<string, string>;
+  /**
    * Provide fetch implementation. It is required if you want to use Jitsu in NodeJS
    */
   fetch?: typeof fetch;


### PR DESCRIPTION
This PR introduces a new optional `cookieCapture` property to allow tracking of additional cookies beyond the default ones.

The following cookies were already being tracked by default before this change:
- Facebook: `_fbc`, `_fbp`
- Google Analytics 4: GA4 client ID.

The `cookieCapture` property allows to specify a custom list of cookies to track. It accepts a `Record<string, string>`, where the keys are cookie names and the values are their corresponding values.

Example usage:
```js
window.jitsuConfig = {
  cookieCapture: {
    ttp: "_ttp", // Custom cookie to capture
  }
};
```

Related discussion: https://github.com/jitsucom/jitsu/issues/1109#issuecomment-2181270368
