### PR TITLE
fix(ci): skip ai-review on bot PRs, switch security-fix to codex

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,6 +16,10 @@ on:
 
 jobs:
   ai-review:
+    # Skip auto-trigger for PRs opened by the bot. codex-action's write-access
+    # check calls the collaborators API which returns 'none' for app-bot actors,
+    # causing the review to fail. security-fix.yml dispatches the review manually
+    # for bot-opened PRs instead.
     if: github.actor != 'jitsu-code-review[bot]'
     uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.10.20260420
     secrets:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,8 +16,12 @@ on:
 
 jobs:
   ai-review:
-    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.4.20260416
-    secrets: inherit
+    if: github.actor != 'jitsu-code-review[bot]'
+    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.10.20260420
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AI_CODE_REVIEW_APP_ID: ${{ secrets.AI_CODE_REVIEW_APP_ID }}
+      AI_CODE_REVIEW_PRIVATE_KEY: ${{ secrets.AI_CODE_REVIEW_PRIVATE_KEY }}
     with:
       pr_number: ${{ inputs.pr_number }}
       commit_sha: ${{ inputs.commit_sha }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -20,7 +20,7 @@ jobs:
     # check calls the collaborators API which returns 'none' for app-bot actors,
     # causing the review to fail. security-fix.yml dispatches the review manually
     # for bot-opened PRs instead.
-    if: github.actor != 'jitsu-code-review[bot]'
+    if: github.event_name != 'pull_request' || github.actor != 'jitsu-code-review[bot]'
     uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.10.20260420
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -33,7 +33,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
 
     steps:
       - name: 📥 Checkout code
@@ -181,6 +180,9 @@ jobs:
 
       - name: 🔒 Fix vulnerabilities with Codex
         id: run-codex
+        # openai is a major vendor with a controlled release process; @v1 is a
+        # sufficient pin. SHA-pinning every OpenAI action update would be more
+        # overhead than the risk warrants.
         uses: openai/codex-action@v1
         env:
           GH_TOKEN: ${{ github.token }}
@@ -193,19 +195,28 @@ jobs:
           sandbox: danger-full-access
           codex-home: .github/codex/home
 
-      # ai-review.yml skips PRs opened by jitsu-code-review[bot] (codex-action's
-      # write-access check fails for app-bot actors). We dispatch it manually here
-      # so security PRs still get reviewed. This is safe to run over all open
-      # security/* PRs — this workflow is manual, so a re-review on an older PR
-      # is intentional and harmless.
-      - name: 🔍 Trigger AI review for security PRs
-        if: ${{ inputs.dry_run != true }}
+  # Separate job so actions: write is not available to the Codex step above.
+  # ai-review.yml skips PRs opened by jitsu-code-review[bot] (codex-action's
+  # write-access check fails for app-bot actors), so we dispatch it manually.
+  # Running over all open security/* PRs is intentional — this workflow is
+  # manual, so a re-review on an older PR is harmless.
+  trigger-review:
+    name: 🔍 Trigger AI Review
+    needs: scan-and-fix
+    if: ${{ inputs.dry_run != true }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch AI review for open security PRs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr list --base newjitsu --state open --json number,headRefName \
+          gh pr list --repo ${{ github.repository }} --base newjitsu --state open \
+            --json number,headRefName \
             --jq '[.[] | select(.headRefName | startswith("security/")) | .number | tostring] | .[]' \
           | while IFS= read -r num; do
               echo "Dispatching AI review for PR #$num"
-              gh workflow run ai-review.yml --ref newjitsu -f pr_number="$num"
+              gh workflow run ai-review.yml --repo ${{ github.repository }} --ref newjitsu -f pr_number="$num"
             done
+

--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -103,21 +103,14 @@ jobs:
             }]' > /tmp/dependabot-alerts.json 2>/dev/null || echo '[]' > /tmp/dependabot-alerts.json
           echo "Dependabot alerts: $(jq length /tmp/dependabot-alerts.json)"
 
-      - name: 🤖 Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
-
-      - name: 🔒 Fix vulnerabilities with Claude
+      - name: 📝 Write Codex prompt
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           MIN_SEVERITY: ${{ inputs.severity || 'moderate' }}
           REPO: ${{ github.repository }}
         run: |
-          cat << PROMPT | claude --print \
-            --allowedTools "Bash(cat:*),Bash(jq:*),Bash(pnpm:*),Bash(go:*),Bash(git:*),Bash(gh:*),Bash(grep:*),Bash(head:*),Bash(npm:*)" \
-            --model claude-haiku-4-5-20251001
+          mkdir -p .github/codex
+          cat > .github/codex/security-fix.prompt.md << PROMPT_EOF
           You are a security engineer fixing dependency vulnerabilities in a monorepo.
 
           ## Context
@@ -140,10 +133,10 @@ jobs:
           2. For each vulnerability (or group of trivial same-ecosystem patches):
 
              a. **Analyze the fix**:
-                - Check if the package is a direct dependency (`grep` in package.json files) or transitive.
-                - For transitive deps: use pnpm overrides in root package.json (pattern: `"pkg@<fixed_version": "^fixed_version"`).
+                - Check if the package is a direct dependency (grep in package.json files) or transitive.
+                - For transitive deps: use pnpm overrides in root package.json (pattern: "pkg@<fixed_version": "^fixed_version").
                 - For direct deps: bump the version in the relevant package.json.
-                - For Go deps: run `go -C bulker/modulename get pkg@version && go -C bulker/modulename mod tidy`.
+                - For Go deps: run go -C bulker/modulename get pkg@version && go -C bulker/modulename mod tidy.
                 - Check if the fixed version is a major version bump. If so:
                   - Check the package's changelog/migration guide.
                   - Verify the new version's API is compatible.
@@ -151,24 +144,24 @@ jobs:
                   - If the major bump is risky, create the PR but mark it as needing manual review.
 
              b. **Apply the fix**:
-                - Create a branch: `security/fix-{package-name}` (or `security/fix-batch-{date}` for grouped trivial patches).
+                - Create a branch: security/fix-{package-name} (or security/fix-batch-{date} for grouped trivial patches).
                 - Make the changes.
-                - For Node.js: run `pnpm install` to update the lockfile.
-                - For Go: run `go mod tidy` in affected modules.
-                - Commit with message: `fix(security): upgrade {package} to {version} ({CVE})`
+                - For Node.js: run pnpm install to update the lockfile.
+                - For Go: run go mod tidy in affected modules.
+                - Commit with message: fix(security): upgrade {package} to {version} ({CVE})
 
              c. **Create a PR** (unless DRY_RUN is true):
-                - Title: `fix(security): {package} {CVE} ({severity})`
+                - Title: fix(security): {package} {CVE} ({severity})
                 - Body should include:
                   - CVE ID and severity
                   - What the vulnerability is (1 sentence)
                   - What was changed (override vs direct bump vs Go module update)
                   - Whether this is a major version bump
                   - Any breaking changes or risks noted
-                - Use: `gh pr create --base newjitsu --title "..." --body "..."`
+                - Use: gh pr create --base newjitsu --title "..." --body "..."
 
              d. **Reset** back to newjitsu before the next fix:
-                `git checkout newjitsu && git reset --hard origin/newjitsu`
+                git checkout newjitsu && git reset --hard origin/newjitsu
 
           3. Group trivial patches together: if multiple vulnerabilities can be fixed by
              simple pnpm overrides with no major version bumps, batch them into one PR.
@@ -179,8 +172,34 @@ jobs:
           ## Important rules
           - NEVER force push or modify the newjitsu branch directly.
           - Always create a NEW branch for each PR.
-          - Run `pnpm install` after modifying package.json to verify the fix works.
-          - If `pnpm install` fails after a fix, revert and skip that vulnerability.
-          - For Go modules, use `go -C bulker/modulename` to run in the module directory.
-          - Check existing open PRs with `gh pr list --search "security"` to avoid duplicates.
-          PROMPT
+          - Run pnpm install after modifying package.json to verify the fix works.
+          - If pnpm install fails after a fix, revert and skip that vulnerability.
+          - For Go modules, use go -C bulker/modulename to run in the module directory.
+          - Check existing open PRs with gh pr list --search "security" to avoid duplicates.
+          PROMPT_EOF
+
+      - name: 🔒 Fix vulnerabilities with Codex
+        id: run-codex
+        uses: openai/codex-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/security-fix.prompt.md
+          model: gpt-5.3-codex
+          effort: high
+          sandbox: danger-full-access
+          codex-home: .github/codex/home
+
+      - name: 🔍 Trigger AI review for security PRs
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr list --base newjitsu --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("security/")) | .number | tostring] | .[]' \
+          | while IFS= read -r num; do
+              echo "Dispatching AI review for PR #$num"
+              gh workflow run ai-review.yml --ref newjitsu -f pr_number="$num" || true
+            done

--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     steps:
       - name: 📥 Checkout code
@@ -201,5 +202,5 @@ jobs:
             --jq '[.[] | select(.headRefName | startswith("security/")) | .number | tostring] | .[]' \
           | while IFS= read -r num; do
               echo "Dispatching AI review for PR #$num"
-              gh workflow run ai-review.yml --ref newjitsu -f pr_number="$num" || true
+              gh workflow run ai-review.yml --ref newjitsu -f pr_number="$num"
             done

--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -193,6 +193,11 @@ jobs:
           sandbox: danger-full-access
           codex-home: .github/codex/home
 
+      # ai-review.yml skips PRs opened by jitsu-code-review[bot] (codex-action's
+      # write-access check fails for app-bot actors). We dispatch it manually here
+      # so security PRs still get reviewed. This is safe to run over all open
+      # security/* PRs — this workflow is manual, so a re-review on an older PR
+      # is intentional and harmless.
       - name: 🔍 Trigger AI review for security PRs
         if: ${{ inputs.dry_run != true }}
         env:

--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -207,6 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      pull-requests: read
     steps:
       - name: Dispatch AI review for open security PRs
         env:


### PR DESCRIPTION
## Changes

### `ai-review.yml`
- Skip auto-trigger when actor is `jitsu-code-review[bot]` — the bot's PRs fail
  `codex-action`'s write-access check because app bots aren't GitHub collaborators
- Replace `secrets: inherit` with explicit secret passing
- Bump shared workflow pin to `1.10.20260420` (adds explicit `secrets:` declaration
  + skips review on merge commits)

### `security-fix.yml`
- Replace Claude CLI with `openai/codex-action@v1` (`gpt-5.3-codex`, `effort: high`,
  `sandbox: danger-full-access`)
- After Codex creates PRs, dispatch `ai-review.yml` explicitly for each open
  `security/*` PR (since the auto-trigger is now skipped for bot-opened PRs)