### PR TITLE
ci(services): add fast_fail input to cancel run on critical job failure

### DIFF
--- a/.github/workflows/services.yaml
+++ b/.github/workflows/services.yaml
@@ -29,6 +29,11 @@ on:
         required: false
         type: boolean
         default: false
+      fast_fail:
+        description: "Cancel the whole run as soon as any critical job fails (used by cross-repo callers that wait on this workflow)"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       channel:
@@ -47,6 +52,11 @@ on:
         default: all
       dont_publish:
         description: "Build only, no registry pushes or tag creation"
+        required: false
+        type: boolean
+        default: false
+      fast_fail:
+        description: "Cancel the whole run as soon as any critical job fails"
         required: false
         type: boolean
         default: false
@@ -203,6 +213,12 @@ jobs:
               .
           done
 
+      - name: 🛑 Cancel run on failure (fast_fail)
+        if: ${{ failure() && inputs.fast_fail }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+
   build_bulker:
     needs: [version]
     if: ${{ inputs.scope == 'all' || inputs.scope == 'bulker' }}
@@ -288,6 +304,11 @@ jobs:
               ./bulker
           done
 
+      - name: 🛑 Cancel run on failure (fast_fail)
+        if: ${{ failure() && inputs.fast_fail }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
 
   tag_release:
     needs: [version, nodejs_build, build_bulker, npm_publish]
@@ -533,3 +554,9 @@ jobs:
       - name: 🧹 Cleanup container
         if: always()
         run: docker stop builder && docker rm builder
+
+      - name: 🛑 Cancel run on failure (fast_fail)
+        if: ${{ failure() && inputs.fast_fail }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}

--- a/.github/workflows/services.yaml
+++ b/.github/workflows/services.yaml
@@ -128,6 +128,7 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+      actions: write
 
     steps:
       - name: 📥 Checkout code
@@ -230,6 +231,7 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+      actions: write
 
     steps:
       - name: 📥 Checkout code
@@ -446,6 +448,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
+      actions: write
 
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
## Summary

- Adds a `fast_fail` boolean input (default `false`) to `services.yaml`, on
  both `workflow_call` and `workflow_dispatch` triggers.
- Wires a "Cancel run on failure" step into the three critical jobs
  (`npm_publish`, `nodejs_build`, `build_bulker`) that calls
  `gh run cancel` when the job fails and `inputs.fast_fail` is set.

## Why

When `services.yaml` is dispatched from `jitsu-cloud-infra`, the caller
waits on the run via `gh run watch`. Today the three critical jobs are
independent (each `needs: [version]`), so a 9-second failure in
`npm_publish` (e.g. mismatched npm trusted-publisher config) still leaves
`jitsu-cloud-infra` blocked for ~8 minutes while the Docker builds finish.

`fast_fail=true` flips that: the first failing critical job cancels the
whole run and the caller returns immediately.

Default stays `false`, so manual dispatches and `publish.yml` keep the
current behavior (all jobs run to completion regardless of who fails).

## Test plan

- [ ] `jitsu-cloud-infra` PR adds `-f fast_fail=true` to its
  `gh workflow run services.yaml` call.
- [ ] Trigger a known-failing build (e.g. before the npm trusted-publisher
  rename) and confirm the run cancels within ~30 s instead of running the
  full ~8 min.
- [ ] Trigger a normal manual `services.yaml` dispatch (no `fast_fail`)
  and confirm all jobs run regardless of npm/Docker failures.