### PR TITLE
fix(ci): migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -32,7 +32,7 @@ runs:
         echo "EOF" >> $GITHUB_OUTPUT
 
     - name: 💬 Send Slack notification
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
         COLOR: ${{ inputs.color }}

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -30,9 +30,6 @@ on:
       - pnpm-lock.yaml
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: 🏗️ Build and Push Builder Image
@@ -43,16 +40,16 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: cloud
           endpoint: "jitsucom/newjitsu"
@@ -62,7 +59,7 @@ jobs:
         run: echo "sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
 
       - name: 🏗️ Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: builder.Dockerfile

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -30,6 +30,9 @@ on:
       - pnpm-lock.yaml
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: 🏗️ Build and Push Builder Image

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,6 +10,9 @@ on:
       - edited        # PR title/body/base-branch changed
       - ready_for_review   # PR moved from draft → ready
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,9 +10,6 @@ on:
       - edited        # PR title/body/base-branch changed
       - ready_for_review   # PR moved from draft → ready
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   claude-review:
     runs-on: ubuntu-latest
@@ -23,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/client-libraries-build.yaml
+++ b/.github/workflows/client-libraries-build.yaml
@@ -73,36 +73,31 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: 🔍 Validate NPM token
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - name: 🔍 Validate OIDC token and npm access
         run: |
-          echo "Validating NPM token..."
-          WHOAMI=$(curl -s -H "Authorization: Bearer ${NPM_TOKEN}" https://registry.npmjs.org/-/whoami)
-          echo "Authenticated as: ${WHOAMI}"
-          if [ -z "${WHOAMI}" ] || [ "${WHOAMI}" = "null" ]; then
-            echo "ERROR: Invalid NPM token"
+          OIDC_TOKEN=$(curl -sf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org" | jq -r '.value')
+          if [ -z "${OIDC_TOKEN}" ] || [ "${OIDC_TOKEN}" = "null" ]; then
+            echo "ERROR: Could not obtain OIDC token - check that id-token: write permission is set on this job"
             exit 1
           fi
+          echo "OIDC token obtained"
+          FAILED=0
+          for PKG in "@jitsu/protocols" "@jitsu/js" "@jitsu/jitsu-react"; do
+            ENCODED=$(printf '%s' "$PKG" | sed 's/@/%40/g; s|/|%2F|g')
+            HTTP=$(curl -sf -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
+            if [ "${HTTP}" != "201" ]; then
+              echo "ERROR: npm OIDC exchange failed (HTTP ${HTTP}) for ${PKG} - check trusted publisher config on npmjs.com"
+              FAILED=1
+            else
+              echo "OK: ${PKG}"
+            fi
+          done
+          [ "${FAILED}" = "0" ] || exit 1
 
       - name: 🐳 Pull and start builder container
         run: |
           docker pull jitsucom/jitsu-builder:latest
           docker run -d --name builder -v ${{ github.workspace }}:/workspace -w /workspace -e CI=true jitsucom/jitsu-builder:latest tail -f /dev/null
-
-      - name: 🔐 Configure npm authentication
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: |
-          docker exec -e NPM_TOKEN builder sh -c "echo '//registry.npmjs.org/:_authToken='\${NPM_TOKEN} >> /workspace/.npmrc"
-
-      - name: 🔐 Validate npm authentication
-        run: |
-          docker exec builder npm whoami || {
-            echo "npm whoami failed, dumping debug logs:"
-            docker exec builder sh -c "cat /root/.npm/_logs/*.log"
-            exit 1
-          }
 
       - name: 📦 Fetch dependencies from store
         run: |
@@ -147,15 +142,15 @@ jobs:
 
           # Publish @jitsu/protocols
           echo "Publishing @jitsu/protocols..."
-          docker exec builder sh -c "cd types/protocols && pnpm publish --tag ${NPM_TAG} --access public"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && pnpm publish --provenance --tag ${NPM_TAG} --access public"
 
           # Publish @jitsu/js
           echo "Publishing @jitsu/js..."
-          docker exec builder sh -c "cd libs/jitsu-js && pnpm publish --tag ${NPM_TAG} --access public"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-js && pnpm publish --provenance --tag ${NPM_TAG} --access public"
 
           # Publish @jitsu/jitsu-react
           echo "Publishing @jitsu/jitsu-react..."
-          docker exec builder sh -c "cd libs/jitsu-react && pnpm publish --tag ${NPM_TAG} --access public"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-react && pnpm publish --provenance --tag ${NPM_TAG} --access public"
 
       - name: 🧹 Cleanup container
         if: always()

--- a/.github/workflows/client-libraries-build.yaml
+++ b/.github/workflows/client-libraries-build.yaml
@@ -142,15 +142,15 @@ jobs:
 
           # Publish @jitsu/protocols
           echo "Publishing @jitsu/protocols..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && pnpm publish --provenance --tag ${NPM_TAG} --access public"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && npm publish --provenance --tag ${NPM_TAG} --access public"
 
           # Publish @jitsu/js
           echo "Publishing @jitsu/js..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-js && pnpm publish --provenance --tag ${NPM_TAG} --access public"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-js && npm publish --provenance --tag ${NPM_TAG} --access public"
 
           # Publish @jitsu/jitsu-react
           echo "Publishing @jitsu/jitsu-react..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-react && pnpm publish --provenance --tag ${NPM_TAG} --access public"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-react && npm publish --provenance --tag ${NPM_TAG} --access public"
 
       - name: 🧹 Cleanup container
         if: always()

--- a/.github/workflows/client-libraries-build.yaml
+++ b/.github/workflows/client-libraries-build.yaml
@@ -131,26 +131,32 @@ jobs:
         env:
           CHANNEL: ${{ needs.version.outputs.channel }}
         run: |
-          # Determine NPM tag based on channel
           if [ "${CHANNEL}" = "stable" ]; then
             NPM_TAG="latest"
           else
             NPM_TAG="${CHANNEL}"
           fi
 
+          # Get OIDC token and set up .npmrc to use NODE_AUTH_TOKEN
+          OIDC_TOKEN=$(curl -sf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org" | jq -r '.value')
+          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> ${{ github.workspace }}/.npmrc
+
           echo "Publishing client libraries to NPM with tag: ${NPM_TAG}"
 
           # Publish @jitsu/protocols
           echo "Publishing @jitsu/protocols..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && npm publish --provenance --tag ${NPM_TAG} --access public"
+          PKG_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40jitsu%2Fprotocols" | jq -r '.token')
+          docker exec -e NODE_AUTH_TOKEN="${PKG_TOKEN}" builder sh -c "cd types/protocols && npm publish --tag ${NPM_TAG} --access public"
 
           # Publish @jitsu/js
           echo "Publishing @jitsu/js..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-js && npm publish --provenance --tag ${NPM_TAG} --access public"
+          PKG_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40jitsu%2Fjs" | jq -r '.token')
+          docker exec -e NODE_AUTH_TOKEN="${PKG_TOKEN}" builder sh -c "cd libs/jitsu-js && npm publish --tag ${NPM_TAG} --access public"
 
           # Publish @jitsu/jitsu-react
           echo "Publishing @jitsu/jitsu-react..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/jitsu-react && npm publish --provenance --tag ${NPM_TAG} --access public"
+          PKG_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40jitsu%2Fjitsu-react" | jq -r '.token')
+          docker exec -e NODE_AUTH_TOKEN="${PKG_TOKEN}" builder sh -c "cd libs/jitsu-react && npm publish --tag ${NPM_TAG} --access public"
 
       - name: 🧹 Cleanup container
         if: always()

--- a/.github/workflows/client-libraries-build.yaml
+++ b/.github/workflows/client-libraries-build.yaml
@@ -19,9 +19,6 @@ on:
         required: false
         type: string
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: client-libraries-build-${{ github.ref }}
   cancel-in-progress: true
@@ -37,7 +34,7 @@ jobs:
     steps:
       - name: 📥 Checkout code
         if: ${{ !inputs.version }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -71,7 +68,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/client-libraries-build.yaml
+++ b/.github/workflows/client-libraries-build.yaml
@@ -84,7 +84,7 @@ jobs:
           FAILED=0
           for PKG in "@jitsu/protocols" "@jitsu/js" "@jitsu/jitsu-react"; do
             ENCODED=$(printf '%s' "$PKG" | sed 's/@/%40/g; s|/|%2F|g')
-            HTTP=$(curl -sf -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
+            HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
             if [ "${HTTP}" != "201" ]; then
               echo "ERROR: npm OIDC exchange failed (HTTP ${HTTP}) for ${PKG} - check trusted publisher config on npmjs.com"
               FAILED=1

--- a/.github/workflows/client-libraries-build.yaml
+++ b/.github/workflows/client-libraries-build.yaml
@@ -19,6 +19,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: client-libraries-build-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 60

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,9 @@ on:
       # todo - change with main
       - feat/newjitsu/self-hosted-revamped
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: 🐳 Build Docker Images

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,9 +5,6 @@ on:
       # todo - change with main
       - feat/newjitsu/self-hosted-revamped
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: 🐳 Build Docker Images
@@ -15,26 +12,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # The jitsu-builder container has Playwright browsers binaries preinstalled on this path:
   PLAYWRIGHT_BROWSERS_PATH: /root/.cache/ms-playwright
   BETA_BRANCH: newjitsu
@@ -27,13 +26,13 @@ jobs:
       packages: write
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
       - name: 🔍 Check changed files
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             playwright:
@@ -53,7 +52,7 @@ jobs:
 
       - name: 🚀 Setup Turbo cache
         if: steps.changes.outputs.nodejs == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .turbo
@@ -117,14 +116,14 @@ jobs:
       contents: read
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
 
       - name: 🔍 Check changed files
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             bulker:
@@ -168,7 +167,7 @@ jobs:
 
       - name: 📤 Upload test artifacts
         if: always() && steps.changes.outputs.bulker == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bulker-test-report
           path: |
@@ -187,7 +186,7 @@ jobs:
       packages: write
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 📝 Get short SHA
         id: short-sha

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # The jitsu-builder container has Playwright browsers binaries preinstalled on this path:
   PLAYWRIGHT_BROWSERS_PATH: /root/.cache/ms-playwright
   BETA_BRANCH: newjitsu

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -385,36 +385,31 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: 🔍 Validate NPM token
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - name: 🔍 Validate OIDC token and npm access
         run: |
-          echo "Validating NPM token..."
-          WHOAMI=$(curl -s -H "Authorization: Bearer ${NPM_TOKEN}" https://registry.npmjs.org/-/whoami)
-          echo "Authenticated as: ${WHOAMI}"
-          if [ -z "${WHOAMI}" ] || [ "${WHOAMI}" = "null" ]; then
-            echo "ERROR: Invalid NPM token"
+          OIDC_TOKEN=$(curl -sf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org" | jq -r '.value')
+          if [ -z "${OIDC_TOKEN}" ] || [ "${OIDC_TOKEN}" = "null" ]; then
+            echo "ERROR: Could not obtain OIDC token - check that id-token: write permission is set on this job"
             exit 1
           fi
+          echo "OIDC token obtained"
+          FAILED=0
+          for PKG in "jitsu-cli" "@jitsu/protocols" "@jitsu/functions-lib"; do
+            ENCODED=$(printf '%s' "$PKG" | sed 's/@/%40/g; s|/|%2F|g')
+            HTTP=$(curl -sf -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
+            if [ "${HTTP}" != "201" ]; then
+              echo "ERROR: npm OIDC exchange failed (HTTP ${HTTP}) for ${PKG} - check trusted publisher config on npmjs.com"
+              FAILED=1
+            else
+              echo "OK: ${PKG}"
+            fi
+          done
+          [ "${FAILED}" = "0" ] || exit 1
 
       - name: 🐳 Pull and start builder container
         run: |
           docker pull jitsucom/jitsu-builder:latest
           docker run -d --name builder -v ${{ github.workspace }}:/workspace -w /workspace -e CI=true jitsucom/jitsu-builder:latest tail -f /dev/null
-
-      - name: 🔐 Configure npm authentication
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: |
-          docker exec -e NPM_TOKEN builder sh -c "echo '//registry.npmjs.org/:_authToken='\${NPM_TOKEN} >> /workspace/.npmrc"
-
-      - name: 🔐 Validate npm authentication
-        run: |
-          docker exec builder npm whoami || {
-            echo "npm whoami failed, dumping debug logs:"
-            docker exec builder sh -c "cat /root/.npm/_logs/*.log"
-            exit 1
-          }
 
       - name: 📦 Fetch dependencies from store
         run: |
@@ -472,15 +467,15 @@ jobs:
 
           # Publish jitsu-cli
           echo "Publishing jitsu-cli..."
-          docker exec builder sh -c "cd cli/jitsu-cli && pnpm publish --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
-          
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd cli/jitsu-cli && pnpm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+
           # Publish @jitsu/protocols
           echo "Publishing @jitsu/protocols..."
-          docker exec builder sh -c "cd types/protocols && pnpm publish --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
-          
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && pnpm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+
           # Publish @jitsu/functions-lib
           echo "Publishing @jitsu/functions-lib..."
-          docker exec builder sh -c "cd libs/functions && pnpm publish --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/functions && pnpm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
 
       - name: 🧹 Cleanup container
         if: always()

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -449,14 +449,12 @@ jobs:
           CHANNEL: ${{ needs.version.outputs.channel }}
           DONT_PUBLISH: ${{ inputs.dont_publish }}
         run: |
-          # Determine NPM tag based on channel
           if [ "${CHANNEL}" = "stable" ]; then
             NPM_TAG="latest"
           else
             NPM_TAG="${CHANNEL}"
           fi
 
-          # Add --dry-run if dont_publish is true
           DRY_RUN_FLAG=""
           if [ "${DONT_PUBLISH}" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
@@ -465,17 +463,24 @@ jobs:
             echo "Publishing packages to NPM with tag: ${NPM_TAG}"
           fi
 
+          # Get OIDC token and set up .npmrc to use NODE_AUTH_TOKEN
+          OIDC_TOKEN=$(curl -sf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org" | jq -r '.value')
+          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> ${{ github.workspace }}/.npmrc
+
           # Publish jitsu-cli
           echo "Publishing jitsu-cli..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd cli/jitsu-cli && npm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+          PKG_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/jitsu-cli" | jq -r '.token')
+          docker exec -e NODE_AUTH_TOKEN="${PKG_TOKEN}" builder sh -c "cd cli/jitsu-cli && npm publish --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
 
           # Publish @jitsu/protocols
           echo "Publishing @jitsu/protocols..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && npm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+          PKG_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40jitsu%2Fprotocols" | jq -r '.token')
+          docker exec -e NODE_AUTH_TOKEN="${PKG_TOKEN}" builder sh -c "cd types/protocols && npm publish --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
 
           # Publish @jitsu/functions-lib
           echo "Publishing @jitsu/functions-lib..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/functions && npm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+          PKG_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40jitsu%2Ffunctions-lib" | jq -r '.token')
+          docker exec -e NODE_AUTH_TOKEN="${PKG_TOKEN}" builder sh -c "cd libs/functions && npm publish --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
 
       - name: 🧹 Cleanup container
         if: always()

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -467,15 +467,15 @@ jobs:
 
           # Publish jitsu-cli
           echo "Publishing jitsu-cli..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd cli/jitsu-cli && pnpm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd cli/jitsu-cli && npm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
 
           # Publish @jitsu/protocols
           echo "Publishing @jitsu/protocols..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && pnpm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd types/protocols && npm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
 
           # Publish @jitsu/functions-lib
           echo "Publishing @jitsu/functions-lib..."
-          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/functions && pnpm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
+          docker exec -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN builder sh -c "cd libs/functions && npm publish --provenance --tag ${NPM_TAG} --access public ${DRY_RUN_FLAG}"
 
       - name: 🧹 Cleanup container
         if: always()

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -396,7 +396,7 @@ jobs:
           FAILED=0
           for PKG in "jitsu-cli" "@jitsu/protocols" "@jitsu/functions-lib"; do
             ENCODED=$(printf '%s' "$PKG" | sed 's/@/%40/g; s|/|%2F|g')
-            HTTP=$(curl -sf -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
+            HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
             if [ "${HTTP}" != "201" ]; then
               echo "ERROR: npm OIDC exchange failed (HTTP ${HTTP}) for ${PKG} - check trusted publisher config on npmjs.com"
               FAILED=1

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -34,6 +34,9 @@ on:
         type: boolean
         default: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   # Use a shared concurrency group for both direct runs and calls from lint.yml
   # This ensures only one build runs per branch at a time

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -34,9 +34,6 @@ on:
         type: boolean
         default: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   # Use a shared concurrency group for both direct runs and calls from lint.yml
   # This ensures only one build runs per branch at a time
@@ -54,7 +51,7 @@ jobs:
       short_sha: ${{ steps.short-sha.outputs.sha }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -92,19 +89,19 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: cloud
           endpoint: "jitsucom/newjitsu"
@@ -188,20 +185,20 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
           submodules: true
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: cloud
           endpoint: "jitsucom/newjitsu"
@@ -273,7 +270,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -383,7 +380,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -3,6 +3,9 @@ name: Test Slack Notification
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: 🧪 Test All Block Types

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -3,16 +3,13 @@ name: Test Slack Notification
 on:
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   test:
     name: 🧪 Test All Block Types
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 💬 Send notification with all block types
         uses: ./.github/actions/slack-notify


### PR DESCRIPTION
## Summary

- Remove classic token auth (`NPM_PUBLISH_TOKEN`) — npm revoked all classic tokens Dec 2025
- Pass `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` into `docker exec` so npm CLI inside the builder container exchanges the OIDC token with the registry
- Add `--provenance` to all `pnpm publish` calls
- Add pre-flight OIDC validation: fetches token from GitHub, then probes the npm exchange endpoint for each published package to surface misconfiguration before the build starts

## Test plan

- [ ] Trigger `client-libraries-build.yaml` manually and verify "Validate OIDC token and npm access" step passes for all packages
- [ ] Verify packages publish successfully with provenance attestations