### PR TITLE
fix(ci): drop duplicate header block in slack notify

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -61,7 +61,8 @@ runs:
 
           // Build complete payload. `text` (top-level) and `fallback` (attachment) drive
           // Slack's notification preview / link-unfurl summary; without them the unfurl
-          // shows "[no preview available]".
+          // shows "[no preview available]". Top-level `text` also renders above the
+          // attachment, so we drop the in-attachment header block to avoid duplication.
           const payload = {
             text: process.env.HEADER,
             attachments: [
@@ -69,13 +70,6 @@ runs:
                 color: process.env.COLOR,
                 fallback: process.env.HEADER,
                 blocks: [
-                  {
-                    type: "header",
-                    text: {
-                      type: "plain_text",
-                      text: process.env.HEADER
-                    }
-                  },
                   {
                     type: "section",
                     text: {


### PR DESCRIPTION
## Summary

Follow-up to #1293. Now that top-level `text` renders above the attachment, the in-attachment `header` block duplicated the same line. Drop the header block so the message shows the title once.

## Test plan

- [ ] Trigger `test-slack-notification.yml` and confirm only one header line is shown, with the bullet body inside the colored attachment