### PR TITLE
feat(console): user API tokens — type, name, expiration; audit-log origin

### DIFF
--- a/dev-scripts/src/bin/run-app.ts
+++ b/dev-scripts/src/bin/run-app.ts
@@ -17,11 +17,13 @@
  */
 import { spawn, spawnSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const requireFromHere = createRequire(import.meta.url);
 
 /**
  * Scratch dir we run portless from. Why:
@@ -78,6 +80,46 @@ function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
+/**
+ * Rewrite bare `--require=NAME` / `-r NAME` entries in NODE_OPTIONS to absolute
+ * paths. Bare names break in spawned children whose cwd is outside any
+ * `node_modules` chain (here: SHIM_DIR for portless). Unresolvable names are
+ * left alone — Node will surface the original error in context.
+ */
+function absolutizeRequires(nodeOptions: string | undefined, resolver: NodeRequire): string | undefined {
+  if (!nodeOptions) return nodeOptions;
+  // Tokenize on whitespace; NODE_OPTIONS values don't support shell quoting.
+  const tokens = nodeOptions.split(/\s+/).filter(Boolean);
+  const out: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    const eqMatch = t.match(/^(--require|-r)=(.+)$/);
+    if (eqMatch) {
+      out.push(`${eqMatch[1]}=${tryResolve(eqMatch[2], resolver)}`);
+      continue;
+    }
+    if (t === "--require" || t === "-r") {
+      const next = tokens[i + 1];
+      if (next) {
+        out.push(t, tryResolve(next, resolver));
+        i++;
+        continue;
+      }
+    }
+    out.push(t);
+  }
+  return out.join(" ");
+}
+
+function tryResolve(spec: string, resolver: NodeRequire): string {
+  if (path.isAbsolute(spec) || spec.startsWith("./") || spec.startsWith("../")) return spec;
+  try {
+    return resolver.resolve(spec);
+  } catch {
+    return spec;
+  }
+}
+
 function main(): void {
   const argv = process.argv.slice(2);
   const noBranch = argv.includes("--no-branch");
@@ -118,9 +160,16 @@ function main(): void {
     })`
   );
 
+  // Resolve `--require=env-preload` (set globally via root .npmrc) to an
+  // absolute path so it survives the cwd switch into SHIM_DIR. Without this,
+  // portless starts from SHIM_DIR (no node_modules → no `env-preload`) and
+  // dies in `loadPreloadModules` before bash ever runs the inner command.
+  const resolvedNodeOptions = absolutizeRequires(process.env.NODE_OPTIONS, requireFromHere);
+
   const child = spawn("portless", ["--name", slug, "bash", "-c", innerCmd], {
     cwd: SHIM_DIR,
     stdio: "inherit",
+    env: { ...process.env, NODE_OPTIONS: resolvedNodeOptions },
   });
   child.on("error", err => {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {

--- a/webapps/console/components/AuditLog/AuditLog.tsx
+++ b/webapps/console/components/AuditLog/AuditLog.tsx
@@ -7,6 +7,7 @@ import { rpc } from "juava";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { AuditLogDiff } from "../AuditLogDiff/AuditLogDiff";
+import { inferTokenTypeFromId } from "../../lib/schema";
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
@@ -30,6 +31,8 @@ export type AuditLogItem = {
   userId?: string | null;
   objectId?: string | null;
   authType?: string | null;
+  tokenId?: string | null;
+  token?: { id: string; type?: string | null; name?: string | null } | null;
   changes?: any;
   diff?: DiffEntry[];
   actor?: { id: string; email?: string | null; name?: string | null } | null;
@@ -61,6 +64,41 @@ function severityTag(s?: string | null) {
   if (!s) return null;
   const color = s === "security" ? "red" : s === "warning" ? "orange" : "default";
   return <Tag color={color}>{s}</Tag>;
+}
+
+/**
+ * authType values written by the auth/audit code:
+ *   "next-auth", "oidc", "firebase", "credentials" → user-driven UI session
+ *   "bearer" → API token (cli, api, …)
+ * Older rows may have other values; treat unknowns as UI to avoid claiming a
+ * change came over the API when we don't know.
+ */
+const UI_AUTH_TYPES = new Set(["next-auth", "oidc", "firebase", "credentials"]);
+
+function originTag(item: AuditLogItem) {
+  if (!item.authType) {
+    return <span className="text-text-light">—</span>;
+  }
+  if (item.authType !== "bearer") {
+    return (
+      <Tooltip title={`Auth: ${item.authType}`}>
+        <Tag color={UI_AUTH_TYPES.has(item.authType) ? "blue" : "default"}>UI</Tag>
+      </Tooltip>
+    );
+  }
+  // Bearer auth — derive token type from token row (preferred) or id prefix.
+  const inferredType = item.token?.type || (item.tokenId ? inferTokenTypeFromId(item.tokenId) : "api");
+  const label = `API: ${inferredType}`;
+  const tooltip = item.token?.name
+    ? `${item.token.name} (${item.tokenId})`
+    : item.tokenId
+    ? item.tokenId
+    : "Bearer token";
+  return (
+    <Tooltip title={tooltip}>
+      <Tag color="purple">{label}</Tag>
+    </Tooltip>
+  );
 }
 
 function entityHref(objectType: string | undefined, objectId?: string | null): string | null {
@@ -261,6 +299,11 @@ export const AuditLog: React.FC<AuditLogProps> = ({ workspaceId, workspaceSlug, 
         title: "Actor",
         key: "actor",
         render: (_: any, item: AuditLogItem) => item.actor?.email || item.actor?.name || "—",
+      },
+      {
+        title: "Origin",
+        key: "origin",
+        render: (_: any, item: AuditLogItem) => originTag(item),
       },
       {
         title: "Event",

--- a/webapps/console/components/AuditLog/AuditLog.tsx
+++ b/webapps/console/components/AuditLog/AuditLog.tsx
@@ -8,6 +8,8 @@ import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { AuditLogDiff } from "../AuditLogDiff/AuditLogDiff";
 import { inferTokenTypeFromId } from "../../lib/schema";
+import { FaTerminal } from "react-icons/fa";
+import { FaCloudArrowUp, FaWindowMaximize } from "react-icons/fa6";
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
@@ -68,35 +70,42 @@ function severityTag(s?: string | null) {
 
 /**
  * authType values written by the auth/audit code:
- *   "next-auth", "oidc", "firebase", "credentials" → user-driven UI session
- *   "bearer" → API token (cli, api, …)
- * Older rows may have other values; treat unknowns as UI to avoid claiming a
- * change came over the API when we don't know.
+ *   "next-auth", "oidc", "firebase", "credentials" → UI session
+ *   "bearer" → API token; the row also carries a tokenType ("api" | "cli" | …)
+ * Origin renders as one of three flat labels: UI / API / CLI. Other token
+ * types fall through to their raw label so we don't quietly silo them.
  */
-const UI_AUTH_TYPES = new Set(["next-auth", "oidc", "firebase", "credentials"]);
+type Origin = { label: string; color: string; icon: React.ReactNode };
+
+const ORIGIN_UI: Origin = { label: "UI", color: "geekblue", icon: <FaWindowMaximize /> };
+const ORIGIN_API: Origin = { label: "API", color: "purple", icon: <FaCloudArrowUp /> };
+const ORIGIN_CLI: Origin = { label: "CLI", color: "blue", icon: <FaTerminal /> };
+
+function resolveOrigin(item: AuditLogItem): Origin | null {
+  if (!item.authType) return null;
+  if (item.authType !== "bearer") return ORIGIN_UI;
+  const tokenType = item.token?.type || (item.tokenId ? inferTokenTypeFromId(item.tokenId) : "api");
+  if (tokenType === "cli") return ORIGIN_CLI;
+  if (tokenType === "api") return ORIGIN_API;
+  // Unknown bearer subtype — surface it verbatim rather than collapsing to API.
+  return { label: tokenType.toUpperCase(), color: "default", icon: <FaCloudArrowUp /> };
+}
 
 function originTag(item: AuditLogItem) {
-  if (!item.authType) {
-    return <span className="text-text-light">—</span>;
-  }
-  if (item.authType !== "bearer") {
-    return (
-      <Tooltip title={`Auth: ${item.authType}`}>
-        <Tag color={UI_AUTH_TYPES.has(item.authType) ? "blue" : "default"}>UI</Tag>
-      </Tooltip>
-    );
-  }
-  // Bearer auth — derive token type from token row (preferred) or id prefix.
-  const inferredType = item.token?.type || (item.tokenId ? inferTokenTypeFromId(item.tokenId) : "api");
-  const label = `API: ${inferredType}`;
-  const tooltip = item.token?.name
-    ? `${item.token.name} (${item.tokenId})`
-    : item.tokenId
-    ? item.tokenId
-    : "Bearer token";
+  const origin = resolveOrigin(item);
+  if (!origin) return <span className="text-text-light">—</span>;
+  const tooltip =
+    item.authType === "bearer"
+      ? item.token?.name
+        ? `${item.token.name} (${item.tokenId})`
+        : item.tokenId || "Bearer token"
+      : `Auth: ${item.authType}`;
   return (
     <Tooltip title={tooltip}>
-      <Tag color="purple">{label}</Tag>
+      <Tag color={origin.color} className="inline-flex items-center gap-1">
+        <span className="inline-flex items-center">{origin.icon}</span>
+        <span>{origin.label}</span>
+      </Tag>
     </Tooltip>
   );
 }

--- a/webapps/console/lib/api.ts
+++ b/webapps/console/lib/api.ts
@@ -3,7 +3,7 @@ import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 import { assertDefined, checkHash, checkRawToken, getErrorMessage, requireDefined, tryJson } from "juava";
 import { getServerSession, Session } from "next-auth";
 import { nextAuthConfig } from "./nextauth.config";
-import { SessionUser } from "./schema";
+import { inferTokenTypeFromId, SessionUser } from "./schema";
 import { db } from "./server/db";
 import { prepareZodObjectForDeserialization, safeParseWithDate } from "./zod";
 import { ApiError } from "./shared/errors";
@@ -277,6 +277,9 @@ export async function getUser(
       if (!checkHash(token.hash, secret)) {
         throw new ApiError(`Invalid API key secret for ${keyId}`, { keyId }, { status: 401 });
       }
+      if (token.expiresAt && token.expiresAt.getTime() < Date.now()) {
+        throw new ApiError(`API key ${keyId} has expired`, { keyId }, { status: 401 });
+      }
       const user = requireDefined(
         await db.prisma().userProfile.findUnique({ where: { id: token.userId } }),
         `Can't find user ${token.userId} for API key ${keyId}`
@@ -290,6 +293,8 @@ export async function getUser(
         email: user.email,
         name: user.name,
         authType: "bearer",
+        tokenId: token.id,
+        tokenType: token.type ?? inferTokenTypeFromId(token.id),
       };
     }
   }

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -13,6 +13,10 @@ export const SessionUser = z.object({
   externalUsername: z.string().nullish(),
   mustChangePassword: z.boolean().nullish(),
   authType: z.string().nullish().optional(),
+  // Set only when authType === "bearer". Identifies which UserApiToken row was used.
+  tokenId: z.string().nullish().optional(),
+  // Set only when authType === "bearer". Mirrors UserApiToken.type ("api", "cli", ...).
+  tokenType: z.string().nullish().optional(),
 });
 export type SessionUser = z.infer<typeof SessionUser>;
 
@@ -145,8 +149,21 @@ export const ApiKey = z.object({
   createdAt: z.coerce.date().nullish(),
   lastUsed: z.coerce.date().nullish(),
   id: z.string(),
+  type: z.string().nullish(),
+  name: z.string().nullish(),
+  expiresAt: z.coerce.date().nullish(),
 });
 export type ApiKey = z.infer<typeof ApiKey>;
+
+/**
+ * Legacy keys created before UserApiToken.type existed have no stored type.
+ * Recover one from the id prefix used by jitsu-cli (`jitsu-cli-...`); everything
+ * else falls back to "api". Pure function — safe to import from client code.
+ */
+export function inferTokenTypeFromId(id: string): string {
+  if (id.startsWith("jitsu-cli-")) return "cli";
+  return "api";
+}
 
 export const StreamConfig = ConfigEntityBase.merge(
   z.object({

--- a/webapps/console/lib/server/audit-log.ts
+++ b/webapps/console/lib/server/audit-log.ts
@@ -202,6 +202,7 @@ export async function configObjectAuditLog(
         objectId: id,
         userId: user.internalId,
         authType: user.authType,
+        tokenId: user.tokenId ?? null,
         changes: {
           _redacted: true,
           objectType: type,
@@ -256,7 +257,7 @@ const membershipEventToType: Record<MembershipOp, AccountAlertEventType> = {
 };
 
 export async function membershipAuditLog(
-  actor: Pick<SessionUser, "internalId" | "email" | "name" | "authType"> | null,
+  actor: Pick<SessionUser, "internalId" | "email" | "name" | "authType" | "tokenId"> | null,
   workspaceId: string,
   op: MembershipOp,
   target: { userId?: string; email?: string },
@@ -276,6 +277,7 @@ export async function membershipAuditLog(
         userId: actor?.internalId ?? null,
         objectId: target.userId ?? null,
         authType: actor?.authType ?? null,
+        tokenId: actor?.tokenId ?? null,
         timestamp: occurredAt,
         changes: {
           actorEmail: actor?.email,
@@ -308,7 +310,7 @@ export async function membershipAuditLog(
 }
 
 export async function workspaceAuditLog(
-  actor: Pick<SessionUser, "internalId" | "email" | "name" | "authType">,
+  actor: Pick<SessionUser, "internalId" | "email" | "name" | "authType" | "tokenId">,
   workspaceId: string,
   op: "updated" | "deleted",
   changes?: { prevVersion?: any; newVersion?: any; workspaceName?: string }
@@ -327,6 +329,7 @@ export async function workspaceAuditLog(
         workspaceId,
         userId: actor.internalId,
         authType: actor.authType,
+        tokenId: actor.tokenId ?? null,
         timestamp: occurredAt,
         changes: {
           actorEmail: actor.email,

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -231,6 +231,15 @@ const ItemSchema = z.object({
   userId: z.string().nullable().optional(),
   objectId: z.string().nullable().optional(),
   authType: z.string().nullable().optional(),
+  tokenId: z.string().nullable().optional(),
+  token: z
+    .object({
+      id: z.string(),
+      type: z.string().nullable().optional(),
+      name: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
   changes: z.any().nullable().optional(),
   diff: z
     .array(
@@ -374,6 +383,16 @@ export default createRoute()
       : [];
     const workspaceById = new Map(workspaces.map(w => [w.id, w]));
 
+    // Bulk-fetch token metadata for rows that were authored via bearer auth.
+    const tokenIds = Array.from(new Set(page.map(r => r.tokenId).filter((v): v is string => !!v)));
+    const tokens = tokenIds.length
+      ? await db.prisma().userApiToken.findMany({
+          where: { id: { in: tokenIds } },
+          select: { id: true, type: true, name: true },
+        })
+      : [];
+    const tokenById = new Map(tokens.map(t => [t.id, t]));
+
     // Enrich link (connection) display names: a link has no `name` of its own,
     // so we synthesize "<from.name> → <to.name>" from the related entities.
     const linkIds = Array.from(
@@ -453,6 +472,8 @@ export default createRoute()
 
         const ws = r.workspaceId ? workspaceById.get(r.workspaceId) : undefined;
 
+        const token = r.tokenId ? tokenById.get(r.tokenId) ?? null : null;
+
         return {
           id: r.id,
           timestamp: r.timestamp.toISOString(),
@@ -463,6 +484,8 @@ export default createRoute()
           userId: r.userId ?? null,
           objectId: r.objectId ?? null,
           authType: r.authType ?? null,
+          tokenId: r.tokenId ?? null,
+          token,
           changes: finalChanges,
           diff,
           actor: r.userId ? actorById.get(r.userId) ?? null : null,

--- a/webapps/console/pages/api/user/cli-key.ts
+++ b/webapps/console/pages/api/user/cli-key.ts
@@ -4,6 +4,8 @@ import { db } from "../../../lib/server/db";
 import { hint, randomId } from "juava";
 import { createHash } from "juava";
 
+const CLI_KEY_EXPIRATION_DAYS = 90;
+
 const api: Api = {
   url: inferUrl(__filename),
   GET: {
@@ -11,18 +13,23 @@ const api: Api = {
     types: {
       result: ApiKey,
     },
-    handle: async ({ user, req, res }) => {
+    handle: async ({ user }) => {
       const newKey = randomId(32);
-      const key = { id: `jitsu-cli-${randomId(22)}`, plaintext: newKey };
-      const toCreate = {
-        id: key.id,
-        userId: user.internalId,
-        hint: hint(newKey),
-        hash: createHash(newKey),
-      };
-      await db.prisma().userApiToken.create({ data: toCreate });
-
-      return key;
+      const id = `jitsu-cli-${randomId(22)}`;
+      const expiresAt = new Date();
+      expiresAt.setDate(expiresAt.getDate() + CLI_KEY_EXPIRATION_DAYS);
+      await db.prisma().userApiToken.create({
+        data: {
+          id,
+          userId: user.internalId,
+          hint: hint(newKey),
+          hash: createHash(newKey),
+          type: "cli",
+          name: "jitsu-cli",
+          expiresAt,
+        },
+      });
+      return { id, plaintext: newKey, expiresAt, type: "cli", name: "jitsu-cli" };
     },
   },
 };

--- a/webapps/console/pages/api/user/keys.ts
+++ b/webapps/console/pages/api/user/keys.ts
@@ -1,9 +1,17 @@
 import { Api, inferUrl, nextJsApiHandler } from "../../../lib/api";
+import { ApiError } from "../../../lib/shared/errors";
 import { ApiKey } from "../../../lib/schema";
 import { z } from "zod";
 import { db } from "../../../lib/server/db";
-import { hint } from "juava";
-import { createHash, requireDefined } from "juava";
+import { hint, randomId } from "juava";
+import { createHash } from "juava";
+
+const CreateKeyBody = z.object({
+  name: z.string().optional(),
+  type: z.string().optional(),
+  // ISO date or null. If null/missing → never expires.
+  expiresAt: z.coerce.date().nullish(),
+});
 
 const api: Api = {
   url: inferUrl(__filename),
@@ -15,38 +23,64 @@ const api: Api = {
     handle: async ({ user }) => {
       return await db.prisma().userApiToken.findMany({
         where: { userId: user.internalId },
-        select: { id: true, hint: true, createdAt: true, lastUsed: true },
+        select: {
+          id: true,
+          hint: true,
+          createdAt: true,
+          lastUsed: true,
+          type: true,
+          name: true,
+          expiresAt: true,
+        },
+        orderBy: { createdAt: "desc" },
       });
     },
   },
   POST: {
     auth: true,
     types: {
-      body: z.array(ApiKey),
-      result: z.array(ApiKey),
+      body: CreateKeyBody,
+      result: ApiKey,
     },
     handle: async ({ user, body }) => {
-      const currentKeys = await db.prisma().userApiToken.findMany({
-        where: { userId: user.internalId },
-        select: { id: true },
+      const plaintext = randomId(32);
+      const id = randomId(32);
+      const created = await db.prisma().userApiToken.create({
+        data: {
+          id,
+          userId: user.internalId,
+          hint: hint(plaintext),
+          hash: createHash(plaintext),
+          type: body.type ?? "api",
+          name: body.name ?? null,
+          expiresAt: body.expiresAt ?? null,
+        },
       });
-      const toDelete = currentKeys.filter(k => !body.find(b => b.id === k.id)).map(k => k.id);
-      const toCreate = body
-        .filter(b => !currentKeys.find(k => k.id === b.id))
-        .map(b => {
-          const plaintext = requireDefined(b.plaintext, `key ${JSON.stringify(b)} expected to contain plaintext`);
-          return {
-            id: b.id,
-            userId: user.internalId,
-            hint: hint(plaintext),
-            hash: createHash(plaintext),
-          };
-        });
-
-      await db.prisma().userApiToken.deleteMany({ where: { id: { in: toDelete } } });
-      await db.prisma().userApiToken.createMany({ data: toCreate });
-
-      return currentKeys;
+      return {
+        id: created.id,
+        plaintext,
+        hint: created.hint,
+        createdAt: created.createdAt,
+        lastUsed: created.lastUsed,
+        type: created.type,
+        name: created.name,
+        expiresAt: created.expiresAt,
+      };
+    },
+  },
+  DELETE: {
+    auth: true,
+    types: {
+      query: z.object({ id: z.string() }),
+      result: z.object({ ok: z.boolean() }),
+    },
+    handle: async ({ user, query }) => {
+      const existing = await db.prisma().userApiToken.findUnique({ where: { id: query.id } });
+      if (!existing || existing.userId !== user.internalId) {
+        throw new ApiError(`Key not found`, {}, { status: 404 });
+      }
+      await db.prisma().userApiToken.delete({ where: { id: query.id } });
+      return { ok: true };
     },
   },
 };

--- a/webapps/console/pages/api/user/keys.ts
+++ b/webapps/console/pages/api/user/keys.ts
@@ -68,6 +68,39 @@ const api: Api = {
       };
     },
   },
+  PATCH: {
+    auth: true,
+    types: {
+      query: z.object({ id: z.string() }),
+      body: z.object({
+        name: z.string().nullish(),
+        // ISO date, null, or omitted. Null = clear (never expires); omitted = leave alone.
+        expiresAt: z.coerce.date().nullish(),
+      }),
+      result: ApiKey,
+    },
+    handle: async ({ user, query, body }) => {
+      const existing = await db.prisma().userApiToken.findUnique({ where: { id: query.id } });
+      if (!existing || existing.userId !== user.internalId) {
+        throw new ApiError(`Key not found`, {}, { status: 404 });
+      }
+      // `expiresAt` is tri-state on the wire: present-as-Date sets, present-as-null
+      // clears, missing leaves the column alone. Same for `name`.
+      const data: { name?: string | null; expiresAt?: Date | null } = {};
+      if (Object.prototype.hasOwnProperty.call(body, "name")) data.name = body.name ?? null;
+      if (Object.prototype.hasOwnProperty.call(body, "expiresAt")) data.expiresAt = body.expiresAt ?? null;
+      const updated = await db.prisma().userApiToken.update({ where: { id: query.id }, data });
+      return {
+        id: updated.id,
+        hint: updated.hint,
+        createdAt: updated.createdAt,
+        lastUsed: updated.lastUsed,
+        type: updated.type,
+        name: updated.name,
+        expiresAt: updated.expiresAt,
+      };
+    },
+  },
   DELETE: {
     auth: true,
     types: {

--- a/webapps/console/pages/user.tsx
+++ b/webapps/console/pages/user.tsx
@@ -31,7 +31,11 @@ function choiceToDate(c: ExpirationChoice): Date | null {
       return d;
     }
     case "custom":
-      return c.date ? c.date.toDate() : null;
+      // The DatePicker emits a date-only Dayjs (midnight local). Snapping to
+      // end-of-day means picking "today" yields an expiry ~24h out — without
+      // it the token would be considered expired the instant it's saved
+      // (getUser rejects when expiresAt < Date.now()).
+      return c.date ? c.date.endOf("day").toDate() : null;
   }
 }
 
@@ -193,9 +197,12 @@ const KeyModal: React.FC<KeyModalProps> = props => {
       if (isCreate) {
         await props.onSubmit({ name: name.trim() || undefined, expiresAt: choiceToDate(expiration) });
       } else {
+        // Edit mode: same end-of-day snap as create. The DatePicker is
+        // date-only; without this, choosing "today" would mark the key
+        // expired immediately.
         await props.onSubmit({
           name: name.trim() || null,
-          expiresAt: editDate ? editDate.toDate() : null,
+          expiresAt: editDate ? editDate.endOf("day").toDate() : null,
         });
       }
     } finally {

--- a/webapps/console/pages/user.tsx
+++ b/webapps/console/pages/user.tsx
@@ -1,61 +1,255 @@
 import { FaArrowLeft } from "react-icons/fa";
-import { Button, Input } from "antd";
+import { Button, Form, Input, Modal, Radio, Table, Tag, Tooltip } from "antd";
 import { useRouter } from "next/router";
 import { useUser } from "../lib/context";
-import { ApiKeysEditor } from "../components/ApiKeyEditor/ApiKeyEditor";
 import { get, useApi } from "../lib/useApi";
 import React, { useState } from "react";
-import { ApiKey } from "../lib/schema";
-import { feedbackError, feedbackSuccess, useUnsavedChanges } from "../lib/ui";
+import { ApiKey, inferTokenTypeFromId } from "../lib/schema";
+import { copyTextToClipboard, feedbackError, feedbackSuccess, confirmOp } from "../lib/ui";
 import { QueryResponse } from "../components/QueryResponse/QueryResponse";
 import { JitsuButton } from "../components/JitsuButton/JitsuButton";
 import { ChangePassword } from "../components/ChangePassword/ChangePassword";
+import { FaCopy, FaPlus, FaTrash } from "react-icons/fa";
+
+const expirationOptions: { label: string; days: number | null }[] = [
+  { label: "30 days", days: 30 },
+  { label: "60 days", days: 60 },
+  { label: "90 days", days: 90 },
+  { label: "Never", days: null },
+];
+
+function expirationToDate(days: number | null): Date | null {
+  if (days === null) return null;
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function fmtDate(value: Date | string | null | undefined): string {
+  if (!value) return "—";
+  const d = typeof value === "string" ? new Date(value) : value;
+  return d.toLocaleString();
+}
+
+function effectiveType(key: ApiKey): string {
+  if (key.type) return key.type;
+  return inferTokenTypeFromId(key.id);
+}
+
+const KeyCell: React.FC<{ value: string }> = ({ value }) => {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="flex items-center font-mono text-xs">
+      <code className="break-all">{value}</code>
+      <Tooltip title={copied ? "Copied!" : "Copy to clipboard"}>
+        <Button
+          type="text"
+          size="small"
+          onClick={() => {
+            copyTextToClipboard(value);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+        >
+          <FaCopy />
+        </Button>
+      </Tooltip>
+    </div>
+  );
+};
+
+const NewKeyModal: React.FC<{
+  generated: { id: string; plaintext: string } | null;
+  onCreate: (vals: { name?: string; expiresAt: Date | null }) => Promise<void>;
+  onClose: () => void;
+}> = ({ generated, onCreate, onClose }) => {
+  const [form] = Form.useForm<{ name?: string; expirationDays: number | null }>();
+  const [loading, setLoading] = useState(false);
+  const [expirationDays, setExpirationDays] = useState<number | null>(90);
+
+  return (
+    <Modal
+      open={true}
+      title={generated ? "Save your secret key" : "Create new API key"}
+      maskClosable={!generated}
+      closable={true}
+      onCancel={onClose}
+      footer={
+        generated ? (
+          <Button type="primary" onClick={onClose}>
+            Done
+          </Button>
+        ) : (
+          <div className="flex justify-end gap-2">
+            <Button onClick={onClose}>Cancel</Button>
+            <Button
+              type="primary"
+              loading={loading}
+              onClick={async () => {
+                const values = await form.validateFields();
+                setLoading(true);
+                try {
+                  await onCreate({
+                    name: values.name?.trim() || undefined,
+                    expiresAt: expirationToDate(expirationDays),
+                  });
+                } finally {
+                  setLoading(false);
+                }
+              }}
+            >
+              Create key
+            </Button>
+          </div>
+        )
+      }
+    >
+      {generated ? (
+        <div className="flex flex-col gap-3">
+          <p>
+            Copy and store this key in a safe place. <strong>You will not be able to see it again.</strong>
+          </p>
+          <KeyCell value={`${generated.id}:${generated.plaintext}`} />
+        </div>
+      ) : (
+        <Form form={form} layout="vertical" initialValues={{ expirationDays: 90 }}>
+          <Form.Item label="Name (optional)" name="name" help="A human-readable label. Leave blank to use the key id.">
+            <Input placeholder="e.g. local dev / CI bot" autoFocus />
+          </Form.Item>
+          <Form.Item label="Expiration" name="expirationDays">
+            <Radio.Group
+              value={expirationDays}
+              onChange={e => setExpirationDays(e.target.value)}
+              options={expirationOptions.map(o => ({ label: o.label, value: o.days }))}
+              optionType="button"
+            />
+          </Form.Item>
+        </Form>
+      )}
+    </Modal>
+  );
+};
 
 function ApiKeys() {
   const apiRes = useApi<ApiKey[]>("/api/user/keys");
-  const [newKeys, setNewKeys] = useState<ApiKey[]>();
-  const [loading, setLoading] = useState(false);
-  useUnsavedChanges(!!newKeys, { message: "You have unsaved changes. Are you sure you want to leave?" });
+  const [modalOpen, setModalOpen] = useState(false);
+  const [generated, setGenerated] = useState<{ id: string; plaintext: string } | null>(null);
+
   return (
     <QueryResponse
       result={apiRes}
       errorTitle={"Failed to load API keys"}
-      render={keys => (
-        <>
-          <p className="text-lg font-bold">API Keys</p>
-          <ApiKeysEditor
-            value={keys}
-            onChange={k => {
-              setNewKeys(k);
-            }}
-          />
-          <div className="flex justify-end pt-6">
-            <Button
-              type="primary"
-              loading={loading}
-              disabled={!newKeys}
-              onClick={async () => {
-                if (newKeys) {
-                  setLoading(true);
-                  try {
-                    await get("/api/user/keys", { method: "POST", body: newKeys });
-                    setNewKeys(undefined);
-                    await apiRes.reload();
-                    feedbackSuccess(`API keys has been saved`);
-                  } catch (e) {
-                    feedbackError(`Failed to save API keys`);
-                  } finally {
-                    //await reload();
-                    setLoading(false);
+      render={keys => {
+        const columns: any[] = [
+          {
+            title: "Name",
+            key: "name",
+            render: (k: ApiKey) => (
+              <div className="flex flex-col">
+                <span className="font-medium">{k.name || k.id}</span>
+                <Tooltip title={k.id}>
+                  <code className="text-xs text-textLight">
+                    {k.id}:{k.hint?.replace("*", "*".repeat(32 - 6))}
+                  </code>
+                </Tooltip>
+              </div>
+            ),
+          },
+          {
+            title: "Type",
+            key: "type",
+            render: (k: ApiKey) => <Tag>{effectiveType(k)}</Tag>,
+          },
+          {
+            title: <div className="whitespace-nowrap">Created</div>,
+            dataIndex: "createdAt",
+            className: "text-xs whitespace-nowrap",
+            render: (v: any) => fmtDate(v),
+          },
+          {
+            title: <div className="whitespace-nowrap">Last used</div>,
+            dataIndex: "lastUsed",
+            className: "text-xs whitespace-nowrap",
+            render: (v: any) => (v ? fmtDate(v) : "Never"),
+          },
+          {
+            title: <div className="whitespace-nowrap">Expires</div>,
+            dataIndex: "expiresAt",
+            className: "text-xs whitespace-nowrap",
+            render: (v: any) => {
+              if (!v) return <span className="text-textLight">Never</span>;
+              const d = new Date(v);
+              const expired = d.getTime() < Date.now();
+              return <span className={expired ? "text-error" : ""}>{fmtDate(d)}</span>;
+            },
+          },
+          {
+            title: "",
+            key: "actions",
+            className: "text-right",
+            render: (k: ApiKey) => (
+              <Button
+                type="text"
+                onClick={async () => {
+                  if (await confirmOp(`Delete key ${k.name || k.id}? This cannot be undone.`)) {
+                    try {
+                      await get(`/api/user/keys?id=${encodeURIComponent(k.id)}`, { method: "DELETE" });
+                      await apiRes.reload();
+                      feedbackSuccess("Key deleted");
+                    } catch (e) {
+                      feedbackError("Failed to delete key");
+                    }
                   }
-                }
-              }}
-            >
-              Save
-            </Button>
-          </div>
-        </>
-      )}
+                }}
+              >
+                <FaTrash />
+              </Button>
+            ),
+          },
+        ];
+
+        return (
+          <>
+            <div className="flex items-center justify-between">
+              <p className="text-lg font-bold m-0">API Keys</p>
+              <Button type="primary" icon={<FaPlus />} onClick={() => setModalOpen(true)}>
+                Create the key
+              </Button>
+            </div>
+            <div className="pt-3">
+              {keys.length === 0 ? (
+                <div className="flex text-textDisabled justify-center py-6">
+                  No API keys yet. Click "Create the key" to make one.
+                </div>
+              ) : (
+                <Table size="small" columns={columns} dataSource={keys} pagination={false} rowKey={k => k.id} />
+              )}
+            </div>
+            {modalOpen && (
+              <NewKeyModal
+                generated={generated}
+                onCreate={async vals => {
+                  try {
+                    const created = await get("/api/user/keys", {
+                      method: "POST",
+                      body: { name: vals.name, expiresAt: vals.expiresAt, type: "api" },
+                    });
+                    setGenerated({ id: created.id, plaintext: created.plaintext });
+                    await apiRes.reload();
+                    feedbackSuccess("API key created");
+                  } catch (e) {
+                    feedbackError("Failed to create key");
+                  }
+                }}
+                onClose={() => {
+                  setModalOpen(false);
+                  setGenerated(null);
+                }}
+              />
+            )}
+          </>
+        );
+      }}
     />
   );
 }
@@ -84,12 +278,6 @@ const UserPage = (props: any) => {
             </div>
           </div>
           {user.loginProvider === "credentials" && <ChangePassword />}
-          {/*<div className={"mt-6"}>*/}
-          {/*  <div className="px-8 py-6 border border-textDisabled rounded-lg">*/}
-          {/*    <div className="text-lg font-bold">Default Notification Settings</div>*/}
-          {/*    <UserNotificationSettings />*/}
-          {/*  </div>*/}
-          {/*</div>*/}
           <div className="px-8 py-6 border border-textDisabled rounded-lg mt-6">
             <ApiKeys />
           </div>

--- a/webapps/console/pages/user.tsx
+++ b/webapps/console/pages/user.tsx
@@ -1,5 +1,6 @@
 import { FaArrowLeft } from "react-icons/fa";
-import { Button, Form, Input, InputNumber, Modal, Radio, Table, Tag, Tooltip } from "antd";
+import { Button, DatePicker, Form, Input, Modal, Radio, Table, Tag, Tooltip } from "antd";
+import dayjs, { Dayjs } from "dayjs";
 import { useRouter } from "next/router";
 import { useUser } from "../lib/context";
 import { get, useApi } from "../lib/useApi";
@@ -13,33 +14,24 @@ import { FaCopy, FaPlus, FaTrash, FaTerminal, FaPencilAlt } from "react-icons/fa
 import { FaCloudArrowUp } from "react-icons/fa6";
 
 /**
- * Expiration picker state. The "keep" kind only makes sense in edit mode and
- * means: don't send `expiresAt` to the server at all (column stays as-is).
+ * Expiration picker state for the create modal. Edit mode uses a plain
+ * DatePicker instead and skips this enum.
  */
-type ExpirationChoice =
-  | { kind: "30" | "60" | "90" }
-  | { kind: "never" }
-  | { kind: "custom"; days: number }
-  | { kind: "keep" };
+type ExpirationChoice = { kind: "30" | "60" | "90" } | { kind: "never" } | { kind: "custom"; date: Dayjs | null };
 
-function choiceToExpiresAt(c: ExpirationChoice): { include: boolean; value: Date | null } {
+function choiceToDate(c: ExpirationChoice): Date | null {
   switch (c.kind) {
-    case "keep":
-      return { include: false, value: null };
     case "never":
-      return { include: true, value: null };
+      return null;
     case "30":
     case "60":
     case "90": {
       const d = new Date();
       d.setDate(d.getDate() + Number(c.kind));
-      return { include: true, value: d };
+      return d;
     }
-    case "custom": {
-      const d = new Date();
-      d.setDate(d.getDate() + c.days);
-      return { include: true, value: d };
-    }
+    case "custom":
+      return c.date ? c.date.toDate() : null;
   }
 }
 
@@ -131,44 +123,37 @@ const CopyButton: React.FC<{ text: string }> = ({ text }) => {
 const ExpirationField: React.FC<{
   value: ExpirationChoice;
   onChange: (next: ExpirationChoice) => void;
-  showKeep?: boolean;
-}> = ({ value, onChange, showKeep }) => {
-  const customDays = value.kind === "custom" ? value.days : 30;
+}> = ({ value, onChange }) => {
   const presetOptions: { label: string; kind: ExpirationChoice["kind"] }[] = [
-    ...(showKeep ? [{ label: "Keep", kind: "keep" as const }] : []),
     { label: "30 days", kind: "30" },
     { label: "60 days", kind: "60" },
     { label: "90 days", kind: "90" },
     { label: "Custom", kind: "custom" },
     { label: "Never", kind: "never" },
   ];
+  const today = dayjs().startOf("day");
   return (
     <div className="flex flex-col gap-2">
       <Radio.Group
         value={value.kind}
         onChange={e => {
           const kind = e.target.value as ExpirationChoice["kind"];
-          if (kind === "custom") onChange({ kind: "custom", days: customDays });
-          else if (kind === "keep") onChange({ kind: "keep" });
-          else if (kind === "never") onChange({ kind: "never" });
+          if (kind === "custom") {
+            const seed = value.kind === "custom" ? value.date : dayjs().add(30, "day");
+            onChange({ kind: "custom", date: seed });
+          } else if (kind === "never") onChange({ kind: "never" });
           else onChange({ kind: kind as "30" | "60" | "90" });
         }}
         options={presetOptions.map(o => ({ label: o.label, value: o.kind }))}
         optionType="button"
       />
       {value.kind === "custom" && (
-        <div className="flex items-center gap-2">
-          <InputNumber
-            min={1}
-            max={3650}
-            value={value.days}
-            onChange={v => onChange({ kind: "custom", days: typeof v === "number" ? v : 30 })}
-            addonAfter="days"
-          />
-          <span className="text-text-light text-sm">
-            expires {new Date(Date.now() + value.days * 86_400_000).toLocaleDateString()}
-          </span>
-        </div>
+        <DatePicker
+          value={value.date}
+          onChange={d => onChange({ kind: "custom", date: d })}
+          disabledDate={d => !!d && d.isBefore(today)}
+          allowClear={false}
+        />
       )}
     </div>
   );
@@ -192,7 +177,11 @@ const KeyModal: React.FC<KeyModalProps> = props => {
   const isCreate = props.mode === "create";
   const initialName = isCreate ? "" : props.target.name ?? "";
   const [name, setName] = useState(initialName);
-  const [expiration, setExpiration] = useState<ExpirationChoice>(isCreate ? { kind: "90" } : { kind: "keep" });
+  const [expiration, setExpiration] = useState<ExpirationChoice>({ kind: "90" });
+  // Edit mode renders a plain DatePicker rather than the preset row. State is
+  // a Dayjs (specific date) or null (never expires).
+  const initialEditDate = !isCreate && props.target.expiresAt ? dayjs(props.target.expiresAt) : null;
+  const [editDate, setEditDate] = useState<Dayjs | null>(initialEditDate);
   const [loading, setLoading] = useState(false);
   const generated = isCreate ? props.generated : null;
 
@@ -202,15 +191,12 @@ const KeyModal: React.FC<KeyModalProps> = props => {
     setLoading(true);
     try {
       if (isCreate) {
-        const exp = choiceToExpiresAt(expiration);
-        await props.onSubmit({ name: name.trim() || undefined, expiresAt: exp.value });
+        await props.onSubmit({ name: name.trim() || undefined, expiresAt: choiceToDate(expiration) });
       } else {
-        const exp = choiceToExpiresAt(expiration);
-        const vals: { name?: string | null; expiresAt?: Date | null } = {
+        await props.onSubmit({
           name: name.trim() || null,
-        };
-        if (exp.include) vals.expiresAt = exp.value;
-        await props.onSubmit(vals);
+          expiresAt: editDate ? editDate.toDate() : null,
+        });
       }
     } finally {
       setLoading(false);
@@ -261,12 +247,22 @@ const KeyModal: React.FC<KeyModalProps> = props => {
               onChange={e => setName(e.target.value)}
             />
           </Form.Item>
-          <Form.Item label="Expiration">
-            <ExpirationField value={expiration} onChange={setExpiration} showKeep={!isCreate} />
-            {!isCreate && expiration.kind === "keep" && (
-              <div className="text-text-light text-xs mt-1">
-                Current: {props.target.expiresAt ? fmtFullDate(props.target.expiresAt) : "Never"}
-              </div>
+          <Form.Item
+            label="Expiration"
+            help={
+              !isCreate ? (editDate ? "Leave blank to remove the expiration." : "Cleared — key will never expire.") : ""
+            }
+          >
+            {isCreate ? (
+              <ExpirationField value={expiration} onChange={setExpiration} />
+            ) : (
+              <DatePicker
+                value={editDate}
+                onChange={setEditDate}
+                disabledDate={d => !!d && d.isBefore(dayjs().startOf("day"))}
+                placeholder="Never"
+                allowClear
+              />
             )}
           </Form.Item>
         </Form>

--- a/webapps/console/pages/user.tsx
+++ b/webapps/console/pages/user.tsx
@@ -1,5 +1,5 @@
 import { FaArrowLeft } from "react-icons/fa";
-import { Button, Form, Input, Modal, Radio, Table, Tag, Tooltip } from "antd";
+import { Button, Form, Input, InputNumber, Modal, Radio, Table, Tag, Tooltip } from "antd";
 import { useRouter } from "next/router";
 import { useUser } from "../lib/context";
 import { get, useApi } from "../lib/useApi";
@@ -9,21 +9,38 @@ import { copyTextToClipboard, feedbackError, feedbackSuccess, confirmOp } from "
 import { QueryResponse } from "../components/QueryResponse/QueryResponse";
 import { JitsuButton } from "../components/JitsuButton/JitsuButton";
 import { ChangePassword } from "../components/ChangePassword/ChangePassword";
-import { FaCopy, FaPlus, FaTrash, FaTerminal } from "react-icons/fa";
+import { FaCopy, FaPlus, FaTrash, FaTerminal, FaPencilAlt } from "react-icons/fa";
 import { FaCloudArrowUp } from "react-icons/fa6";
 
-const expirationOptions: { label: string; days: number | null }[] = [
-  { label: "30 days", days: 30 },
-  { label: "60 days", days: 60 },
-  { label: "90 days", days: 90 },
-  { label: "Never", days: null },
-];
+/**
+ * Expiration picker state. The "keep" kind only makes sense in edit mode and
+ * means: don't send `expiresAt` to the server at all (column stays as-is).
+ */
+type ExpirationChoice =
+  | { kind: "30" | "60" | "90" }
+  | { kind: "never" }
+  | { kind: "custom"; days: number }
+  | { kind: "keep" };
 
-function expirationToDate(days: number | null): Date | null {
-  if (days === null) return null;
-  const d = new Date();
-  d.setDate(d.getDate() + days);
-  return d;
+function choiceToExpiresAt(c: ExpirationChoice): { include: boolean; value: Date | null } {
+  switch (c.kind) {
+    case "keep":
+      return { include: false, value: null };
+    case "never":
+      return { include: true, value: null };
+    case "30":
+    case "60":
+    case "90": {
+      const d = new Date();
+      d.setDate(d.getDate() + Number(c.kind));
+      return { include: true, value: d };
+    }
+    case "custom": {
+      const d = new Date();
+      d.setDate(d.getDate() + c.days);
+      return { include: true, value: d };
+    }
+  }
 }
 
 const dateFmt: Intl.DateTimeFormatOptions = { month: "short", day: "numeric", year: "numeric" };
@@ -111,47 +128,112 @@ const CopyButton: React.FC<{ text: string }> = ({ text }) => {
   );
 };
 
-const NewKeyModal: React.FC<{
-  generated: { id: string; plaintext: string } | null;
-  onCreate: (vals: { name?: string; expiresAt: Date | null }) => Promise<void>;
-  onClose: () => void;
-}> = ({ generated, onCreate, onClose }) => {
-  const [form] = Form.useForm<{ name?: string; expirationDays: number | null }>();
+const ExpirationField: React.FC<{
+  value: ExpirationChoice;
+  onChange: (next: ExpirationChoice) => void;
+  showKeep?: boolean;
+}> = ({ value, onChange, showKeep }) => {
+  const customDays = value.kind === "custom" ? value.days : 30;
+  const presetOptions: { label: string; kind: ExpirationChoice["kind"] }[] = [
+    ...(showKeep ? [{ label: "Keep", kind: "keep" as const }] : []),
+    { label: "30 days", kind: "30" },
+    { label: "60 days", kind: "60" },
+    { label: "90 days", kind: "90" },
+    { label: "Custom", kind: "custom" },
+    { label: "Never", kind: "never" },
+  ];
+  return (
+    <div className="flex flex-col gap-2">
+      <Radio.Group
+        value={value.kind}
+        onChange={e => {
+          const kind = e.target.value as ExpirationChoice["kind"];
+          if (kind === "custom") onChange({ kind: "custom", days: customDays });
+          else if (kind === "keep") onChange({ kind: "keep" });
+          else if (kind === "never") onChange({ kind: "never" });
+          else onChange({ kind: kind as "30" | "60" | "90" });
+        }}
+        options={presetOptions.map(o => ({ label: o.label, value: o.kind }))}
+        optionType="button"
+      />
+      {value.kind === "custom" && (
+        <div className="flex items-center gap-2">
+          <InputNumber
+            min={1}
+            max={3650}
+            value={value.days}
+            onChange={v => onChange({ kind: "custom", days: typeof v === "number" ? v : 30 })}
+            addonAfter="days"
+          />
+          <span className="text-text-light text-sm">
+            expires {new Date(Date.now() + value.days * 86_400_000).toLocaleDateString()}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+type KeyModalProps =
+  | {
+      mode: "create";
+      generated: { id: string; plaintext: string } | null;
+      onSubmit: (vals: { name?: string; expiresAt: Date | null }) => Promise<void>;
+      onClose: () => void;
+    }
+  | {
+      mode: "edit";
+      target: ApiKey;
+      onSubmit: (vals: { name?: string | null; expiresAt?: Date | null }) => Promise<void>;
+      onClose: () => void;
+    };
+
+const KeyModal: React.FC<KeyModalProps> = props => {
+  const isCreate = props.mode === "create";
+  const initialName = isCreate ? "" : props.target.name ?? "";
+  const [name, setName] = useState(initialName);
+  const [expiration, setExpiration] = useState<ExpirationChoice>(isCreate ? { kind: "90" } : { kind: "keep" });
   const [loading, setLoading] = useState(false);
-  const [expirationDays, setExpirationDays] = useState<number | null>(90);
+  const generated = isCreate ? props.generated : null;
+
+  const title = isCreate ? (generated ? "Save your secret key" : "Create new API key") : "Edit API key";
+
+  const submit = async () => {
+    setLoading(true);
+    try {
+      if (isCreate) {
+        const exp = choiceToExpiresAt(expiration);
+        await props.onSubmit({ name: name.trim() || undefined, expiresAt: exp.value });
+      } else {
+        const exp = choiceToExpiresAt(expiration);
+        const vals: { name?: string | null; expiresAt?: Date | null } = {
+          name: name.trim() || null,
+        };
+        if (exp.include) vals.expiresAt = exp.value;
+        await props.onSubmit(vals);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <Modal
       open={true}
-      title={generated ? "Save your secret key" : "Create new API key"}
+      title={title}
       maskClosable={!generated}
       closable={true}
-      onCancel={onClose}
+      onCancel={props.onClose}
       footer={
         generated ? (
-          <Button type="primary" onClick={onClose}>
+          <Button type="primary" onClick={props.onClose}>
             Done
           </Button>
         ) : (
           <div className="flex justify-end gap-2">
-            <Button onClick={onClose}>Cancel</Button>
-            <Button
-              type="primary"
-              loading={loading}
-              onClick={async () => {
-                const values = await form.validateFields();
-                setLoading(true);
-                try {
-                  await onCreate({
-                    name: values.name?.trim() || undefined,
-                    expiresAt: expirationToDate(expirationDays),
-                  });
-                } finally {
-                  setLoading(false);
-                }
-              }}
-            >
-              Create key
+            <Button onClick={props.onClose}>Cancel</Button>
+            <Button type="primary" loading={loading} onClick={submit}>
+              {isCreate ? "Create key" : "Save"}
             </Button>
           </div>
         )
@@ -170,17 +252,22 @@ const NewKeyModal: React.FC<{
           </div>
         </div>
       ) : (
-        <Form form={form} layout="vertical" initialValues={{ expirationDays: 90 }}>
-          <Form.Item label="Name (optional)" name="name" help="A human-readable label. Leave blank to use the key id.">
-            <Input placeholder="e.g. local dev / CI bot" autoFocus />
-          </Form.Item>
-          <Form.Item label="Expiration" name="expirationDays">
-            <Radio.Group
-              value={expirationDays}
-              onChange={e => setExpirationDays(e.target.value)}
-              options={expirationOptions.map(o => ({ label: o.label, value: o.days }))}
-              optionType="button"
+        <Form layout="vertical">
+          <Form.Item label="Name (optional)" help="A human-readable label. Leave blank to use the key id.">
+            <Input
+              placeholder="e.g. local dev / CI bot"
+              value={name}
+              autoFocus
+              onChange={e => setName(e.target.value)}
             />
+          </Form.Item>
+          <Form.Item label="Expiration">
+            <ExpirationField value={expiration} onChange={setExpiration} showKeep={!isCreate} />
+            {!isCreate && expiration.kind === "keep" && (
+              <div className="text-text-light text-xs mt-1">
+                Current: {props.target.expiresAt ? fmtFullDate(props.target.expiresAt) : "Never"}
+              </div>
+            )}
           </Form.Item>
         </Form>
       )}
@@ -188,9 +275,11 @@ const NewKeyModal: React.FC<{
   );
 };
 
+type ModalState = { kind: "closed" } | { kind: "create" } | { kind: "edit"; target: ApiKey };
+
 function ApiKeys() {
   const apiRes = useApi<ApiKey[]>("/api/user/keys");
-  const [modalOpen, setModalOpen] = useState(false);
+  const [modal, setModal] = useState<ModalState>({ kind: "closed" });
   const [generated, setGenerated] = useState<{ id: string; plaintext: string } | null>(null);
 
   return (
@@ -280,34 +369,47 @@ function ApiKeys() {
             title: "",
             key: "actions",
             className: "text-right",
-            width: 48,
+            width: 96,
             render: (k: ApiKey) => (
-              <Button
-                type="text"
-                size="small"
-                onClick={async () => {
-                  if (await confirmOp(`Delete key ${k.name || k.id}? This cannot be undone.`)) {
-                    try {
-                      await get(`/api/user/keys?id=${encodeURIComponent(k.id)}`, { method: "DELETE" });
-                      await apiRes.reload();
-                      feedbackSuccess("Key deleted");
-                    } catch (e) {
-                      feedbackError("Failed to delete key");
-                    }
-                  }
-                }}
-              >
-                <FaTrash />
-              </Button>
+              <div className="inline-flex gap-1">
+                <Tooltip title="Edit">
+                  <Button type="text" size="small" onClick={() => setModal({ kind: "edit", target: k })}>
+                    <FaPencilAlt />
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Delete">
+                  <Button
+                    type="text"
+                    size="small"
+                    onClick={async () => {
+                      if (await confirmOp(`Delete key ${k.name || k.id}? This cannot be undone.`)) {
+                        try {
+                          await get(`/api/user/keys?id=${encodeURIComponent(k.id)}`, { method: "DELETE" });
+                          await apiRes.reload();
+                          feedbackSuccess("Key deleted");
+                        } catch (e) {
+                          feedbackError("Failed to delete key");
+                        }
+                      }
+                    }}
+                  >
+                    <FaTrash />
+                  </Button>
+                </Tooltip>
+              </div>
             ),
           },
         ];
 
+        const closeModal = () => {
+          setModal({ kind: "closed" });
+          setGenerated(null);
+        };
         return (
           <>
             <div className="flex items-center justify-between">
               <h2 className="text-xl font-semibold m-0">API Keys</h2>
-              <Button type="primary" icon={<FaPlus />} onClick={() => setModalOpen(true)}>
+              <Button type="primary" icon={<FaPlus />} onClick={() => setModal({ kind: "create" })}>
                 Create the key
               </Button>
             </div>
@@ -320,10 +422,11 @@ function ApiKeys() {
                 <Table size="middle" columns={columns} dataSource={keys} pagination={false} rowKey={k => k.id} />
               )}
             </div>
-            {modalOpen && (
-              <NewKeyModal
+            {modal.kind === "create" && (
+              <KeyModal
+                mode="create"
                 generated={generated}
-                onCreate={async vals => {
+                onSubmit={async vals => {
                   try {
                     const created = await get("/api/user/keys", {
                       method: "POST",
@@ -336,10 +439,27 @@ function ApiKeys() {
                     feedbackError("Failed to create key");
                   }
                 }}
-                onClose={() => {
-                  setModalOpen(false);
-                  setGenerated(null);
+                onClose={closeModal}
+              />
+            )}
+            {modal.kind === "edit" && (
+              <KeyModal
+                mode="edit"
+                target={modal.target}
+                onSubmit={async vals => {
+                  try {
+                    await get(`/api/user/keys?id=${encodeURIComponent(modal.target.id)}`, {
+                      method: "PATCH",
+                      body: vals,
+                    });
+                    await apiRes.reload();
+                    feedbackSuccess("API key updated");
+                    closeModal();
+                  } catch (e) {
+                    feedbackError("Failed to update key");
+                  }
                 }}
+                onClose={closeModal}
               />
             )}
           </>

--- a/webapps/console/pages/user.tsx
+++ b/webapps/console/pages/user.tsx
@@ -9,7 +9,8 @@ import { copyTextToClipboard, feedbackError, feedbackSuccess, confirmOp } from "
 import { QueryResponse } from "../components/QueryResponse/QueryResponse";
 import { JitsuButton } from "../components/JitsuButton/JitsuButton";
 import { ChangePassword } from "../components/ChangePassword/ChangePassword";
-import { FaCopy, FaPlus, FaTrash } from "react-icons/fa";
+import { FaCopy, FaPlus, FaTrash, FaTerminal } from "react-icons/fa";
+import { FaCloudArrowUp } from "react-icons/fa6";
 
 const expirationOptions: { label: string; days: number | null }[] = [
   { label: "30 days", days: 30 },
@@ -25,10 +26,24 @@ function expirationToDate(days: number | null): Date | null {
   return d;
 }
 
-function fmtDate(value: Date | string | null | undefined): string {
+const dateFmt: Intl.DateTimeFormatOptions = { month: "short", day: "numeric", year: "numeric" };
+
+function fmtShortDate(value: Date | string | null | undefined): string {
   if (!value) return "—";
   const d = typeof value === "string" ? new Date(value) : value;
+  return d.toLocaleDateString(undefined, dateFmt);
+}
+
+function fmtFullDate(value: Date | string | null | undefined): string {
+  if (!value) return "";
+  const d = typeof value === "string" ? new Date(value) : value;
   return d.toLocaleString();
+}
+
+function dateValue(value: Date | string | null | undefined): number {
+  if (!value) return 0;
+  const d = typeof value === "string" ? new Date(value) : value;
+  return d.getTime();
 }
 
 function effectiveType(key: ApiKey): string {
@@ -36,25 +51,63 @@ function effectiveType(key: ApiKey): string {
   return inferTokenTypeFromId(key.id);
 }
 
-const KeyCell: React.FC<{ value: string }> = ({ value }) => {
+const typeStyles: Record<string, { color: string; icon: React.ReactNode; label: string }> = {
+  cli: { color: "blue", icon: <FaTerminal />, label: "cli" },
+  api: { color: "purple", icon: <FaCloudArrowUp />, label: "api" },
+};
+
+function TypeTag({ type }: { type: string }) {
+  const s = typeStyles[type] ?? { color: "default", icon: null, label: type };
+  return (
+    <Tag color={s.color} className="inline-flex items-center gap-1">
+      {s.icon ? <span className="inline-flex items-center">{s.icon}</span> : null}
+      <span>{s.label}</span>
+    </Tag>
+  );
+}
+
+/**
+ * Middle-truncate `value` to at most `max` chars, preserving both ends. The
+ * full string belongs in a tooltip beside the rendered span. Used for names —
+ * common case is a long auto-generated id like `jitsu-cli-Tr78cBn6EHHorI0...`
+ * where the prefix is informative but so is the trailing entropy.
+ */
+function middleTruncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  const keep = max - 1;
+  const head = Math.ceil(keep / 2);
+  const tail = Math.floor(keep / 2);
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * `hint` from juava is `XXX*YYY` (3+1+3). Render as `XXX**********YYY` so the
+ * masked secret looks like a sk- style preview without being so long it pushes
+ * the table out.
+ */
+function renderSecretHint(hint: string | null | undefined): string {
+  if (!hint) return "";
+  const parts = hint.split("*");
+  if (parts.length !== 2) return hint;
+  return `${parts[0]}${"*".repeat(10)}${parts[1]}`;
+}
+
+const CopyButton: React.FC<{ text: string }> = ({ text }) => {
   const [copied, setCopied] = useState(false);
   return (
-    <div className="flex items-center font-mono text-xs">
-      <code className="break-all">{value}</code>
-      <Tooltip title={copied ? "Copied!" : "Copy to clipboard"}>
-        <Button
-          type="text"
-          size="small"
-          onClick={() => {
-            copyTextToClipboard(value);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-          }}
-        >
-          <FaCopy />
-        </Button>
-      </Tooltip>
-    </div>
+    <Tooltip title={copied ? "Copied!" : "Copy to clipboard"}>
+      <Button
+        type="text"
+        size="small"
+        onClick={() => {
+          copyTextToClipboard(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+      >
+        <FaCopy />
+      </Button>
+    </Tooltip>
   );
 };
 
@@ -109,7 +162,12 @@ const NewKeyModal: React.FC<{
           <p>
             Copy and store this key in a safe place. <strong>You will not be able to see it again.</strong>
           </p>
-          <KeyCell value={`${generated.id}:${generated.plaintext}`} />
+          <div className="flex items-center font-mono text-xs bg-neutral-100 rounded px-2 py-1">
+            <code className="break-all">
+              {generated.id}:{generated.plaintext}
+            </code>
+            <CopyButton text={`${generated.id}:${generated.plaintext}`} />
+          </div>
         </div>
       ) : (
         <Form form={form} layout="vertical" initialValues={{ expirationDays: 90 }}>
@@ -144,52 +202,89 @@ function ApiKeys() {
           {
             title: "Name",
             key: "name",
-            render: (k: ApiKey) => (
-              <div className="flex flex-col">
-                <span className="font-medium">{k.name || k.id}</span>
-                <Tooltip title={k.id}>
-                  <code className="text-xs text-textLight">
-                    {k.id}:{k.hint?.replace("*", "*".repeat(32 - 6))}
-                  </code>
+            render: (k: ApiKey) => {
+              const full = k.name || k.id;
+              const display = middleTruncate(full, 32);
+              return (
+                <Tooltip title={full}>
+                  <span className="font-medium">{display}</span>
                 </Tooltip>
-              </div>
-            ),
+              );
+            },
           },
           {
             title: "Type",
             key: "type",
-            render: (k: ApiKey) => <Tag>{effectiveType(k)}</Tag>,
+            render: (k: ApiKey) => <TypeTag type={effectiveType(k)} />,
           },
           {
-            title: <div className="whitespace-nowrap">Created</div>,
+            title: "Key ID",
+            key: "keyId",
+            render: (k: ApiKey) => (
+              <Tooltip title={k.id}>
+                <code className="font-mono text-xs text-text-light">{middleTruncate(k.id, 22)}</code>
+              </Tooltip>
+            ),
+          },
+          {
+            title: "Secret key",
+            key: "secret",
+            render: (k: ApiKey) => (
+              <code className="font-mono text-xs text-text-light">{renderSecretHint(k.hint)}</code>
+            ),
+          },
+          {
+            title: <span className="whitespace-nowrap">Created</span>,
             dataIndex: "createdAt",
-            className: "text-xs whitespace-nowrap",
-            render: (v: any) => fmtDate(v),
+            className: "whitespace-nowrap",
+            defaultSortOrder: "descend" as const,
+            sorter: (a: ApiKey, b: ApiKey) => dateValue(a.createdAt) - dateValue(b.createdAt),
+            render: (v: any) => (
+              <Tooltip title={fmtFullDate(v)}>
+                <span className="text-sm">{fmtShortDate(v)}</span>
+              </Tooltip>
+            ),
           },
           {
-            title: <div className="whitespace-nowrap">Last used</div>,
+            title: <span className="whitespace-nowrap">Last used</span>,
             dataIndex: "lastUsed",
-            className: "text-xs whitespace-nowrap",
-            render: (v: any) => (v ? fmtDate(v) : "Never"),
+            className: "whitespace-nowrap",
+            // Sort never-used keys last in descending mode (default 0 → bottom).
+            sorter: (a: ApiKey, b: ApiKey) => dateValue(a.lastUsed) - dateValue(b.lastUsed),
+            render: (v: any) =>
+              v ? (
+                <Tooltip title={fmtFullDate(v)}>
+                  <span className="text-sm">{fmtShortDate(v)}</span>
+                </Tooltip>
+              ) : (
+                <span className="text-text-light text-sm">Never</span>
+              ),
           },
           {
-            title: <div className="whitespace-nowrap">Expires</div>,
+            title: <span className="whitespace-nowrap">Expires</span>,
             dataIndex: "expiresAt",
-            className: "text-xs whitespace-nowrap",
+            className: "whitespace-nowrap",
+            sorter: (a: ApiKey, b: ApiKey) => dateValue(a.expiresAt) - dateValue(b.expiresAt),
             render: (v: any) => {
-              if (!v) return <span className="text-textLight">Never</span>;
+              if (!v) return <span className="text-text-light text-sm">Never</span>;
               const d = new Date(v);
               const expired = d.getTime() < Date.now();
-              return <span className={expired ? "text-error" : ""}>{fmtDate(d)}</span>;
+              return (
+                <Tooltip title={fmtFullDate(d)}>
+                  <span className={`text-sm ${expired ? "text-error" : ""}`}>{fmtShortDate(d)}</span>
+                </Tooltip>
+              );
             },
           },
           {
             title: "",
             key: "actions",
             className: "text-right",
+            width: 48,
             render: (k: ApiKey) => (
               <Button
                 type="text"
+                size="small"
                 onClick={async () => {
                   if (await confirmOp(`Delete key ${k.name || k.id}? This cannot be undone.`)) {
                     try {
@@ -211,18 +306,18 @@ function ApiKeys() {
         return (
           <>
             <div className="flex items-center justify-between">
-              <p className="text-lg font-bold m-0">API Keys</p>
+              <h2 className="text-xl font-semibold m-0">API Keys</h2>
               <Button type="primary" icon={<FaPlus />} onClick={() => setModalOpen(true)}>
                 Create the key
               </Button>
             </div>
-            <div className="pt-3">
+            <div className="pt-4">
               {keys.length === 0 ? (
                 <div className="flex text-textDisabled justify-center py-6">
                   No API keys yet. Click "Create the key" to make one.
                 </div>
               ) : (
-                <Table size="small" columns={columns} dataSource={keys} pagination={false} rowKey={k => k.id} />
+                <Table size="middle" columns={columns} dataSource={keys} pagination={false} rowKey={k => k.id} />
               )}
             </div>
             {modalOpen && (
@@ -259,7 +354,7 @@ const UserPage = (props: any) => {
   const user = useUser();
   return (
     <div className="flex justify-center">
-      <div className="px-4 py-6 flex flex-col items-center w-full" style={{ maxWidth: "1000px", minWidth: "300px" }}>
+      <div className="px-4 py-6 flex flex-col items-center w-full" style={{ maxWidth: "1440px", minWidth: "300px" }}>
         <JitsuButton icon={<FaArrowLeft />} size="large" type="primary" onClick={() => router.back()}>
           Go back
         </JitsuButton>

--- a/webapps/console/prisma/schema.prisma
+++ b/webapps/console/prisma/schema.prisma
@@ -147,6 +147,9 @@ model UserApiToken {
   hash      String
   userId    String
   user      UserProfile @relation(fields: [userId], references: [id])
+  type      String?
+  name      String?
+  expiresAt DateTime? /// @zod.custom(z.coerce.date())
 }
 
 model InvitationToken {
@@ -220,6 +223,7 @@ model AuditLog {
   objectId    String?
   changes     Json?
   authType    String?
+  tokenId     String?
 
   @@index(timestamp)
   @@index(type)


### PR DESCRIPTION
## Summary

- `UserApiToken` gains optional `type` / `name` / `expiresAt`. Bearer auth rejects expired tokens and threads `tokenId` + `tokenType` through `SessionUser`.
- `/user` route: per-key list (name, hint, type, created, last used, expires) with a "Create the key" modal that asks for a name and an expiration (30 / 60 / 90 days or never). Single-key POST / DELETE replace the bulk save flow.
- jitsu-cli–issued keys now default to `type=cli` with a 90-day expiration. The CLI's `login --apikey` flag was already supported and lets users skip the interactive flow.
- Audit log: new **Origin** column. UI sessions render as `UI`; bearer as `API: <type>` (token type from the row, falling back to id-prefix inference for legacy keys without `type`). `AuditLog.tokenId` is optional — when not set, no link rendered.

## Schema changes (prisma db push)

```prisma
model UserApiToken {
  ...
  type      String?
  name      String?
  expiresAt DateTime?
}

model AuditLog {
  ...
  tokenId   String?
}
```

No SQL migrations are tracked in this repo (this project uses `prisma db push`); deploys pick up the additive optional columns automatically.

## Test plan

- [x] `pnpm typecheck:turbo` clean (19/19)
- [x] `pnpm lint` clean (only pre-existing warnings)
- [x] `pnpm test` — only failure is a pre-existing `libs/juava` Date test, also failing on `newjitsu`
- [ ] Manual: create UI key with each expiration option, copy + use, delete; expired key returns 401; cli-key flow still works; audit log shows Origin for both UI and API actions