### PR TITLE
fix (@jitsu/js): Preserve anonymous ID as a string and avoid parsing

### DIFF
--- a/libs/jitsu-js/__tests__/playwright/cases/anonymous-id-bug.html
+++ b/libs/jitsu-js/__tests__/playwright/cases/anonymous-id-bug.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Tracking page</title>
+    <script>
+      window.testOnload = async j => {
+        j.track("pageLoaded");
+      };
+    </script>
+    <script
+      type="text/javascript"
+      src="<%=trackingBase%>/p.js"
+      data-onload="testOnload"
+      data-debug="true"
+      defer
+    ></script>
+  </head>
+
+  <body>
+    <h1>Test</h1>
+  </body>
+</html>

--- a/libs/jitsu-js/src/analytics-plugin.ts
+++ b/libs/jitsu-js/src/analytics-plugin.ts
@@ -240,6 +240,10 @@ const cookieStorage: StorageFactory = (cookieDomain, key2cookie) => {
     getItem(key: string) {
       const cookieName = key2cookie[key] || key;
       const result = getCookie(cookieName);
+      if (key === "__anon_id") {
+        //anonymous id must always be a string, so we don't parse it to preserve its exact value
+        return result;
+      }
       if (typeof result === "undefined" && key === "__user_id") {
         //backward compatibility with old jitsu cookie. get user id if from traits
         const traits = parse(getCookie("__eventn_id_usr")) || {};


### PR DESCRIPTION
This PR addresses an issue where the `__anon_id` cookie was being parsed, potentially altering its value. The `__anon_id` must always be returned as a string to preserve its exact value.

### Issue Example

Before the fix, parsing the cookie value `1724633695283.638279` with `JSON.parse()` would convert it to a JS number, which results in precision loss. In this case, the number would become `1724633695283.6382` due to the way JavaScript represents floating-point numbers.

After the fix, the `__anon_id` value is returned as a string without any change, preserving the exact value.
