### PR TITLE
Add user creation tools for Jitsu self-hosted

### DIFF
--- a/ADD_USER_GUIDE.md
+++ b/ADD_USER_GUIDE.md
@@ -1,0 +1,239 @@
+# 🚀 Руководство по добавлению пользователей в Jitsu Self-Hosted
+
+## 📋 Доступные скрипты
+
+### 1. `generate-password-hash.js` - Генерация хеша пароля
+
+**Простое использование:**
+```bash
+node generate-password-hash.js "password123"
+```
+
+**С правильным CONSOLE_TOKEN_SECRET:**
+```bash
+# Получите SECRET из вашего .env файла
+cd docker
+export CONSOLE_TOKEN_SECRET=$(grep CONSOLE_TOKEN_SECRET .env | cut -d'=' -f2)
+cd ..
+node generate-password-hash.js "password123"
+```
+
+**Или в одну строку:**
+```bash
+CONSOLE_TOKEN_SECRET="ваш-секрет-из-env" node generate-password-hash.js "password123"
+```
+
+---
+
+### 2. `create-jitsu-user.js` - Полное создание пользователя
+
+**Генерация SQL команд:**
+```bash
+node create-jitsu-user.js "user@example.com" "User Name" "password123"
+```
+
+**Автоматическое создание (если установлен модуль `pg`):**
+```bash
+# Установите pg модуль
+npm install pg
+
+# Загрузите переменные из .env и создайте пользователя
+cd docker
+export $(grep -v '^#' .env | xargs)
+cd ..
+node create-jitsu-user.js "user@example.com" "User Name" "password123"
+```
+
+**Создание администратора:**
+```bash
+node create-jitsu-user.js "admin@example.com" "Admin User" "admin123" true
+```
+
+---
+
+## 🔧 Способы добавления пользователей
+
+### Способ 1: Через Docker контейнер (РЕКОМЕНДУЕТСЯ)
+
+Если у вас Docker доступен, самый простой способ - скопировать скрипт в контейнер:
+
+```bash
+# Скопируйте скрипт в контейнер
+docker cp create-jitsu-user.js jitsu-console-1:/app/
+
+# Запустите внутри контейнера
+docker exec -it jitsu-console-1 node /app/create-jitsu-user.js \
+  "user@example.com" \
+  "User Name" \
+  "password123"
+```
+
+---
+
+### Способ 2: Через PostgreSQL напрямую
+
+**Шаг 1:** Сгенерируйте SQL:
+```bash
+node create-jitsu-user.js "user@example.com" "User Name" "password123"
+```
+
+**Шаг 2:** Подключитесь к PostgreSQL:
+```bash
+# Через Docker
+docker exec -it jitsu-postgres-1 psql -U postgres -d postgres
+
+# Или напрямую (если PostgreSQL доступен)
+psql "postgresql://postgres:YOUR_PASSWORD@localhost:5432/postgres"
+```
+
+**Шаг 3:** Скопируйте и выполните SQL команды из вывода скрипта.
+
+---
+
+### Способ 3: GitHub OAuth (БЕЗ ПАРОЛЕЙ)
+
+Самый простой и безопасный способ для множества пользователей:
+
+**1. Создайте GitHub OAuth App:**
+- Перейдите: https://github.com/settings/developers
+- Нажмите "New OAuth App"
+- Заполните:
+  - **Application name**: Jitsu Self-Hosted
+  - **Homepage URL**: `http://localhost:3000` (или ваш домен)
+  - **Authorization callback URL**: `http://localhost:3000/api/auth/callback/github`
+
+**2. Обновите `.env`:**
+```bash
+GITHUB_CLIENT_ID=ваш_client_id
+GITHUB_CLIENT_SECRET=ваш_client_secret
+```
+
+**3. Перезапустите Jitsu:**
+```bash
+cd docker
+docker-compose down
+docker-compose up -d
+```
+
+Теперь пользователи могут регистрироваться через GitHub на странице `/signup`!
+
+---
+
+## ⚠️ ВАЖНО: Проблема с CONSOLE_TOKEN_SECRET
+
+Хеши паролей в Jitsu **зависят от CONSOLE_TOKEN_SECRET**!
+
+### Проверка вашего SECRET:
+
+**На сервере:**
+```bash
+cd docker
+grep CONSOLE_TOKEN_SECRET .env
+```
+
+**Копируйте этот SECRET при генерации хешей:**
+```bash
+CONSOLE_TOKEN_SECRET="значение_из_env_файла" node generate-password-hash.js "password"
+```
+
+### Почему это важно?
+
+- ❌ Хеш созданный с дефолтным SECRET не будет работать, если на сервере кастомный SECRET
+- ✅ Всегда используйте одинаковый SECRET при генерации и проверке хешей
+- ✅ Храните CONSOLE_TOKEN_SECRET в безопасном месте (password manager)
+
+---
+
+## 📊 Какой способ выбрать?
+
+| Ситуация | Рекомендуемый способ |
+|----------|---------------------|
+| Много пользователей | GitHub OAuth |
+| 1-5 пользователей | create-jitsu-user.js + DATABASE_URL |
+| Одноразовое добавление | generate-password-hash.js + SQL вручную |
+| Нет доступа к серверу | Отправьте SQL администратору |
+| Автоматизация | Используйте скрипт с DATABASE_URL в CI/CD |
+
+---
+
+## 🔍 Проверка созданного пользователя
+
+```sql
+-- В PostgreSQL выполните:
+SELECT
+  u.id,
+  u.email,
+  u.name,
+  u.admin,
+  u."loginProvider",
+  CASE WHEN p.hash IS NOT NULL THEN '✓ Есть' ELSE '✗ Нет' END as password
+FROM "UserProfile" u
+LEFT JOIN "UserPassword" p ON u.id = p."userId"
+WHERE u.email = 'user@example.com';
+```
+
+---
+
+## 🎯 Быстрый старт
+
+**Для одного пользователя (самый быстрый способ):**
+
+```bash
+# 1. Перейдите в директорию jitsu
+cd /home/user/jitsu
+
+# 2. Загрузите переменные из .env
+cd docker && source .env && cd ..
+
+# 3. Создайте пользователя
+node create-jitsu-user.js "newuser@example.com" "New User" "password123"
+
+# 4. Скопируйте SQL и выполните в PostgreSQL
+docker exec -it jitsu-postgres-1 psql -U postgres -d postgres
+# Вставьте SQL команды из вывода скрипта
+```
+
+---
+
+## 📚 Дополнительные ресурсы
+
+- **Issue о проблеме с приглашениями**: https://github.com/jitsucom/jitsu/issues/1131
+- **Документация Jitsu**: https://docs.jitsu.com/self-hosting/
+- **GitHub OAuth настройка**: https://docs.github.com/en/developers/apps/building-oauth-apps
+
+---
+
+## 🆘 Решение проблем
+
+### "Password hash не работает"
+
+**Проблема:** Пароль не принимается при входе
+
+**Решение:**
+1. Проверьте CONSOLE_TOKEN_SECRET на сервере
+2. Пересоздайте хеш с правильным SECRET
+3. Обновите запись в UserPassword
+
+### "Пользователь уже существует"
+
+**Проблема:** Ошибка при создании пользователя
+
+**Решение:**
+```sql
+-- Проверьте существующих пользователей
+SELECT email, "loginProvider" FROM "UserProfile" WHERE email = 'user@example.com';
+
+-- Если нужно, удалите старого пользователя
+DELETE FROM "UserPassword" WHERE "userId" = (SELECT id FROM "UserProfile" WHERE email = 'user@example.com');
+DELETE FROM "UserProfile" WHERE email = 'user@example.com';
+```
+
+### "Permission denied на ./data/"
+
+**Проблема:** Docker не может писать в bind mount
+
+**Решение:** Используйте Named Volumes вместо bind mounts (см. README.md)
+
+---
+
+Удачи! 🚀

--- a/create-jitsu-user.js
+++ b/create-jitsu-user.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+/**
+ * Скрипт для создания пользователя в Jitsu (без зависимостей от Prisma)
+ *
+ * Использование:
+ *   DATABASE_URL="postgresql://..." node create-jitsu-user.js email@example.com "User Name" "password123"
+ *
+ * Или с переменными из .env:
+ *   cd docker && source .env && node ../create-jitsu-user.js email@example.com "User Name" "password123"
+ */
+
+const crypto = require('crypto');
+
+// ============================================================================
+// Функции хеширования (из juava/security.ts)
+// ============================================================================
+
+const defaultSeed = "dea42a58-acf4-45af-85bb-e77e94bd5025";
+
+const globalSeed = (
+  process.env.GLOBAL_HASH_SECRET ||
+  process.env.CONSOLE_TOKEN_SECRET ||
+  process.env.ROTOR_TOKEN_SECRET ||
+  defaultSeed
+).split(",").map(s => s.trim())[0];
+
+function hash(algorithm, value) {
+  const h = crypto.createHash(algorithm);
+  h.update(value);
+  return h.digest('hex');
+}
+
+function createHash(secret) {
+  const randomSeed = crypto.randomBytes(16).toString('hex');
+  const hashValue = hash('sha512', secret + randomSeed + globalSeed);
+  return `${randomSeed}.${hashValue}`;
+}
+
+function toId(email) {
+  return hash('sha256', email.toLowerCase().trim());
+}
+
+// ============================================================================
+// Парсинг аргументов
+// ============================================================================
+
+const [email, name, password, isAdmin] = process.argv.slice(2);
+
+if (!email || !name || !password) {
+  console.error('\n❌ Ошибка: недостаточно параметров\n');
+  console.log('Использование:');
+  console.log('  node create-jitsu-user.js EMAIL NAME PASSWORD [ADMIN]\n');
+  console.log('Примеры:');
+  console.log('  node create-jitsu-user.js user@example.com "John Doe" "password123"');
+  console.log('  node create-jitsu-user.js admin@example.com "Admin User" "secure123" true\n');
+  console.log('С DATABASE_URL:');
+  console.log('  DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres" \\');
+  console.log('    node create-jitsu-user.js user@example.com "User" "pass123"\n');
+  console.log('С переменными из .env:');
+  console.log('  cd docker && source .env && node ../create-jitsu-user.js email "Name" "pass"\n');
+  process.exit(1);
+}
+
+// ============================================================================
+// Генерация данных
+// ============================================================================
+
+const passwordHash = createHash(password);
+const externalId = toId(email);
+const admin = isAdmin === 'true' || isAdmin === '1';
+
+console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.log('👤 Создание пользователя Jitsu');
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+console.log('Данные пользователя:');
+console.log(`  Email:        ${email}`);
+console.log(`  Name:         ${name}`);
+console.log(`  Admin:        ${admin}`);
+console.log(`  External ID:  ${externalId}`);
+console.log(`  Password:     ${'*'.repeat(password.length)}`);
+console.log(`  Hash:         ${passwordHash.substring(0, 20)}...${passwordHash.substring(passwordHash.length - 10)}\n`);
+
+// Проверяем SECRET
+const usingDefaultSeed = globalSeed === defaultSeed;
+if (usingDefaultSeed) {
+  console.log('⚠️  ВНИМАНИЕ: Используется дефолтный GLOBAL_HASH_SECRET!');
+  console.log('   Если на сервере кастомный CONSOLE_TOKEN_SECRET, пароль не сработает.\n');
+} else {
+  console.log('✅ Используется кастомный CONSOLE_TOKEN_SECRET\n');
+}
+
+// ============================================================================
+// SQL команды
+// ============================================================================
+
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.log('📋 SQL команды для выполнения:');
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+const sql = `
+-- 1. Проверить, существует ли пользователь
+SELECT id, email, "loginProvider" FROM "UserProfile" WHERE email = '${email}';
+
+-- Если пользователь НЕ существует, выполните следующие команды:
+
+-- 2. Создать UserProfile
+INSERT INTO "UserProfile" (
+  id, name, email, admin, "loginProvider", "externalId", "createdAt", "updatedAt"
+) VALUES (
+  gen_random_uuid()::text,
+  '${name.replace(/'/g, "''")}',
+  '${email}',
+  ${admin},
+  'credentials',
+  '${externalId}',
+  NOW(),
+  NOW()
+);
+
+-- 3. Добавить пароль
+INSERT INTO "UserPassword" ("userId", hash, "changeAtNextLogin", "createdAt", "updatedAt")
+SELECT
+  id,
+  '${passwordHash}',
+  true,
+  NOW(),
+  NOW()
+FROM "UserProfile"
+WHERE email = '${email}' AND "loginProvider" = 'credentials';
+
+-- 4. Проверить создание
+SELECT
+  u.id,
+  u.email,
+  u.name,
+  u.admin,
+  CASE WHEN p.hash IS NOT NULL THEN '✓ Установлен' ELSE '✗ Отсутствует' END as password_status
+FROM "UserProfile" u
+LEFT JOIN "UserPassword" p ON u.id = p."userId"
+WHERE u.email = '${email}';
+`;
+
+console.log(sql);
+
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.log('🔧 Как выполнить:');
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+console.log('Через Docker:');
+console.log('  docker exec -it jitsu-postgres-1 psql -U postgres -d postgres\n');
+
+console.log('Через psql напрямую:');
+console.log('  psql "postgresql://postgres:YOUR_PASSWORD@localhost:5432/postgres"\n');
+
+console.log('Скопируйте SQL команды выше и выполните их в psql.\n');
+
+// ============================================================================
+// Попытка подключения к БД (опционально, если есть pg модуль)
+// ============================================================================
+
+if (process.env.DATABASE_URL) {
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('🔌 Автоматическое создание пользователя');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+  try {
+    const { Client } = require('pg');
+
+    (async () => {
+      const client = new Client({
+        connectionString: process.env.DATABASE_URL,
+      });
+
+      try {
+        await client.connect();
+        console.log('✅ Подключено к базе данных\n');
+
+        // Проверяем существование пользователя
+        console.log('Проверка существующего пользователя...');
+        const checkResult = await client.query(
+          'SELECT id, email FROM "UserProfile" WHERE email = $1',
+          [email]
+        );
+
+        if (checkResult.rows.length > 0) {
+          console.log(`❌ Пользователь с email ${email} уже существует!`);
+          console.log(`   ID: ${checkResult.rows[0].id}\n`);
+          process.exit(1);
+        }
+
+        console.log('✓ Пользователь не найден, создаем...\n');
+
+        // Создаем UserProfile
+        const userResult = await client.query(`
+          INSERT INTO "UserProfile" (
+            id, name, email, admin, "loginProvider", "externalId", "createdAt", "updatedAt"
+          ) VALUES (
+            gen_random_uuid()::text, $1, $2, $3, 'credentials', $4, NOW(), NOW()
+          ) RETURNING id
+        `, [name, email, admin, externalId]);
+
+        const userId = userResult.rows[0].id;
+        console.log(`✅ UserProfile создан, ID: ${userId}`);
+
+        // Создаем пароль
+        await client.query(`
+          INSERT INTO "UserPassword" ("userId", hash, "changeAtNextLogin", "createdAt", "updatedAt")
+          VALUES ($1, $2, true, NOW(), NOW())
+        `, [userId, passwordHash]);
+
+        console.log('✅ Пароль установлен\n');
+
+        // Проверяем результат
+        const verifyResult = await client.query(`
+          SELECT
+            u.id,
+            u.email,
+            u.name,
+            u.admin,
+            CASE WHEN p.hash IS NOT NULL THEN true ELSE false END as has_password
+          FROM "UserProfile" u
+          LEFT JOIN "UserPassword" p ON u.id = p."userId"
+          WHERE u.id = $1
+        `, [userId]);
+
+        console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+        console.log('✅ Пользователь успешно создан!');
+        console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+        console.log('Данные пользователя:');
+        console.log(`  ID:           ${verifyResult.rows[0].id}`);
+        console.log(`  Email:        ${verifyResult.rows[0].email}`);
+        console.log(`  Name:         ${verifyResult.rows[0].name}`);
+        console.log(`  Admin:        ${verifyResult.rows[0].admin}`);
+        console.log(`  Password:     ${verifyResult.rows[0].has_password ? '✓ Установлен' : '✗ Отсутствует'}`);
+        console.log('\nПользователь может войти по адресу:');
+        console.log(`  ${process.env.JITSU_PUBLIC_URL || 'http://localhost:3000'}/signin`);
+        console.log(`  Email:    ${email}`);
+        console.log(`  Password: ${password}`);
+        console.log('\n⚠️  Рекомендуется сменить пароль при первом входе!\n');
+
+      } catch (err) {
+        console.error('❌ Ошибка при работе с базой данных:', err.message);
+        console.log('\nИспользуйте SQL команды выше для ручного создания пользователя.\n');
+        process.exit(1);
+      } finally {
+        await client.end();
+      }
+    })();
+
+  } catch (err) {
+    console.log('⚠️  Модуль pg не установлен, используйте SQL команды выше');
+    console.log('   Для автоматического создания установите: npm install pg\n');
+  }
+} else {
+  console.log('💡 Для автоматического создания пользователя установите DATABASE_URL:\n');
+  console.log('   DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres" \\');
+  console.log('     node create-jitsu-user.js email "Name" "password"\n');
+}

--- a/generate-password-hash.js
+++ b/generate-password-hash.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * Генератор хешей паролей для Jitsu
+ *
+ * Использование:
+ *   node generate-password-hash.js "your-password"
+ *
+ * Или с кастомным CONSOLE_TOKEN_SECRET:
+ *   CONSOLE_TOKEN_SECRET="your-secret" node generate-password-hash.js "your-password"
+ */
+
+const crypto = require('crypto');
+
+// ВАЖНО: Должен совпадать с CONSOLE_TOKEN_SECRET на сервере!
+const defaultSeed = "dea42a58-acf4-45af-85bb-e77e94bd5025";
+
+const globalSeed = (
+  process.env.GLOBAL_HASH_SECRET ||
+  process.env.CONSOLE_TOKEN_SECRET ||
+  process.env.ROTOR_TOKEN_SECRET ||
+  defaultSeed
+).split(",").map(s => s.trim())[0];
+
+function hash(algorithm, value) {
+  const h = crypto.createHash(algorithm);
+  h.update(value);
+  return h.digest('hex');
+}
+
+function createHash(secret) {
+  const randomSeed = crypto.randomBytes(16).toString('hex');
+  const hashValue = hash('sha512', secret + randomSeed + globalSeed);
+  return `${randomSeed}.${hashValue}`;
+}
+
+function toId(email) {
+  return hash('sha256', email.toLowerCase().trim());
+}
+
+// Основная логика
+const password = process.argv[2];
+
+if (!password) {
+  console.error('\n❌ Ошибка: пароль не указан\n');
+  console.log('Использование:');
+  console.log('  node generate-password-hash.js "your-password"\n');
+  console.log('С кастомным secret:');
+  console.log('  CONSOLE_TOKEN_SECRET="your-secret" node generate-password-hash.js "your-password"\n');
+  process.exit(1);
+}
+
+console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.log('📝 Генератор хешей паролей для Jitsu');
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+// Проверяем, используется ли дефолтный seed
+const usingDefaultSeed = globalSeed === defaultSeed;
+
+if (usingDefaultSeed) {
+  console.log('⚠️  ВНИМАНИЕ: Используется дефолтный GLOBAL_HASH_SECRET');
+  console.log('   Если на сервере установлен кастомный CONSOLE_TOKEN_SECRET,');
+  console.log('   хеш НЕ БУДЕТ РАБОТАТЬ!\n');
+  console.log('   Установите переменную окружения:');
+  console.log('   CONSOLE_TOKEN_SECRET="ваш-секрет" node generate-password-hash.js "пароль"\n');
+} else {
+  console.log('✅ Используется кастомный GLOBAL_HASH_SECRET');
+  console.log(`   Secret: ${globalSeed.substring(0, 8)}...${globalSeed.substring(globalSeed.length - 4)}\n`);
+}
+
+const passwordHash = createHash(password);
+
+console.log('📋 Результат:\n');
+console.log('Password Hash:');
+console.log(`  ${passwordHash}\n`);
+
+// Показываем пример использования
+const exampleEmail = 'user@example.com';
+const externalId = toId(exampleEmail);
+
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.log('📖 Пример SQL для создания пользователя:');
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+console.log(`-- 1. Создать UserProfile`);
+console.log(`INSERT INTO "UserProfile" (`);
+console.log(`  id, name, email, admin, "loginProvider", "externalId", "createdAt", "updatedAt"`);
+console.log(`) VALUES (`);
+console.log(`  gen_random_uuid()::text,`);
+console.log(`  'User Name',`);
+console.log(`  '${exampleEmail}',`);
+console.log(`  false,`);
+console.log(`  'credentials',`);
+console.log(`  '${externalId}',`);
+console.log(`  NOW(),`);
+console.log(`  NOW()`);
+console.log(`);\n`);
+
+console.log(`-- 2. Добавить пароль`);
+console.log(`INSERT INTO "UserPassword" ("userId", hash, "changeAtNextLogin", "createdAt", "updatedAt")`);
+console.log(`SELECT`);
+console.log(`  id,`);
+console.log(`  '${passwordHash}',`);
+console.log(`  true,`);
+console.log(`  NOW(),`);
+console.log(`  NOW()`);
+console.log(`FROM "UserProfile"`);
+console.log(`WHERE email = '${exampleEmail}';\n`);
+
+console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');


### PR DESCRIPTION
Created utilities to address issue #1131 where user invitations don't work in self-hosted deployments:

- generate-password-hash.js: Generate password hashes with proper CONSOLE_TOKEN_SECRET
- create-jitsu-user.js: Create users with automatic SQL generation or direct DB insertion
- ADD_USER_GUIDE.md: Comprehensive guide for adding users via multiple methods

These tools solve the problem of adding second users when email invitations are broken, with proper handling of the custom hashing system that includes GLOBAL_HASH_SECRET.