### PR TITLE
fix(ci): skip beta publish when no relevant code changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -235,7 +235,29 @@ jobs:
     permissions:
       actions: write
     steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🔍 Check changed files
+        id: changes
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            services:
+              - 'bulker/**'          # bulker/ingest/syncctl/… Go images
+              - 'services/**'        # rotor and functions-server images
+              - 'webapps/**'         # console image
+              - 'libs/**'            # libs/functions (→ @jitsu/functions-lib NPM),
+                                     # libs/juava (→ jitsu-cli), libs/jitsu-js/react (→ console)
+              - 'cli/**'             # jitsu-cli NPM package
+              - 'types/**'           # @jitsu/protocols — imported by services and functions-lib
+              - 'all.Dockerfile'     # multi-stage build file for console/rotor/functions-server
+              - '.services.version.json'  # explicit version bump → always publish
+              - 'pnpm-lock.yaml'     # any dep change can affect build output
+              - '.github/workflows/services-build.yaml'  # re-test if the build workflow itself changes
+
       - name: 🚀 Trigger services-build workflow
+        if: steps.changes.outputs.services == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -251,7 +273,24 @@ jobs:
     permissions:
       actions: write
     steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🔍 Check changed files
+        id: changes
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            client-libs:
+              - 'libs/jitsu-js/**'       # @jitsu/js — the main browser SDK
+              - 'libs/jitsu-react/**'    # @jitsu/jitsu-react — depends on @jitsu/js
+              - 'types/**'               # @jitsu/protocols — peer-dep of @jitsu/js
+              - '.jsclient.version.json' # explicit version bump → always publish
+              - 'pnpm-lock.yaml'         # any dep change can affect build output
+              - '.github/workflows/client-libraries-build.yaml'  # re-test if build workflow changes
+
       - name: 🚀 Trigger client-libraries-build workflow
+        if: steps.changes.outputs.client-libs == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -287,6 +287,7 @@ jobs:
               - 'libs/jitsu-js/**'       # @jitsu/js — the main browser SDK
               - 'libs/jitsu-react/**'    # @jitsu/jitsu-react — depends on @jitsu/js
               - 'types/**'               # @jitsu/protocols — peer-dep of @jitsu/js
+              - 'libs/common-config/**'  # common config for all client libs (eslint, tsconfig, build scripts)
               - '.jsclient.version.json' # explicit version bump → always publish
               - 'pnpm-lock.yaml'         # any dep change can affect build output
               - '.github/workflows/client-libraries-build.yaml'  # re-test if build workflow changes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -257,7 +257,7 @@ jobs:
               - '.github/workflows/services-build.yaml'  # re-test if the build workflow itself changes
 
       - name: 🚀 Trigger services-build workflow
-        if: false && steps.changes.outputs.services == 'true'
+        if: steps.changes.outputs.services == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -290,7 +290,7 @@ jobs:
               - '.github/workflows/client-libraries-build.yaml'  # re-test if build workflow changes
 
       - name: 🚀 Trigger client-libraries-build workflow
-        if: false && steps.changes.outputs.client-libs == 'true'
+        if: steps.changes.outputs.client-libs == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -257,7 +257,7 @@ jobs:
               - '.github/workflows/services-build.yaml'  # re-test if the build workflow itself changes
 
       - name: 🚀 Trigger services-build workflow
-        if: steps.changes.outputs.services == 'true'
+        if: false && steps.changes.outputs.services == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -290,7 +290,7 @@ jobs:
               - '.github/workflows/client-libraries-build.yaml'  # re-test if build workflow changes
 
       - name: 🚀 Trigger client-libraries-build workflow
-        if: steps.changes.outputs.client-libs == 'true'
+        if: false && steps.changes.outputs.client-libs == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -236,6 +236,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v6
@@ -274,6 +275,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v6
@@ -293,7 +295,7 @@ jobs:
               - '.github/workflows/client-libraries-build.yaml'  # re-test if build workflow changes
 
       - name: 🚀 Trigger client-libraries-build workflow
-        if: steps.changes.outputs.client-libs == 'true'
+        if: steps.changes.outputs['client-libs'] == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,9 @@
 name: 🧪Lint and Test
 on:
-  push:
   pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [newjitsu]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [newjitsu]
+    branches: [newjitsu, stable-services, stable-jsclient]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Problem

`lint.yml` triggers `services-build` and `client-libraries-build` on **every push** to `newjitsu` via `gh workflow run`. This fires even for doc changes, test fixes, or other unrelated commits — producing noisy beta releases (was happening 4-5x/day for unrelated changes).

## Solution

Add `dorny/paths-filter` to the `deploy` and `deploy-client-libraries` jobs and gate the `gh workflow run` call on whether files that actually affect the built artifacts changed.

**Services build triggers on:**
- `bulker/**` — Go images (bulker, ingest, syncctl, …)
- `services/**` — rotor and functions-server images
- `webapps/**` — console image
- `libs/**` — functions-lib (→ NPM), juava (→ jitsu-cli), jitsu-js/react (→ console)
- `cli/**` — jitsu-cli NPM package
- `types/**` — @jitsu/protocols, imported by services and functions-lib
- `all.Dockerfile` — multi-stage build file for Node services
- `.services.version.json` — explicit version bump
- `pnpm-lock.yaml` — dep changes affect build output
- `.github/workflows/services-build.yaml` — re-test if the build workflow changes

**Client libraries build triggers on:**
- `libs/jitsu-js/**` — @jitsu/js
- `libs/jitsu-react/**` — @jitsu/jitsu-react (depends on @jitsu/js)
- `types/**` — @jitsu/protocols (peer-dep of @jitsu/js)
- `.jsclient.version.json` — explicit version bump
- `pnpm-lock.yaml` — dep changes affect build output
- `.github/workflows/client-libraries-build.yaml` — re-test if the build workflow changes