### PR TITLE
Use FETCH_TIMEOUT_MS instead of a hardcoded 2000ms

### DIFF
--- a/services/rotor/src/http/functions.ts
+++ b/services/rotor/src/http/functions.ts
@@ -1,4 +1,4 @@
-import { getLog, requireDefined } from "juava";
+import { getLog, parseNumber, requireDefined } from "juava";
 import { IngestMessage } from "@jitsu/protocols/async-request";
 import { MessageHandlerContext, rotorMessageHandler } from "../lib/message-handler";
 import { CONNECTION_IDS_HEADER } from "../lib/rotor";
@@ -8,9 +8,11 @@ import { parse as semverParse } from "semver";
 import * as jsondiffpatch from "jsondiffpatch";
 import { connectionsStore, functionsStore, streamsStore } from "../lib/repositories";
 import { promHandlerMetric } from "../lib/metrics";
+import { getServerEnv } from "../serverEnv";
 
 const jsondiffpatchInstance = jsondiffpatch.create();
 const log = getLog("functions_handler");
+const fetchTimeoutMs = parseNumber(getServerEnv().FETCH_TIMEOUT_MS, 2000);
 
 export const FunctionsHandler =
   (rotorContext: Omit<MessageHandlerContext, "connectionStore" | "functionsStore" | "streamsStore">) =>
@@ -37,7 +39,7 @@ export const FunctionsHandlerMulti =
     const message = req.body as IngestMessage;
     const functionsFetchTimeout = req.headers["x-request-timeout-ms"]
       ? parseInt(req.headers["x-request-timeout-ms"] as string)
-      : 2000;
+      : fetchTimeoutMs;
     const prom = connectionIds
       .filter(id => !!id)
       .map(id => {


### PR DESCRIPTION
- Replaces the hardcoded `2000`ms fallback timeout in the functions HTTP handler with a configurable value read from the `FETCH_TIMEOUT_MS` environment variable.
- The default remains `2000ms` if the env var is not set, preserving existing behavior.

In `FunctionsHandlerMulti`, when the `x-request-timeout-ms` header is not present on a request, the fetch timeout fell back to a hardcoded `2000`. This value is now read from `getServerEnv().FETCH_TIMEOUT_MS` at startup (using `parseNumber` with a default of `2000`), making it configurable without a code change.

Fixes #1253 