### PR TITLE
feat(services): upload resolved version as artifact

### DIFF
--- a/.github/workflows/services.yaml
+++ b/.github/workflows/services.yaml
@@ -91,6 +91,22 @@ jobs:
         id: short-sha
         run: echo "sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
 
+      - name: 📝 Write version file for cross-repo callers
+        # Cross-repo callers (e.g. jitsu-cloud-infra's deploy workflow) need
+        # the resolved Docker tag back. workflow_dispatch doesn't expose
+        # outputs across repos, so we ship it as an artifact instead.
+        env:
+          VERSION: ${{ steps.manual.outputs.version || steps.generated.outputs.version }}
+        run: printf '%s' "$VERSION" > /tmp/version.txt
+
+      - name: 📤 Upload version artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: version
+          path: /tmp/version.txt
+          if-no-files-found: error
+          retention-days: 7
+
   nodejs_build:
     needs: [version]
     if: ${{ inputs.scope == 'all' || inputs.scope == 'nodejs' }}


### PR DESCRIPTION
## Summary

Adds two steps at the end of the `version` job in `services.yaml`: write the resolved Docker tag to `/tmp/version.txt` and upload it as an artifact named `version`.

This lets cross-repo callers (specifically the new deploy workflow in [jitsucom/jitsu-cloud-infra#7](https://github.com/jitsucom/jitsu-cloud-infra/pull/7)) read back the version a `workflow_dispatch` build produced, since `workflow_dispatch` has no cross-repo output mechanism. Callers fetch it with:

```sh
gh run download --repo jitsucom/jitsu --name version --dir /tmp <run-id>
TAG=$(cat /tmp/version.txt)
```

Notion task: https://www.notion.so/35d737892e4781699578c92305d772b8

## Test plan

- [ ] Trigger services.yaml manually (any channel) and confirm the `version` artifact appears in the run's artifacts list.
- [ ] Run `gh run download --repo jitsucom/jitsu --name version --dir /tmp <run-id>` from a separate machine and confirm `version.txt` contains the expected tag with no trailing newline.

## Out of scope

- Migrating the in-repo `deploy.yml` (which doesn't need this — it reads git tags) to use this artifact.