### PR TITLE
fix(ci): add text/fallback to slack notify payload

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -59,11 +59,15 @@ runs:
 
           const text = lines.join('\n');
 
-          // Build complete payload
+          // Build complete payload. `text` (top-level) and `fallback` (attachment) drive
+          // Slack's notification preview / link-unfurl summary; without them the unfurl
+          // shows "[no preview available]".
           const payload = {
+            text: process.env.HEADER,
             attachments: [
               {
                 color: process.env.COLOR,
+                fallback: process.env.HEADER,
                 blocks: [
                   {
                     type: "header",


### PR DESCRIPTION
## Summary

CI Slack notifications were rendering as "[no preview available]" in unfurls and notification previews because the payload only set `attachments[].blocks` — Slack uses the top-level `text` (and attachment `fallback`) to populate preview/summary text.

This sets both to the existing `header` input (e.g. `✅ Lint & Test on branch \`newjitsu\` SUCCEEDED`), so previews show the same one-liner as the in-channel header.

## Test plan

- [ ] Trigger `test-slack-notification.yml` and confirm the Slack message preview shows the header text instead of "[no preview available]"