### PR TITLE
feat (@jitsu/js): Add `defaultPayloadContext` to include default context in all requests

### DIFF
--- a/libs/jitsu-js/__tests__/node/nodejs.test.ts
+++ b/libs/jitsu-js/__tests__/node/nodejs.test.ts
@@ -214,6 +214,33 @@ describe("Test Jitsu NodeJS client", () => {
     expect((p.body.anonymousId ?? "").length).toBeGreaterThan(0);
   });
 
+  test("test defaultPayloadContext", async () => {
+    const config = {
+      host: server.baseUrl,
+      writeKey: "key:secret",
+      debug: true,
+      defaultPayloadContext: {
+        awesomeIdentifier: "awesome-identifier",
+        awesome: {
+          nestedKey: "awesome-key",
+        },
+      },
+    };
+    const client = jitsuAnalytics(config);
+    expect(requestLog.length).toBe(0);
+    await client.identify("myUserId", { email: "myUserId@example.com" });
+    await client.group("myGroupId", { name: "myGroupId" });
+    await client.track("myEvent", { prop1: "value1" });
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    expect(requestLog.length).toBe(3);
+    expect(requestLog[0].body.context.awesomeIdentifier).toBe("awesome-identifier");
+    expect(requestLog[0].body.context.awesome.nestedKey).toBe("awesome-key");
+    expect(requestLog[1].body.context.awesomeIdentifier).toBe("awesome-identifier");
+    expect(requestLog[1].body.context.awesome.nestedKey).toBe("awesome-key");
+    expect(requestLog[2].body.context.awesomeIdentifier).toBe("awesome-identifier");
+    expect(requestLog[2].body.context.awesome.nestedKey).toBe("awesome-key");
+  });
+
   test("node js", async () => {
     const jitsu: AnalyticsInterface = jitsuAnalytics({
       writeKey: "key:secret",

--- a/libs/jitsu-js/src/analytics-plugin.ts
+++ b/libs/jitsu-js/src/analytics-plugin.ts
@@ -39,6 +39,7 @@ const defaultConfig: Required<JitsuOptions> = {
   s2s: undefined,
   idEndpoint: undefined,
   errorPolicy: "log",
+  defaultPayloadContext: {},
   privacy: {
     dontSend: false,
     disableUserIds: false,
@@ -445,7 +446,10 @@ function adjustPayload(
     properties.path = fixPath(urlPath(targetUrl));
   }
 
-  const customContext = payload.properties?.context || payload.options?.context || {};
+  const customContext = deepMerge(
+    config.defaultPayloadContext,
+    payload.properties?.context || payload.options?.context || {}
+  );
   delete payload.properties?.context;
   const referrer = runtime.referrer();
   const context: AnalyticsClientEvent["context"] = {

--- a/types/protocols/analytics.d.ts
+++ b/types/protocols/analytics.d.ts
@@ -347,6 +347,15 @@ export type JitsuOptions = {
    */
   debug?: boolean;
   /**
+   * Default payload context to be included in all requests.
+   * These attributes are merged with the request-specific payload context,
+   * allowing common or global data (e.g., browser timezone, some extra user identifier)
+   * to be automatically included to every request.
+   *
+   * The context can be a nested structure.
+   */
+  defaultPayloadContext?: Record<string, JSONValue>;
+  /**
    * Explicitly specify cookie domain. If not set, cookie domain will be set to top level
    * of the current domain. Example: if JS lives on "app.example.com", cookie domain will be
    * set to ".example.com". If it lives on "example.com", cookie domain will be set to ".example.com" too


### PR DESCRIPTION
This PR introduces a new property `defaultPayloadContext` to the configuration. It allows default context data (e.g., browser timezone, some extra user identifier) to be automatically included in every request's payload.

### Example Usage

```js
window.jitsuConfig = {
  defaultPayloadContext: {
    browserTz: Intl.DateTimeFormat().resolvedOptions().timeZone,
    userIdentity: getUserIdentity(),
  }
}
```

The values of `browserTz` and `userIdentity` will now be included in the payload of every request, ensuring that the common context data is consistently available in all API calls, without needing to manually include them with each request.
