### PR TITLE
feat: display OIDC provider avatar (Google profile photo) in Console UI

### DIFF
--- a/webapps/console/components/PageLayout/WorkspacePageLayout.tsx
+++ b/webapps/console/components/PageLayout/WorkspacePageLayout.tsx
@@ -339,7 +339,7 @@ const UserProfileButton: React.FC<{}> = () => {
       trigger={["click"]}
     >
       <div className="h-8 w-8 cursor-pointer">
-        {user.image && user.image.indexOf("googleusercontent.com/") < 0 ? (
+        {user.image ? (
           <img className="rounded-full w-8 h-8" src={user.image} about="userpic" alt="" width="100" height="100" />
         ) : (
           <FaUserCircle className="text-primary w-full h-full" />

--- a/webapps/console/lib/nextauth.config.ts
+++ b/webapps/console/lib/nextauth.config.ts
@@ -163,6 +163,9 @@ export const nextAuthConfig: NextAuthOptions = {
         mustChangePassword: user.mustChangePassword,
         externalUsername: props.profile?.["login"],
         loginProvider: loginProvider,
+        // Propagate avatar from OIDC/GitHub profile to the JWT token.
+        // Google OIDC uses "picture", GitHub uses "avatar_url".
+        picture: props.token.picture || props.profile?.["picture"] || props.profile?.["avatar_url"],
         ...props.token,
       };
     },
@@ -174,6 +177,11 @@ export const nextAuthConfig: NextAuthOptions = {
         loginProvider: token.loginProvider,
         externalId: token.externalId,
         externalUsername: token.externalUsername,
+        // Pass avatar URL to session so UI can render provider profile photos
+        user: {
+          ...session.user,
+          image: (token.picture as string | undefined) || session.user?.image,
+        },
       };
     },
   },


### PR DESCRIPTION
## Summary

- Propagate the `picture` claim from OIDC providers (Google Workspace, Auth0, Okta, etc.) and `avatar_url` from GitHub through NextAuth's JWT and session callbacks to `session.user.image`
- Remove the explicit exclusion of `googleusercontent.com` URLs in `UserProfileButton` that prevented Google profile photos from rendering

## Problem

When using OIDC authentication (e.g. Google Workspace SSO), user profile photos are never displayed in the Console — the avatar always shows the generic `FaUserCircle` icon. Two issues:

1. **`nextauth.config.ts`**: The `picture` claim from the OIDC profile response isn't passed through the JWT and session callbacks, so `session.user.image` is always undefined
2. **`WorkspacePageLayout.tsx`**: `UserProfileButton` has an explicit check `user.image.indexOf("googleusercontent.com/") < 0` that filters out Google profile photo URLs even if they were available

## Changes

### `webapps/console/lib/nextauth.config.ts`
- **JWT callback**: Capture `picture` from token or profile (supports Google's `picture` claim and GitHub's `avatar_url`)
- **Session callback**: Pass `picture` through to `session.user.image` so the existing avatar rendering code can display it

### `webapps/console/components/PageLayout/WorkspacePageLayout.tsx`
- **`UserProfileButton`**: Remove the `googleusercontent.com` URL exclusion — render any valid `user.image` URL as an avatar

## Scope

This is a minimal, backward-compatible change:
- Users without a profile photo continue to see the generic icon
- Works with any OIDC provider that returns a `picture` claim (Google, Auth0, Okta, Azure AD, Keycloak)
- Also supports GitHub's `avatar_url` in the same code path
- No database schema changes required
- No new dependencies

## Test plan
- [x] Verified Google OIDC returns `picture` claim in profile response
- [x] Confirmed `UserProfileButton` already has avatar `<img>` rendering — just needs the URL propagated
- [x] Confirmed the `googleusercontent.com` filter is the only blocker for Google avatars

---
*Generated with [Claude Code](https://claude.ai/code)*