### PR TITLE
feat (rotor): Add localized names for continents, countries, regions, and cities

### DIFF
--- a/libs/core-functions/src/functions/lib/udf_wrapper.ts
+++ b/libs/core-functions/src/functions/lib/udf_wrapper.ts
@@ -373,6 +373,7 @@ export async function UDFTestRun({
         },
         region: {
           code: "NY",
+          name: "New York",
         },
         location: {
           latitude: 40.6808,

--- a/types/protocols/analytics.d.ts
+++ b/types/protocols/analytics.d.ts
@@ -12,12 +12,19 @@ export type WithConfidence<T> = T & {
 export type Geo = {
   continent?: {
     code: "AF" | "AN" | "AS" | "EU" | "NA" | "OC" | "SA";
+    /**
+     * Localized name of the continent
+     */
+    name: string;
   };
   country?: {
     /**
      * Two-letter country code (ISO 3166-1 alpha-2): https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
      */
     code: string;
+    /**
+     * Localized name of the country
+     */
     name: string;
     isEU: boolean;
   };
@@ -27,8 +34,15 @@ export type Geo = {
      * For USA it's two-letter capitaluzed state code (such as NY)
      */
     code: string;
+    /**
+     * Localized name of the region
+     */
+    name: string;
   }>;
   city?: WithConfidence<{
+    /**
+     * Localized name of the city
+     */
     name: string;
   }>;
 


### PR DESCRIPTION
This PR introduces two key improvements to geographical data handling:
1. Previously, the `name` field existed for cities and countries but was missing for continents and regions. This PR adds the `name` field to continents and regions.
2. Implemented support for localizing geographical names based on locale. This can be configured via the optional `MAXMIND_LOCALE` environment variable. If not set, the default language remains English.

The list of available locales can be found here:
https://maxmind.github.io/GeoIP2-node/interfaces/Names.html
