### PR TITLE
posthog-destination: fix an issue with the tracking of anonymous users

### DIFF
--- a/libs/core-functions/src/functions/posthog-destination.ts
+++ b/libs/core-functions/src/functions/posthog-destination.ts
@@ -82,6 +82,9 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
   event,
   { props, fetch, log }
 ) => {
+  // compatibility with configs that were created before this separate setting was introduced
+  const sendAnonymousEvents =
+    typeof props.sendAnonymousEvents !== "undefined" ? props.sendAnonymousEvents : props.enableAnonymousUserProfiles;
   const groupType = props.groupType || "group";
   const client = new PostHog(props.key, { host: props.host || POSTHOG_DEFAULT_HOST, fetch: fetch });
   try {
@@ -96,8 +99,8 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
        * in Posthog, we should merge the anonymous person with the identified
        * one, so that the entire user event history is consolidated.
        */
-      const alias: string | undefined = event.anonymousId || event.traits?.email;
-      if (props.enableAnonymousUserProfiles && alias) {
+      const alias: string | undefined = event.anonymousId || (event.traits?.email as string);
+      if (sendAnonymousEvents && alias) {
         client.alias({
           distinctId: event.userId as string,
           alias: alias,
@@ -118,17 +121,19 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
       if (!distinctId) {
         log.info(`No distinct id found for event ${JSON.stringify(event)}`);
       } else {
-        client.capture({
-          distinctId: distinctId as string,
-          event: event.event || event.name || "Unknown Event",
-          timestamp: new Date(eventTimeSafeMs(event)),
-          properties: {
-            ...getEventProperties(event),
-            // https://posthog.com/docs/getting-started/person-properties
-            $process_person_profile: props.enableAnonymousUserProfiles || !!event.userId,
-          },
-          ...groups,
-        });
+        if (event.userId || sendAnonymousEvents) {
+          client.capture({
+            distinctId: distinctId as string,
+            event: event.event || event.name || "Unknown Event",
+            timestamp: new Date(eventTimeSafeMs(event)),
+            properties: {
+              ...getEventProperties(event),
+              // https://posthog.com/docs/getting-started/person-properties
+              $process_person_profile: props.enableAnonymousUserProfiles || !!event.userId,
+            },
+            ...groups,
+          });
+        }
       }
     } else if (event.type === "page" || event.type === "screen") {
       let groups = {};
@@ -141,17 +146,19 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
           `No distinct id found for ${event.type === "page" ? "Page View" : "Screen"} event ${JSON.stringify(event)}`
         );
       } else {
-        client.capture({
-          distinctId: distinctId as string,
-          event: event.type === "page" ? "$pageview" : "$screen",
-          timestamp: new Date(eventTimeSafeMs(event)),
-          properties: {
-            ...getEventProperties(event),
-            // https://posthog.com/docs/getting-started/person-properties
-            $process_person_profile: props.enableAnonymousUserProfiles || !!event.userId,
-          },
-          ...groups,
-        });
+        if (event.userId || sendAnonymousEvents) {
+          client.capture({
+            distinctId: distinctId as string,
+            event: event.type === "page" ? "$pageview" : "$screen",
+            timestamp: new Date(eventTimeSafeMs(event)),
+            properties: {
+              ...getEventProperties(event),
+              // https://posthog.com/docs/getting-started/person-properties
+              $process_person_profile: props.enableAnonymousUserProfiles || !!event.userId,
+            },
+            ...groups,
+          });
+        }
       }
     }
   } catch (e: any) {

--- a/libs/core-functions/src/functions/posthog-destination.ts
+++ b/libs/core-functions/src/functions/posthog-destination.ts
@@ -86,40 +86,23 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
   const client = new PostHog(props.key, { host: props.host || POSTHOG_DEFAULT_HOST, fetch: fetch });
   try {
     if (event.type === "identify") {
-      if (!event.userId) {
-        const distinctId = event.anonymousId || event.traits?.email;
-        if (!distinctId) {
-          log.info(`No distinct id found for event ${JSON.stringify(event)}`);
-        } else if (props.enableAnonymousUserProfiles) {
-          client.identify({
-            distinctId: distinctId as string,
-            properties: { $anon_distinct_id: event.anonymousId || undefined, ...event.traits },
-          });
-        }
-      } else {
-        if (props.enableAnonymousUserProfiles) {
-          if (event.anonymousId || event.traits?.email) {
-            client.alias({
-              distinctId: (event.anonymousId || event.traits?.email) as string,
-              alias: event.userId as string,
-            });
-          }
-        }
-        client.identify({
+      client.identify({
+        distinctId: event.userId as string,
+        properties: { $anon_distinct_id: event.anonymousId || undefined, ...event.traits },
+      });
+
+      /**
+       * If we've been tracking anonymous events under user/"Person" profiles
+       * in Posthog, we should merge the anonymous person with the identified
+       * one, so that the entire user event history is consolidated.
+       */
+      const alias: string | undefined = event.anonymousId || event.traits?.email;
+      if (props.enableAnonymousUserProfiles && alias) {
+        client.alias({
           distinctId: event.userId as string,
-          properties: { $anon_distinct_id: event.anonymousId || undefined, ...event.traits },
+          alias: alias,
         });
       }
-      // if (props.sendIdentifyEvents) {
-      //   const distinctId = event.userId || (event.traits?.email as string) || event.anonymousId;
-      //   // if (distinctId) {
-      //   //   client.capture({
-      //   //     distinctId: distinctId as string,
-      //   //     event: "Identify",
-      //   //     properties: getEventProperties(event),
-      //   //   });
-      //   // }
-      // }
     } else if (event.type === "group" && props.enableGroupAnalytics) {
       client.groupIdentify({
         groupType: groupType,
@@ -135,15 +118,17 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
       if (!distinctId) {
         log.info(`No distinct id found for event ${JSON.stringify(event)}`);
       } else {
-        if (event.userId || props.enableAnonymousUserProfiles) {
-          client.capture({
-            distinctId: distinctId as string,
-            event: event.event || event.name || "Unknown Event",
-            timestamp: new Date(eventTimeSafeMs(event)),
-            properties: getEventProperties(event),
-            ...groups,
-          });
-        }
+        client.capture({
+          distinctId: distinctId as string,
+          event: event.event || event.name || "Unknown Event",
+          timestamp: new Date(eventTimeSafeMs(event)),
+          properties: {
+            ...getEventProperties(event),
+            // https://posthog.com/docs/getting-started/person-properties
+            $process_person_profile: props.enableAnonymousUserProfiles || !!event.userId,
+          },
+          ...groups,
+        });
       }
     } else if (event.type === "page" || event.type === "screen") {
       let groups = {};
@@ -156,15 +141,17 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
           `No distinct id found for ${event.type === "page" ? "Page View" : "Screen"} event ${JSON.stringify(event)}`
         );
       } else {
-        if (event.userId || props.enableAnonymousUserProfiles) {
-          client.capture({
-            distinctId: distinctId as string,
-            event: event.type === "page" ? "$pageview" : "$screen",
-            timestamp: new Date(eventTimeSafeMs(event)),
-            properties: getEventProperties(event),
-            ...groups,
-          });
-        }
+        client.capture({
+          distinctId: distinctId as string,
+          event: event.type === "page" ? "$pageview" : "$screen",
+          timestamp: new Date(eventTimeSafeMs(event)),
+          properties: {
+            ...getEventProperties(event),
+            // https://posthog.com/docs/getting-started/person-properties
+            $process_person_profile: props.enableAnonymousUserProfiles || !!event.userId,
+          },
+          ...groups,
+        });
       }
     }
   } catch (e: any) {

--- a/libs/core-functions/src/meta.ts
+++ b/libs/core-functions/src/meta.ts
@@ -210,13 +210,33 @@ export const PosthogDestinationConfig = z.object({
     .describe(
       "Group type is the abstract type of whatever our group represents (e.g. company, team, chat, post, etc.). <a href='https://posthog.com/docs/getting-started/group-analytics#groups-vs-group-types' target='_blank' rel='noreferrer noopener'>Groups vs. group types.</a>"
     ),
+  sendAnonymousEvents: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Send events from anonymous users. If disabled, only events from identified users will be tracked."),
   enableAnonymousUserProfiles: z
     .boolean()
     .optional()
     .default(false)
-    .describe("If enabled, anonymous users will be tracked in Posthog"),
-  //  sendIdentifyEvents: z.boolean().optional().default(false),
+    .describe(
+      "Enable Anonymous Person Profiles::Create <a href='https://posthog.com/docs/getting-started/person-properties' target='_blank' rel='noreferrer noopener'>Person profiles</a> for anonymous users. If disabled, only identified users will have profiles."
+    ),
 });
+
+export const PosthogDestinationConfigUi: Partial<
+  Record<keyof PosthogDestinationConfig, { correction?: any; hidden?: any }>
+> = {
+  sendAnonymousEvents: {
+    // assumes value of this freshly added property from the value of the `enableAnonymousUserProfiles` property
+    correction: obj =>
+      typeof obj?.sendAnonymousEvents === "undefined" ? obj?.enableAnonymousUserProfiles : obj?.sendAnonymousEvents,
+  },
+  enableAnonymousUserProfiles: {
+    hidden: obj =>
+      typeof obj?.sendAnonymousEvents === "undefined" ? !obj.enableAnonymousUserProfiles : !obj.sendAnonymousEvents,
+  },
+};
 
 export type PosthogDestinationConfig = z.infer<typeof PosthogDestinationConfig>;
 

--- a/webapps/console/lib/schema/destinations.tsx
+++ b/webapps/console/lib/schema/destinations.tsx
@@ -827,6 +827,7 @@ export const coreDestinations: DestinationType<any>[] = [
     tags: "Product Analytics",
     connectionOptions: CloudDestinationsConnectionOptions,
     credentials: meta.PosthogDestinationConfig,
+    credentialsUi: meta.PosthogDestinationConfigUi,
     description:
       "Posthog is an open-source product analytics tool. Jitsu supports both self-hosted Posthog and Posthog Cloud.",
   },


### PR DESCRIPTION
Currently, it seems to us that there are a few issues with the tracking of anonymous users. First I want to specify that the term "anonymous" is overloaded here. There are 3 categories of events, and I'll specify some terms I'll refer to them by to keep them straight:

1. `Anonymous/Unidentified` - Events that occur before a user has identified themselves, which should have some sort of `anonymousId` associated with them. Importantly, we do intend to merge these events into an identified user/"Person" at some point.
2. `Identified` - Events that occur after a user has identified themselves.
3. `Anonymous/Anonymous` - Posthog "anonymous" events which are intended never to have identifiable information associated with them. Importantly, these events should never be merged into a "Person" record.

## When `Enable Anonymous User Profiles` Is Enabled

When this setting is enabled, over multiple sessions where the user starts as `Anonymous/Unidentified` and then becomes `Identified`, currently, you'll end up with duplicate "person" records in Posthog for that user. While there is an alias event that connects the two of them together, they don't get merged into a single record as they should properly be. Therefore, overtime you accumulate a large set of distinct "Person" records in Posthog all containing the `Anonymous/Unidentified` event history of a user prior to identification, with aliases back to the true identity with the actual `Identified` events.

By [default, all Posthog events are associated with a person profile](https://posthog.com/docs/getting-started/person-properties). Therefore, `identify` should not be called for a `Anonymous/Unidentified` user, but rather only called for the actual `Identified` user and then immediately aliased to the `Anonymous/Unidentified` users' previous `distinctId`. This merges all the users' data (both `Anonymous/Unidentified` & `Identified`) into a single record. 

## When `Enable Anonymous User Profiles` Is Disabled

If you disable this setting, no events are sent to posthog at all, whereas what I would expect would happen is to [have `Anonymous/Anonymous` events sent to Posthog](https://posthog.com/docs/data/anonymous-vs-identified-events).