### PR TITLE
Custom GA4 measurement protocol url

### DIFF
--- a/libs/core-functions/src/functions/ga4-destination.ts
+++ b/libs/core-functions/src/functions/ga4-destination.ts
@@ -347,9 +347,10 @@ const Ga4Destination: JitsuFunction<AnalyticsServerEvent, Ga4Credentials> = asyn
       ctx.log.info(`Ga4: no GA4 event is mapped for event type: ${event.type} ID: ${event.messageId}`);
       return;
     }
-    const debug = "";
-    //const debug = ctx.props.validationMode ? "/debug" : "";
-    const url = `https://www.google-analytics.com${debug}/mp/collect?${query}`;
+
+    const baseUrl = ctx.props.url ?? 'https://www.google-analytics.com/mp/collect';
+
+    const url = `${baseUrl}?${query}`;
 
     gaRequest = {
       ...idPart,

--- a/libs/core-functions/src/meta.ts
+++ b/libs/core-functions/src/meta.ts
@@ -304,8 +304,8 @@ export const Ga4Credentials = z.object({
       "The measurement ID associated with a stream.<br/><b>For Web:</b> found in the Google Analytics UI under: " +
         "<b>Admin > Data Streams > choose your stream > Measurement ID</b><br/><b>For Apps</b>: the Firebase App ID, found in the Firebase console under: <b>Project Settings > General > Your Apps > App ID</b>"
     ),
+  url: z.string().url().describe("Measurement Protocol URL.<br/>Default: <code>https://www.google-analytics.com/mp/collect</code><br/>Default debug url: <code>https://www.google-analytics.com/debug/mp/collect</code>").default('https://www.google-analytics.com/mp/collect'),
   events: z.string().optional().default("").describe(eventsParamDescription),
-  //validationMode: z.boolean().default(false).optional(),
 });
 export type Ga4Credentials = z.infer<typeof Ga4Credentials>;
 

--- a/webapps/console/lib/schema/destinations.tsx
+++ b/webapps/console/lib/schema/destinations.tsx
@@ -807,7 +807,7 @@ export const coreDestinations: DestinationType<any>[] = [
   {
     id: "ga4",
     icon: ga4Icon,
-    title: "Google Analytics 4",
+    title: "GA4 (Measurement Protocol)",
     tags: "Product Analytics",
     connectionOptions: CloudDestinationsConnectionOptions,
     credentials: meta.Ga4Credentials,


### PR DESCRIPTION
Added a possibility to set custom measurement protocol url. 
Critical for server side GTM users  https://developers.google.com/tag-platform/tag-manager/server-side/send-data
