### PR TITLE
chore(bulker): enable topic manager all table token configuration

### DIFF
--- a/bulker/.docs/server-config.md
+++ b/bulker/.docs/server-config.md
@@ -194,6 +194,16 @@ String prefixed to all destination topic names.
 
 e.g. if `BULKER_KAFKA_TOPIC_PREFIX=some.prefix.`, then a full topic name could be `some.prefix.in.id.clyzlw-.m.batch.t.events`
 
+### `BULKER_TOPIC_MANAGER_ALL_TABLE_TOKEN`
+
+*Optional, default value: `_all_`*
+
+It allows overwriting default suffix to topics for all tables in a destination, such as 
+`dead` and `retries` topics
+
+e.g. if `BULKER_TOPIC_MANAGER_ALL_TABLE_TOKEN=all`, then a retry topic for destination `clyzlw-` would be
+`in.id.clyzlw-.m.retry.t.all`
+
 ### `BULKER_KAFKA_TOPIC_RETENTION_HOURS`
 
 *Optional, default value: `48` (2 days)*

--- a/bulker/bulkerapp/app/app_config.go
+++ b/bulker/bulkerapp/app/app_config.go
@@ -51,7 +51,7 @@ type Config struct {
 
 	// TopicManagerRefreshPeriodSec how often topic manager will check for new topics
 	TopicManagerRefreshPeriodSec int `mapstructure:"TOPIC_MANAGER_REFRESH_PERIOD_SEC" default:"5"`
-	// TopicManagerAllTableToken allows overwriting default sufix to topics for all tables in a destination, such as
+	// TopicManagerAllTableToken allows overwriting default suffix to topics for all tables in a destination, such as
 	// `dead` and `retries`
 	TopicManagerAllTableToken string `mapstructure:"TOPIC_MANAGER_ALL_TABLE_TOKEN" default:"_all_"`
 

--- a/bulker/bulkerapp/app/app_config.go
+++ b/bulker/bulkerapp/app/app_config.go
@@ -51,6 +51,9 @@ type Config struct {
 
 	// TopicManagerRefreshPeriodSec how often topic manager will check for new topics
 	TopicManagerRefreshPeriodSec int `mapstructure:"TOPIC_MANAGER_REFRESH_PERIOD_SEC" default:"5"`
+	// TopicManagerAllTableToken allows overwriting default sufix to topics for all tables in a destination, such as
+	// `dead` and `retries`
+	TopicManagerAllTableToken string `mapstructure:"TOPIC_MANAGER_ALL_TABLE_TOKEN" default:"_all_"`
 
 	// # BATCHING
 

--- a/bulker/bulkerapp/app/topic_manager.go
+++ b/bulker/bulkerapp/app/topic_manager.go
@@ -24,12 +24,14 @@ const (
 	deadTopicMode     = "dead"
 	profilesTopicMode = "profiles"
 
-	allTablesToken = "_all_"
-
 	topicLengthLimit = 249
 )
 
-var topicPattern = regexp.MustCompile(`^in[.]id[.](.*)[.]m[.](.*)[.](t|b64)[.](.*)$`)
+var (
+	topicPattern = regexp.MustCompile(`^in[.]id[.](.*)[.]m[.](.*)[.](t|b64)[.](.*)$`)
+
+	allTablesToken = "_all_"
+)
 
 type TopicManager struct {
 	appbase.Service
@@ -77,6 +79,9 @@ func NewTopicManager(appContext *Context) (*TopicManager, error) {
 	if err != nil {
 		return nil, base.NewError("Error creating kafka admin client: %v", err)
 	}
+
+	allTablesToken = appContext.config.TopicManagerAllTableToken
+
 	return &TopicManager{
 		Service:              base,
 		config:               appContext.config,


### PR DESCRIPTION
## WHY

Recently, while installing Bulker as a self-hosted solution, we’ve faced some issues setting up the standard topics for destinations named with `_all_` suffix via a K8S operator. This happens because our operator sets/uses the topic name as the object name of K8S, which should be compliant with [DNS Subdomain names RFC](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names). 

Hence, I'd like to check with you guys the possibility of either changing the `allTablesToken` via env var or something analogous. This will not only help my organization and me, but also other folks who should be compliant with this RFC

## WHAT

Added a new env var for Bulker called `TOPIC_MANAGER_ALL_TABLE_TOKEN`, which allows overwriting the default `allTablesToken` value

To minimize the number of changes, opted to convert `allTablesToken` from a constant to a variable and overwrite it in the `TopicManager` build time.