### PR TITLE
docker: fix Kafka image pull (bitnami → bitnamilegacy)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   kafka:
     tty: true
-    image: "bitnami/kafka:3.6.0"
+    image: bitnamilegacy/kafka:3.6.0
     environment:
       TERM: "xterm-256color"
       KAFKA_CFG_NODE_ID: 0


### PR DESCRIPTION
Summary:
`docker compose up` may fail to pull `bitnami/kafka:<tag>`. This PR switches the Kafka image reference in `docker/docker-compose.yml` to `bitnamilegacy/kafka:<tag>`.

Change scope: one line in docker/docker-compose.yml.

Testing:
Local `docker compose pull kafka && docker compose up -d` succeeds.

Kafka broker starts normally.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix docker compose pull failures for Kafka by switching the image from bitnami/kafka:3.6.0 to bitnamilegacy/kafka:3.6.0. This unblocks local setup; the broker starts normally.

<!-- End of auto-generated description by cubic. -->

