### PR TITLE
chore(@console|@profile): remove database credentials from logs

### DIFF
--- a/services/profiles/src/lib/db.ts
+++ b/services/profiles/src/lib/db.ts
@@ -197,7 +197,7 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${connectionUrl}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
+        `Connecting new database client. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
           (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html

--- a/webapps/console/lib/server/db.ts
+++ b/webapps/console/lib/server/db.ts
@@ -116,7 +116,7 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${connectionUrl}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
+        `Connecting new database client. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
           (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html


### PR DESCRIPTION
## Why

Currently, in the console app and profiles service database credentials were being exposed in logs when a new database client connection was established. This can lead to a secret leak which is undesirable.

## What

This change removes the connection URL from logs since having this information on the connection step does not add any value and in case of failure, the error already shows its cause.