### PR TITLE
chore(@console): remove risky console.logs

### DIFF
--- a/libs/core-functions/src/functions/ga4-destination.ts
+++ b/libs/core-functions/src/functions/ga4-destination.ts
@@ -348,7 +348,7 @@ const Ga4Destination: JitsuFunction<AnalyticsServerEvent, Ga4Credentials> = asyn
       return;
     }
 
-    const baseUrl = ctx.props.url ?? 'https://www.google-analytics.com/mp/collect';
+    const baseUrl = ctx.props.url ?? "https://www.google-analytics.com/mp/collect";
 
     const url = `${baseUrl}?${query}`;
 

--- a/libs/core-functions/src/meta.ts
+++ b/libs/core-functions/src/meta.ts
@@ -304,7 +304,13 @@ export const Ga4Credentials = z.object({
       "The measurement ID associated with a stream.<br/><b>For Web:</b> found in the Google Analytics UI under: " +
         "<b>Admin > Data Streams > choose your stream > Measurement ID</b><br/><b>For Apps</b>: the Firebase App ID, found in the Firebase console under: <b>Project Settings > General > Your Apps > App ID</b>"
     ),
-  url: z.string().url().describe("Measurement Protocol URL.<br/>Default: <code>https://www.google-analytics.com/mp/collect</code><br/>Default debug url: <code>https://www.google-analytics.com/debug/mp/collect</code>").default('https://www.google-analytics.com/mp/collect'),
+  url: z
+    .string()
+    .url()
+    .describe(
+      "Measurement Protocol URL.<br/>Default: <code>https://www.google-analytics.com/mp/collect</code><br/>Default debug url: <code>https://www.google-analytics.com/debug/mp/collect</code>"
+    )
+    .default("https://www.google-analytics.com/mp/collect"),
   events: z.string().optional().default("").describe(eventsParamDescription),
 });
 export type Ga4Credentials = z.infer<typeof Ga4Credentials>;

--- a/webapps/console/components/SignInOrUp/SignIn.tsx
+++ b/webapps/console/components/SignInOrUp/SignIn.tsx
@@ -117,7 +117,6 @@ export const SocialLogin: React.FC<{ onSocialLogin: (type: string) => Promise<vo
               await onSocialLogin("github.com");
               redirectIfNeeded(router);
             } catch (error: any) {
-              console.log(JSON.stringify(error, null, 2));
               setError(handleFirebaseError(error));
             } finally {
               setLoading(undefined);

--- a/webapps/console/lib/nextauth.config.ts
+++ b/webapps/console/lib/nextauth.config.ts
@@ -46,7 +46,6 @@ const credentialsProvider =
       if (!username) {
         throw new ApiError("Username is not defined");
       }
-      console.log(JSON.stringify(credentials, null, 2));
       const user = await db.prisma().userProfile.findFirst({ where: { email: username }, include: { password: true } });
       if (!user) {
         log.atDebug().log(`Attempt to login with unknown user: ${username}`);


### PR DESCRIPTION
Console's logs are exposing basic auth credentials when an admin logs in. Here's an example (values manually redacted by me):
![Screenshot 2025-01-17 at 10 59 48](https://github.com/user-attachments/assets/6f325b1c-1a31-4241-ad6d-d20917e8422f)

I believe the cause is the `console.log()` in `nextauth.config.ts`. I assume this is a leftover from a debug attempt, and since it doesn't seem to offer much value in Production, I think it's best to remove it outright.

I also spotted another potentially risky instance in the SignInOrUp component, so removing that as well.