### PR TITLE
rotor: Enhance Redis support

### DIFF
--- a/libs/core-functions/src/functions/lib/store.ts
+++ b/libs/core-functions/src/functions/lib/store.ts
@@ -29,32 +29,81 @@ function getTtlSec(opts?: SetOpts): number {
   return Math.min(seconds, maxAllowedTTL);
 }
 
-export const createTtlStore = (namespace: string, redisClient: Redis): TTLStore => ({
+function success(namespace: string, operation: "get" | "set" | "del" | "ttl", metrics?: RotorMetrics) {
+  if (metrics) {
+    metrics.storeStatus(namespace, operation, "success");
+  }
+}
+
+function storeErr(
+  namespace: string,
+  operation: "get" | "set" | "del" | "ttl",
+  err: any,
+  text: string,
+  metrics?: RotorMetrics
+) {
+  log.atError().log(`${text}: ${err.message}`);
+  if (metrics) {
+    metrics.storeStatus(namespace, operation, "error");
+  }
+  if ((err.message ?? "").includes("timed out")) {
+    return new RetryError(text + ": Timed out.");
+  }
+  return new RetryError(text + ": " + err.message);
+}
+
+export const createRedisStore = (namespace: string, redisClient: Redis, metrics?: RotorMetrics): TTLStore => ({
   get: async (key: string) => {
-    const res = await redisClient.get(`store:${namespace}:${key}`);
-    return res ? JSON.parse(res) : undefined;
+    try {
+      const res = await redisClient.get(`store:${namespace}:${key}`);
+      success(namespace, "get", metrics);
+      return res ? JSON.parse(res) : undefined;
+    } catch (err: any) {
+      throw storeErr(namespace, "get", err, `Error getting key ${key} from redis store ${namespace}`);
+    }
   },
   getWithTTL: async (key: string) => {
-    const res = await redisClient.get(`store:${namespace}:${key}`);
-    if (!res) {
-      return undefined;
+    try {
+      const res = await redisClient.get(`store:${namespace}:${key}`);
+      if (!res) {
+        return undefined;
+      }
+      const ttl = await redisClient.ttl(`store:${namespace}:${key}`);
+      success(namespace, "get", metrics);
+      return { value: JSON.parse(res), ttl };
+    } catch (err: any) {
+      throw storeErr(namespace, "get", err, `Error getting key ${key} from redis store ${namespace}`);
     }
-    const ttl = await redisClient.ttl(`store:${namespace}:${key}`);
-    return { value: JSON.parse(res), ttl };
   },
   set: async (key: string, obj: any, opts?: SetOpts) => {
-    const ttl = getTtlSec(opts);
-    if (ttl >= 0) {
-      await redisClient.set(`store:${namespace}:${key}`, JSON.stringify(obj), "EX", ttl);
-    } else {
-      await redisClient.set(`store:${namespace}:${key}`, JSON.stringify(obj));
+    try {
+      const ttl = getTtlSec(opts);
+      if (ttl >= 0) {
+        await redisClient.set(`store:${namespace}:${key}`, JSON.stringify(obj), "EX", ttl);
+      } else {
+        await redisClient.set(`store:${namespace}:${key}`, JSON.stringify(obj));
+      }
+      success(namespace, "set", metrics);
+    } catch (err: any) {
+      throw storeErr(namespace, "set", err, `Error setting key ${key} from redis store ${namespace}`);
     }
   },
   del: async (key: string) => {
-    await redisClient.del(`store:${namespace}:${key}`);
+    try {
+      await redisClient.del(`store:${namespace}:${key}`);
+      success(namespace, "del", metrics);
+    } catch (err: any) {
+      throw storeErr(namespace, "del", err, `Error deleting key ${key} from redis store ${namespace}`);
+    }
   },
   ttl: async (key: string) => {
-    return await redisClient.ttl(`store:${namespace}:${key}`);
+    try {
+      const res = await redisClient.ttl(`store:${namespace}:${key}`);
+      success(namespace, "ttl", metrics);
+      return res;
+    } catch (err: any) {
+      throw storeErr(namespace, "ttl", err, `Error getting key ${key} from redis store ${namespace}`);
+    }
   },
 });
 
@@ -115,32 +164,15 @@ export const createMongoStore = (
     }
   }
 
-  function storeErr(operation: "get" | "set" | "del" | "ttl", err: any, text: string, metrics?: RotorMetrics) {
-    log.atError().log(`${text}: ${err.message}`);
-    if (metrics) {
-      metrics.storeStatus(namespace, operation, "error");
-    }
-    if ((err.message ?? "").includes("timed out")) {
-      return new RetryError(text + ": Timed out.");
-    }
-    return new RetryError(text + ": " + err.message);
-  }
-
-  function success(operation: "get" | "set" | "del" | "ttl", metrics?: RotorMetrics) {
-    if (metrics) {
-      metrics.storeStatus(namespace, operation, "success");
-    }
-  }
-
   return {
     get: async (key: string) => {
       try {
         const res =
           getFromLocalCache(key) || (await ensureCollection().then(c => c.findOne({ _id: key }, readOptions)));
-        success("get", metrics);
+        success(namespace, "get", metrics);
         return res ? res.value : undefined;
       } catch (err: any) {
-        throw storeErr("get", err, `Error getting key ${key} from mongo store ${namespace}`);
+        throw storeErr(namespace, "get", err, `Error getting key ${key} from mongo store ${namespace}`);
       }
     },
     getWithTTL: async (key: string) => {
@@ -151,10 +183,10 @@ export const createMongoStore = (
           return undefined;
         }
         const ttl = res.expireAt ? Math.max(Math.floor((res.expireAt.getTime() - new Date().getTime()) / 1000), 0) : -1;
-        success("get", metrics);
+        success(namespace, "get", metrics);
         return { value: res.value, ttl };
       } catch (err: any) {
-        throw storeErr("get", err, `Error getting key ${key} from mongo store ${namespace}`);
+        throw storeErr(namespace, "get", err, `Error getting key ${key} from mongo store ${namespace}`);
       }
     },
     set: async (key: string, obj: any, opts?: SetOpts) => {
@@ -180,10 +212,10 @@ export const createMongoStore = (
             }
           })
           .then(() => {
-            success("set", metrics);
+            success(namespace, "set", metrics);
           });
       } catch (err: any) {
-        throw storeErr("set", err, `Error setting key ${key} in mongo store ${namespace}`);
+        throw storeErr(namespace, "set", err, `Error setting key ${key} in mongo store ${namespace}`);
       }
     },
     del: async (key: string) => {
@@ -195,23 +227,23 @@ export const createMongoStore = (
               delete localCache[key];
             }
           });
-        success("del", metrics);
+        success(namespace, "del", metrics);
       } catch (err: any) {
-        throw storeErr("del", err, `Error deleting key ${key} from mongo store ${namespace}`);
+        throw storeErr(namespace, "del", err, `Error deleting key ${key} from mongo store ${namespace}`);
       }
     },
     ttl: async (key: string) => {
       try {
         const res =
           getFromLocalCache(key) || (await ensureCollection().then(c => c.findOne({ _id: key }, readOptions)));
-        success("ttl", metrics);
+        success(namespace, "ttl", metrics);
         return res
           ? res.expireAt
             ? Math.max(Math.floor((res.expireAt.getTime() - new Date().getTime()) / 1000), 0)
             : -1
           : -2;
       } catch (err: any) {
-        throw storeErr("ttl", err, `Error getting key ${key} from mongo store ${namespace}`);
+        throw storeErr(namespace, "ttl", err, `Error getting key ${key} from mongo store ${namespace}`);
       }
     },
   };

--- a/services/rotor/src/lib/functions-chain.ts
+++ b/services/rotor/src/lib/functions-chain.ts
@@ -1,9 +1,10 @@
-import { AnonymousEventsStore, AnyEvent, EventContext, FuncReturn } from "@jitsu/protocols/functions";
+import { AnonymousEventsStore, AnyEvent, EventContext, FuncReturn, TTLStore } from "@jitsu/protocols/functions";
 import {
   createClient,
+  createDummyStore,
   createMongoStore,
   createMultiStore,
-  createTtlStore,
+  createRedisStore,
   EnrichedConnectionConfig,
   EntityStore,
   FuncChainResult,
@@ -123,17 +124,33 @@ export function buildFunctionChain(
       );
     }
   }
-  let store = rotorContext.dummyPersistentStore;
+  let store: TTLStore | undefined = rotorContext.dummyPersistentStore;
   if (!store) {
-    store = createMongoStore(
-      conWorkspaceId,
-      mongodb,
-      false,
-      fastStoreWorkspaceId.includes(conWorkspaceId),
-      rotorContext.metrics
-    );
+    let mongodbStore: TTLStore | undefined, redisStore: TTLStore | undefined;
+
+    if (process.env.MONGODB_URL) {
+      mongodbStore = createMongoStore(
+        conWorkspaceId,
+        mongodb,
+        false,
+        fastStoreWorkspaceId.includes(conWorkspaceId),
+        rotorContext.metrics
+      );
+    }
+
     if (rotorContext.redisClient) {
-      store = createMultiStore(store, createTtlStore(conWorkspaceId, rotorContext.redisClient));
+      redisStore = createRedisStore(conWorkspaceId, rotorContext.redisClient, rotorContext.metrics);
+    }
+
+    if (mongodbStore && redisStore) {
+      store = createMultiStore(mongodbStore, redisStore);
+    } else if (mongodbStore) {
+      store = mongodbStore;
+    } else if (redisStore) {
+      store = redisStore;
+    } else {
+      store = createDummyStore();
+      log.atWarn().log(`No persistence storage configured. MONGODB_URL or REDIS_URL environment variable is required`);
     }
   }
 

--- a/services/rotor/src/lib/message-handler.ts
+++ b/services/rotor/src/lib/message-handler.ts
@@ -10,7 +10,6 @@ import {
   parseUserAgent,
   EventsStore,
   ProfilesFunction,
-  createDummyStore,
   ProfilesConfig,
   EntityStore,
   EnrichedConnectionConfig,

--- a/services/rotor/src/lib/redis.ts
+++ b/services/rotor/src/lib/redis.ts
@@ -18,29 +18,66 @@ function hideSensitiveInfoFromURL(url: string) {
   return parsed.toString();
 }
 
-export function createRedis(): Redis {
-  const redisUrl = requireDefined(process.env.REDIS_URL, "env REDIS_URL is not defined");
-  log.atDebug().log(`Building redis client for ${hideSensitiveInfoFromURL(redisUrl)}`);
-  let tls: any = undefined;
+function resolveRedisConnectionOptions(
+  redisUrl: string,
+  redisSentinelAddress: string | undefined
+): Record<string, any> {
+  let sentinels: any;
+
+  if (redisSentinelAddress) {
+    sentinels = redisSentinelAddress.split(",").map(sentinel => {
+      const [host, port] = sentinel.split(":");
+      return {
+        host,
+        port: port ? parseInt(port, 10) : undefined,
+      };
+    });
+  }
+
+  let tls: any;
   if (redisUrl.startsWith("rediss://")) {
     tls = {
       rejectUnauthorized: false,
     };
   }
-  const redisClient = new Redis(requireDefined(process.env.REDIS_URL, "env REDIS_URL is not defined"), {
-    maxRetriesPerRequest: 3,
-    tls: tls,
-    lazyConnect: false,
+
+  return {
     enableAutoPipelining: true,
-  });
+    lazyConnect: false,
+    maxRetriesPerRequest: 3,
+    sentinels,
+    tls,
+  };
+}
+
+/**
+ * Example `REDIS_URL` values for a standalone Redis instance:
+ * - Standalone Redis: `redis://username:password@localhost:6379/1`
+ * - Standalone Redis with SSL: `rediss://username:password@localhost:6379/2`
+ *
+ * Example `REDIS_URL` and `REDIS_SENTINEL_ADDRESS` values for Redis Sentinel:
+ * - Redis URL: `redis://username:password@/3?name=mymaster`
+ * - Redis Sentinel Address: `sentinel1:26379,sentinel2:26379,sentinel3:26379`
+ */
+export function createRedis(): Redis {
+  const redisUrl = requireDefined(process.env.REDIS_URL, "env REDIS_URL is not defined");
+  const redisSentinelAddress = process.env.REDIS_SENTINEL_ADDRESS;
+
+  let sanitizedRedisUrl: string = hideSensitiveInfoFromURL(redisUrl);
+  if (redisSentinelAddress) {
+    sanitizedRedisUrl += ` (${redisSentinelAddress})`;
+  }
+
+  log.atDebug().log(`Building redis client for ${sanitizedRedisUrl}`);
+
+  const connectionOptions = resolveRedisConnectionOptions(redisUrl, redisSentinelAddress);
+  const redisClient = new Redis(redisUrl, connectionOptions);
+
   redisClient.on("error", err => {
-    log
-      .atWarn()
-      .withCause(err)
-      .log(`Redis @ ${hideSensitiveInfoFromURL(redisUrl)} - failed to connect`);
+    log.atWarn().withCause(err).log(`Redis @ ${sanitizedRedisUrl} - failed to connect`);
   });
   redisClient.on("connect", () => {
-    log.atInfo().log(`Redis @ ${hideSensitiveInfoFromURL(redisUrl)} - successfully connected`);
+    log.atInfo().log(`Redis @ ${sanitizedRedisUrl} - successfully connected`);
   });
   return redisClient;
 }


### PR DESCRIPTION
## Overview

This PR introduces key enhancements to Redis support:

1. Redis Sentinel support - automatic failover and HA for Redis instances.
2. Redis can now be used as the exclusive persistent storage solution, replacing MongoDB.
3. Metrics tracking for Redis storage.

No breaking changes introduced - it supports smooth migration from Redis to MongoDB for users who still wish to use MongoDB.

## Motivation

Our workload has shown that Redis outperforms MongoDB significantly in terms of resource efficiency. Specifically, MongoDB was consuming nearly 1 CPU core per replica and 750MB of memory at just ~250 requests per second, which we believe is excessive for such a simple use case as K/V storage.

Although Jitsu's documentation states that Redis is deprecated in favor of MongoDB, I believe this decision should be reconsidered. Based on our internal performance tests, Redis offers a more efficient solution than MongoDB for our workload. Redis' resource usage is far more optimal, making it a more suitable choice in scenarios with high-performance demands.

Supporting both MongoDB and Redis would provide greater flexibility, allowing users to choose the best storage solution for their needs. For users who don't require features like identity stitching and prefer Redis for its speed and resource efficiency, this approach would also result in more cost-effective Jitsu deployments.
