### PR TITLE
fix(ci): skip slack commit-message block when head_commit absent

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -40,7 +40,8 @@ runs:
         BLOCKS_JSON: ${{ steps.convert.outputs.blocks_json }}
       with:
         script: |
-          const blocks = JSON.parse(process.env.BLOCKS_JSON);
+          const blocks = JSON.parse(process.env.BLOCKS_JSON)
+            .filter(b => b.value !== '' && b.value != null);
 
           // Build single text with all blocks as bullet points
           const lines = blocks.map(block => {

--- a/.github/workflows/services.yaml
+++ b/.github/workflows/services.yaml
@@ -429,7 +429,7 @@ jobs:
               value: ${{ needs.version.outputs.short_sha }}
               url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
             - title: Commit message
-              value: ${{ github.event.head_commit.message && toJSON(github.event.head_commit.message) || 'N/A' }}
+              value: ${{ github.event.head_commit.message && toJSON(github.event.head_commit.message) || '' }}
               is_code: true
             - title: Workflow run
               value: ${{ job.status == 'success' && 'View workflow run' || 'View failed run' }}


### PR DESCRIPTION
## Summary

Release notifications (e.g. [run 25685792091](https://github.com/jitsucom/jitsu/actions/runs/25685792091)) posted **Commit message: N/A** because the Slack block reads `github.event.head_commit.message`, which is only set on `push` events — and that run was a `workflow_dispatch`.

- `slack-notify` action: filter out blocks whose `value` is empty/nullish before rendering. Generic, benefits any caller that wants a conditional block.
- `services.yaml` finalize step: change the commit-message fallback from `'N/A'` to `''`, so the block is dropped entirely when missing.

Other blocks (Version, Tag, NPM Tag) keep their informational fallbacks — only `Commit message` becomes pure noise when missing.

## Test plan

- [ ] Trigger \`services.yaml\` via workflow_dispatch from \`newjitsu\` and confirm the Slack post no longer contains a \`Commit message\` line.
- [ ] Trigger via a \`push\` and confirm the commit message still renders as before.