### PR TITLE
chore(@console|@profile): remove database credentials from logs

### DIFF
--- a/libs/juava/src/security.ts
+++ b/libs/juava/src/security.ts
@@ -76,3 +76,13 @@ export function decrypt(secret: string, iv: string, value: string): string {
   const decrypted = Buffer.concat([decipher.update(Buffer.from(value, "hex")), decipher.final()]);
   return decrypted.toString();
 }
+
+export function hideSensitiveInfo(url: string) {
+  try {
+    const parsedUrl = new URL(url);
+    parsedUrl.password = "****";
+    return parsedUrl.toString();
+  } catch (e) {
+    return "***";
+  }
+}

--- a/services/profiles/src/lib/db.ts
+++ b/services/profiles/src/lib/db.ts
@@ -197,9 +197,9 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. ` +
-        `Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
-          (schema ? `. Default schema: ${schema}` : "")
+        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. Pool stat: idle=${pool.idleCount}, waiting=${
+          pool.waitingCount
+        }, total=${pool.totalCount}` + (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html
     //let's leave it commented for information purposes

--- a/services/profiles/src/lib/db.ts
+++ b/services/profiles/src/lib/db.ts
@@ -197,7 +197,8 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
+        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. ` +
+        `Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
           (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html

--- a/services/profiles/src/lib/db.ts
+++ b/services/profiles/src/lib/db.ts
@@ -1,6 +1,6 @@
 import { Pool, PoolClient } from "pg";
 import Cursor from "pg-cursor";
-import { getSingleton, namedParameters, newError, requireDefined, stopwatch, getLog } from "juava";
+import { getSingleton, namedParameters, newError, requireDefined, stopwatch, getLog, hideSensitiveInfo } from "juava";
 
 export type Handler = (row: Record<string, any>) => Promise<void> | void;
 
@@ -197,7 +197,7 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${connectionUrl}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
+        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
           (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html

--- a/webapps/console/lib/server/db.ts
+++ b/webapps/console/lib/server/db.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { Pool, PoolClient } from "pg";
 import Cursor from "pg-cursor";
-import { getSingleton, namedParameters, newError, requireDefined, stopwatch } from "juava";
+import { getSingleton, namedParameters, newError, requireDefined, stopwatch, hideSensitiveInfo } from "juava";
 import { getServerLog } from "./log";
 import { isReadOnly } from "./read-only-mode";
 import { isTruish } from "../shared/chores";
@@ -116,7 +116,7 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${connectionUrl}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
+        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
           (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html

--- a/webapps/console/lib/server/db.ts
+++ b/webapps/console/lib/server/db.ts
@@ -116,7 +116,8 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
+        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. ` +
+        `Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
           (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html

--- a/webapps/console/lib/server/db.ts
+++ b/webapps/console/lib/server/db.ts
@@ -116,9 +116,9 @@ export function createPg(): Pool {
     log
       .atInfo()
       .log(
-        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. ` +
-        `Pool stat: idle=${pool.idleCount}, waiting=${pool.waitingCount}, total=${pool.totalCount}` +
-          (schema ? `. Default schema: ${schema}` : "")
+        `Connecting new client ${hideSensitiveInfo(connectionUrl)}. Pool stat: idle=${pool.idleCount}, waiting=${
+          pool.waitingCount
+        }, total=${pool.totalCount}` + (schema ? `. Default schema: ${schema}` : "")
       );
     //this is commented on purpose, it won't work for pgbouncer in transaction mode https://www.pgbouncer.org/features.html
     //let's leave it commented for information purposes

--- a/webapps/ee-api/lib/store.ts
+++ b/webapps/ee-api/lib/store.ts
@@ -1,4 +1,4 @@
-import { assertDefined, getErrorMessage } from "juava";
+import { assertDefined, getErrorMessage, hideSensitiveInfo } from "juava";
 import * as PG from "pg";
 import { getServerLog } from "./log";
 
@@ -79,16 +79,6 @@ function maybeDeleteExpiredObjects(pgPool, table) {
     log.atInfo().log(`Deleting expired objects: ${query}`);
     //no need to wait. It can be executed in asynchronous manner
     pgPool.query(query);
-  }
-}
-
-function hideSensitiveInfo(url: string) {
-  try {
-    const parsedUrl = new URL(url);
-    parsedUrl.password = "****";
-    return parsedUrl.toString();
-  } catch (e) {
-    return "***";
   }
 }
 


### PR DESCRIPTION
(rework of #1160)

## Why
Currently, in the console app and profiles service database credentials were being exposed in logs when a new database client connection was established. This can lead to a secret leak which is undesirable.
 
## What
This change removes the connection URL from logs since having this information on the connection step does not add any value and in case of failure, the error already shows its cause.