### PR TITLE
feat(ingest): apply Segment-style sentAt clock-skew correction on batches

### DIFF
--- a/bulker/ingest/router.go
+++ b/bulker/ingest/router.go
@@ -403,7 +403,16 @@ func patchEvent(c *gin.Context, messageId string, ev types.Json, tp string, inge
 		// it is only allowed to be set via functions
 		types.FilterEvent(ev)
 	}
-	nowIsoDate := time.Now().UTC().Format(timestamp.JsonISO)
+	now := time.Now().UTC()
+	// Segment-style clock-skew correction. Reads `sentAt` from the event
+	// itself — for batch payloads BatchHandler propagates the envelope's
+	// sentAt onto each event before this is called; for single-event
+	// endpoints (server-side, browser, pixel, funcs) the SDK or caller
+	// puts sentAt directly on the event. Must run before the SetIfAbsent
+	// below so events without a timestamp keep the server's now-stamp
+	// (nothing to correct in that case anyway).
+	applyEventTimestampCorrection(ev, ev.GetS("sentAt"), now)
+	nowIsoDate := now.Format(timestamp.JsonISO)
 	ev.Set("receivedAt", nowIsoDate)
 	ev.Set("type", typeFixed)
 	ev.SetIfAbsent("timestamp", nowIsoDate)

--- a/bulker/ingest/router.go
+++ b/bulker/ingest/router.go
@@ -403,16 +403,7 @@ func patchEvent(c *gin.Context, messageId string, ev types.Json, tp string, inge
 		// it is only allowed to be set via functions
 		types.FilterEvent(ev)
 	}
-	now := time.Now().UTC()
-	// Segment-style clock-skew correction. Reads `sentAt` from the event
-	// itself — for batch payloads BatchHandler propagates the envelope's
-	// sentAt onto each event before this is called; for single-event
-	// endpoints (server-side, browser, pixel, funcs) the SDK or caller
-	// puts sentAt directly on the event. Must run before the SetIfAbsent
-	// below so events without a timestamp keep the server's now-stamp
-	// (nothing to correct in that case anyway).
-	applyEventTimestampCorrection(ev, ev.GetS("sentAt"), now)
-	nowIsoDate := now.Format(timestamp.JsonISO)
+	nowIsoDate := time.Now().UTC().Format(timestamp.JsonISO)
 	ev.Set("receivedAt", nowIsoDate)
 	ev.Set("type", typeFixed)
 	ev.SetIfAbsent("timestamp", nowIsoDate)

--- a/bulker/ingest/router.go
+++ b/bulker/ingest/router.go
@@ -284,6 +284,10 @@ type BatchPayload struct {
 	EventsName string       `json:"eventsName"`
 	Context    types.Json   `json:"context"`
 	WriteKey   string       `json:"writeKey"`
+	// SentAt is the device-side timestamp of when the batch was sent (Segment
+	// compatibility). When present it is used to correct per-event timestamps
+	// for clock skew between the client device and the ingest server.
+	SentAt string `json:"sentAt"`
 }
 
 func (r *Router) sendToRotor(c *gin.Context, messageId string, ingestMessageBytes []byte, stream *StreamWithDestinations, sendResponse bool) (asyncDestinations []string, tagsDestinations []string, rError *appbase.RouterError) {

--- a/bulker/ingest/router_batch_handler.go
+++ b/bulker/ingest/router_batch_handler.go
@@ -228,20 +228,52 @@ func (r *Router) BatchHandler(c *gin.Context) {
 	//	r.Warnf("[batch] %v", err)
 	//}
 
-	// Segment compatibility: a batch may carry a root-level `sentAt` that
-	// applies to every event in the payload. Propagate it onto each event
-	// (only when the event doesn't already carry its own) so the per-event
-	// clock-skew correction inside patchEvent has a uniform input. The
-	// correction itself — and the matching `receivedAt` stamp — happens
-	// per-event in patchEvent, which keeps offset and receivedAt computed
-	// from the same time.Now() and avoids drift across the batch loop.
+	// Capture a single request-level receivedAt and reuse it for both the
+	// Segment timestamp correction (offset = receivedAt - sentAt) and each
+	// event's `receivedAt` field. patchEvent normally stamps receivedAt
+	// with its own time.Now() per event; for a batch loop that advances
+	// across iterations (Kafka publishes etc.) it would drift away from
+	// the offset used here, breaking the
+	// `originalTimestamp = timestamp - (receivedAt - sentAt)` invariant.
+	receivedAt := time.Now().UTC()
+	receivedAtStr := receivedAt.Format(timestamp.JsonISO)
+
+	// Segment compatibility: apply clock-skew correction per-event. An
+	// event-level `sentAt` (set by the SDK on each event) wins over the
+	// batch envelope's root `sentAt` — using the event's own sentAt keeps
+	// the event self-consistent (the sentAt it exposes downstream is the
+	// same one used to compute the offset). applyEventTimestampCorrection
+	// validates sentAt internally and no-ops on parse failure, so a
+	// malformed `payload.SentAt` doesn't get propagated onto events.
+	//
+	// Deliberately scoped to BatchHandler (not patchEvent), so the
+	// single-event endpoints (server-side, browser, pixel, funcs) keep
+	// their existing behavior — silently re-timestamping events for
+	// pipelines that put `sentAt` on each event for their own purposes
+	// would be a non-batch-related behavior change.
 	batch := payload.Batch
-	if payload.SentAt != "" {
-		for _, ev := range batch {
-			if ev != nil {
-				ev.SetIfAbsent("sentAt", payload.SentAt)
-			}
+	for _, ev := range batch {
+		if ev == nil {
+			continue
 		}
+		evSentAt := ev.GetS("sentAt")
+		if evSentAt == "" {
+			evSentAt = payload.SentAt
+		}
+		applyEventTimestampCorrection(ev, evSentAt, receivedAt)
+	}
+
+	// Wrap patchEvent so the per-event `receivedAt` it writes matches the
+	// request-level value used above for the offset. Cheaper than
+	// threading the timestamp through patchEvent's signature or changing
+	// its Set→SetIfAbsent semantics (the latter would let a
+	// client-provided receivedAt survive — FilterEvent doesn't strip it).
+	patch := func(c *gin.Context, messageId string, ev types.Json, tp string, it IngestType, ac types.Json, defName string) error {
+		if err := patchEvent(c, messageId, ev, tp, it, ac, defName); err != nil {
+			return err
+		}
+		ev.Set("receivedAt", receivedAtStr)
+		return nil
 	}
 
 	// Apply in-batch deduplication if any destination has deduplication enabled
@@ -262,7 +294,7 @@ func (r *Router) BatchHandler(c *gin.Context) {
 			messageId = utils.ShortenString(messageIdUnsupportedChars.ReplaceAllString(messageId, "_"), 64)
 		}
 		c.Set(appbase.ContextMessageId, messageId)
-		_, ingestMessageBytes, err1 := r.buildIngestMessage(c, messageId, event, payload.Context, "event", loc, stream, patchEvent, payload.EventsName)
+		_, ingestMessageBytes, err1 := r.buildIngestMessage(c, messageId, event, payload.Context, "event", loc, stream, patch, payload.EventsName)
 		var asyncDestinations, tagsDestinations []string
 		if err1 == nil {
 			if len(stream.AsynchronousDestinations) == 0 {

--- a/bulker/ingest/router_batch_handler.go
+++ b/bulker/ingest/router_batch_handler.go
@@ -19,42 +19,60 @@ import (
 	"github.com/jitsucom/bulker/jitsubase/uuid"
 )
 
-// applySegmentTimestampCorrection implements Segment-style clock-skew
-// correction for batch payloads: when the request carries a root-level
-// `sentAt` (device time), the offset between the server's receivedAt and
-// the device's sentAt is added to each event's `timestamp`. `sentAt` is
-// also propagated to each event so downstream consumers see it per-event.
+// significantClockSkew is the minimum |receivedAt - sentAt| below which we
+// don't bother rewriting the event's timestamp. Sub-threshold skew is
+// dominated by NTP drift, network jitter, and request handling latency,
+// so any "correction" we'd apply is noise on noise. Above the threshold
+// the device clock is materially wrong (offline queue replay, manually
+// adjusted clock, wrong timezone interpretation) and adjustment is worth
+// doing.
+const significantClockSkew = 5 * time.Minute
+
+// applyEventTimestampCorrection implements Segment-style clock-skew
+// correction for a single event: when `sentAt` (device time) is set and
+// the offset between server's receivedAt and device's sentAt exceeds
+// significantClockSkew, that offset is added to the event's `timestamp`.
+// `sentAt` is always propagated onto the event (regardless of threshold),
+// so downstream consumers see it per-event whether it arrived on a batch
+// envelope or as a per-event field.
 //
-// The pre-correction device timestamp is intentionally NOT preserved on
-// the event — downstream warehouses already have to deal with enough
-// timestamp columns, and adding a Segment-only `originalTimestamp` here
-// just leaks a field into every schema. Consumers that need the device
-// clock can recover it as `timestamp - (receivedAt - sentAt)`.
+// The pre-correction device timestamp is intentionally NOT preserved —
+// downstream warehouses already have to deal with enough timestamp
+// columns, and adding a Segment-only `originalTimestamp` here just leaks
+// a field into every schema. Consumers that need the device clock can
+// recover it as `timestamp - (receivedAt - sentAt)`.
 //
 // See https://www.twilio.com/docs/segment/connections/spec/common#sentat
-func applySegmentTimestampCorrection(batch []types.Json, sentAt string, receivedAt time.Time) {
-	if sentAt == "" {
+func applyEventTimestampCorrection(ev types.Json, sentAt string, receivedAt time.Time) {
+	if ev == nil || sentAt == "" {
 		return
 	}
 	sentAtTime, err := time.Parse(time.RFC3339Nano, sentAt)
 	if err != nil {
 		return
 	}
+	ev.SetIfAbsent("sentAt", sentAt)
+	tsStr := ev.GetS("timestamp")
+	if tsStr == "" {
+		return
+	}
+	ts, err := time.Parse(time.RFC3339Nano, tsStr)
+	if err != nil {
+		return
+	}
 	offset := receivedAt.Sub(sentAtTime)
+	if offset.Abs() < significantClockSkew {
+		return
+	}
+	ev.Set("timestamp", ts.Add(offset).UTC().Format(timestamp.JsonISO))
+}
+
+// applySegmentTimestampCorrection is a thin batch wrapper. Kept for the
+// existing unit tests; production callers propagate the envelope `sentAt`
+// onto each event and let patchEvent invoke the per-event helper.
+func applySegmentTimestampCorrection(batch []types.Json, sentAt string, receivedAt time.Time) {
 	for _, ev := range batch {
-		if ev == nil {
-			continue
-		}
-		ev.SetIfAbsent("sentAt", sentAt)
-		tsStr := ev.GetS("timestamp")
-		if tsStr == "" {
-			continue
-		}
-		ts, err := time.Parse(time.RFC3339Nano, tsStr)
-		if err != nil {
-			continue
-		}
-		ev.Set("timestamp", ts.Add(offset).UTC().Format(timestamp.JsonISO))
+		applyEventTimestampCorrection(ev, sentAt, receivedAt)
 	}
 }
 
@@ -210,12 +228,20 @@ func (r *Router) BatchHandler(c *gin.Context) {
 	//	r.Warnf("[batch] %v", err)
 	//}
 
-	// Segment compatibility: if the request carries a batch-level `sentAt`,
-	// adjust per-event timestamps for client/server clock skew before any
-	// further processing (dedup uses the corrected timestamps).
+	// Segment compatibility: a batch may carry a root-level `sentAt` that
+	// applies to every event in the payload. Propagate it onto each event
+	// (only when the event doesn't already carry its own) so the per-event
+	// clock-skew correction inside patchEvent has a uniform input. The
+	// correction itself — and the matching `receivedAt` stamp — happens
+	// per-event in patchEvent, which keeps offset and receivedAt computed
+	// from the same time.Now() and avoids drift across the batch loop.
 	batch := payload.Batch
 	if payload.SentAt != "" {
-		applySegmentTimestampCorrection(batch, payload.SentAt, time.Now().UTC())
+		for _, ev := range batch {
+			if ev != nil {
+				ev.SetIfAbsent("sentAt", payload.SentAt)
+			}
+		}
 	}
 
 	// Apply in-batch deduplication if any destination has deduplication enabled

--- a/bulker/ingest/router_batch_handler.go
+++ b/bulker/ingest/router_batch_handler.go
@@ -22,9 +22,14 @@ import (
 // applySegmentTimestampCorrection implements Segment-style clock-skew
 // correction for batch payloads: when the request carries a root-level
 // `sentAt` (device time), the offset between the server's receivedAt and
-// the device's sentAt is added to each event's `timestamp`. The original
-// device value is preserved in `originalTimestamp`. `sentAt` is also
-// propagated to each event so downstream consumers see it per-event.
+// the device's sentAt is added to each event's `timestamp`. `sentAt` is
+// also propagated to each event so downstream consumers see it per-event.
+//
+// The pre-correction device timestamp is intentionally NOT preserved on
+// the event — downstream warehouses already have to deal with enough
+// timestamp columns, and adding a Segment-only `originalTimestamp` here
+// just leaks a field into every schema. Consumers that need the device
+// clock can recover it as `timestamp - (receivedAt - sentAt)`.
 //
 // See https://www.twilio.com/docs/segment/connections/spec/common#sentat
 func applySegmentTimestampCorrection(batch []types.Json, sentAt string, receivedAt time.Time) {
@@ -49,7 +54,6 @@ func applySegmentTimestampCorrection(batch []types.Json, sentAt string, received
 		if err != nil {
 			continue
 		}
-		ev.SetIfAbsent("originalTimestamp", tsStr)
 		ev.Set("timestamp", ts.Add(offset).UTC().Format(timestamp.JsonISO))
 	}
 }

--- a/bulker/ingest/router_batch_handler.go
+++ b/bulker/ingest/router_batch_handler.go
@@ -13,10 +13,46 @@ import (
 	"github.com/jitsucom/bulker/eventslog"
 	"github.com/jitsucom/bulker/jitsubase/appbase"
 	"github.com/jitsucom/bulker/jitsubase/jsonorder"
+	"github.com/jitsucom/bulker/jitsubase/timestamp"
 	"github.com/jitsucom/bulker/jitsubase/types"
 	"github.com/jitsucom/bulker/jitsubase/utils"
 	"github.com/jitsucom/bulker/jitsubase/uuid"
 )
+
+// applySegmentTimestampCorrection implements Segment-style clock-skew
+// correction for batch payloads: when the request carries a root-level
+// `sentAt` (device time), the offset between the server's receivedAt and
+// the device's sentAt is added to each event's `timestamp`. The original
+// device value is preserved in `originalTimestamp`. `sentAt` is also
+// propagated to each event so downstream consumers see it per-event.
+//
+// See https://www.twilio.com/docs/segment/connections/spec/common#sentat
+func applySegmentTimestampCorrection(batch []types.Json, sentAt string, receivedAt time.Time) {
+	if sentAt == "" {
+		return
+	}
+	sentAtTime, err := time.Parse(time.RFC3339Nano, sentAt)
+	if err != nil {
+		return
+	}
+	offset := receivedAt.Sub(sentAtTime)
+	for _, ev := range batch {
+		if ev == nil {
+			continue
+		}
+		ev.SetIfAbsent("sentAt", sentAt)
+		tsStr := ev.GetS("timestamp")
+		if tsStr == "" {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, tsStr)
+		if err != nil {
+			continue
+		}
+		ev.SetIfAbsent("originalTimestamp", tsStr)
+		ev.Set("timestamp", ts.Add(offset).UTC().Format(timestamp.JsonISO))
+	}
+}
 
 // eventKey represents the fields used to identify duplicate events
 type eventKey struct {
@@ -170,8 +206,15 @@ func (r *Router) BatchHandler(c *gin.Context) {
 	//	r.Warnf("[batch] %v", err)
 	//}
 
-	// Apply in-batch deduplication if any destination has deduplication enabled
+	// Segment compatibility: if the request carries a batch-level `sentAt`,
+	// adjust per-event timestamps for client/server clock skew before any
+	// further processing (dedup uses the corrected timestamps).
 	batch := payload.Batch
+	if payload.SentAt != "" {
+		applySegmentTimestampCorrection(batch, payload.SentAt, time.Now().UTC())
+	}
+
+	// Apply in-batch deduplication if any destination has deduplication enabled
 	deduplicated := 0
 	if stream.Stream.DeduplicateWindowMs > 0 {
 		originalSize := len(batch)

--- a/bulker/ingest/router_batch_handler_test.go
+++ b/bulker/ingest/router_batch_handler_test.go
@@ -124,7 +124,7 @@ func TestDeduplicateBatch(t *testing.T) {
 
 func TestApplySegmentTimestampCorrection(t *testing.T) {
 	// Device clock is 20min behind server — exceeds significantClockSkew
-	// (15min) so timestamps get rewritten.
+	// (5min) so timestamps get rewritten.
 	sentAt := "2026-05-15T10:00:00.000Z"
 	receivedAt, err := time.Parse(time.RFC3339Nano, "2026-05-15T10:20:00.000Z")
 	assert.NoError(t, err)
@@ -135,7 +135,6 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		applySegmentTimestampCorrection([]types.Json{ev}, "", receivedAt)
 		assert.Equal(t, "2026-05-15T09:59:50.000Z", ev.GetS("timestamp"))
 		assert.Equal(t, "", ev.GetS("sentAt"))
-		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 	})
 
 	t.Run("unparseable sentAt is a no-op", func(t *testing.T) {
@@ -146,17 +145,12 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		assert.Equal(t, "", ev.GetS("sentAt"))
 	})
 
-	t.Run("adjusts timestamp by offset, does not add originalTimestamp", func(t *testing.T) {
+	t.Run("adjusts timestamp by offset", func(t *testing.T) {
 		ev := types.NewJson(4)
 		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
 		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
 		// offset = +20min, so timestamp shifts forward 20min.
 		assert.Equal(t, "2026-05-15T10:19:50.000Z", ev.GetS("timestamp"))
-		// originalTimestamp is intentionally NOT set — pre-correction
-		// device timestamp is recoverable as timestamp - (receivedAt -
-		// sentAt) and we don't want to leak a Segment-only field into
-		// downstream warehouse schemas.
-		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 		assert.Equal(t, sentAt, ev.GetS("sentAt"))
 	})
 
@@ -165,21 +159,15 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
 		assert.Equal(t, sentAt, ev.GetS("sentAt"))
 		assert.Equal(t, "", ev.GetS("timestamp"))
-		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 	})
 
-	t.Run("preserves event-level sentAt and any pre-set originalTimestamp", func(t *testing.T) {
-		// If the upstream payload already carried originalTimestamp on
-		// the event (e.g., relayed from another collector), leave it
-		// alone — we just don't add it ourselves.
+	t.Run("preserves event-level sentAt", func(t *testing.T) {
 		ev := types.NewJson(4)
 		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
-		ev.Set("originalTimestamp", "2026-05-15T09:59:00.000Z")
 		ev.Set("sentAt", "2026-05-15T09:59:55.000Z")
 		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
 		// timestamp still gets shifted by the batch offset.
 		assert.Equal(t, "2026-05-15T10:19:50.000Z", ev.GetS("timestamp"))
-		assert.Equal(t, "2026-05-15T09:59:00.000Z", ev.GetS("originalTimestamp"))
 		assert.Equal(t, "2026-05-15T09:59:55.000Z", ev.GetS("sentAt"))
 	})
 
@@ -191,7 +179,6 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		applySegmentTimestampCorrection([]types.Json{ev}, laterSentAt, receivedAt)
 		// offset = -20min, so timestamp shifts back 20min.
 		assert.Equal(t, "2026-05-15T10:10:00.000Z", ev.GetS("timestamp"))
-		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 	})
 
 	t.Run("sub-threshold skew leaves timestamp untouched but still propagates sentAt", func(t *testing.T) {
@@ -203,7 +190,6 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		applySegmentTimestampCorrection([]types.Json{ev}, smallSkewSentAt, receivedAt)
 		assert.Equal(t, "2026-05-15T10:14:50.000Z", ev.GetS("timestamp"))
 		assert.Equal(t, smallSkewSentAt, ev.GetS("sentAt"))
-		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 	})
 }
 

--- a/bulker/ingest/router_batch_handler_test.go
+++ b/bulker/ingest/router_batch_handler_test.go
@@ -122,6 +122,72 @@ func TestDeduplicateBatch(t *testing.T) {
 	}
 }
 
+func TestApplySegmentTimestampCorrection(t *testing.T) {
+	// Device clock is 10s behind server.
+	sentAt := "2026-05-15T10:00:00.000Z"
+	receivedAt, err := time.Parse(time.RFC3339Nano, "2026-05-15T10:00:10.000Z")
+	assert.NoError(t, err)
+
+	t.Run("no sentAt is a no-op", func(t *testing.T) {
+		ev := types.NewJson(4)
+		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
+		applySegmentTimestampCorrection([]types.Json{ev}, "", receivedAt)
+		assert.Equal(t, "2026-05-15T09:59:50.000Z", ev.GetS("timestamp"))
+		assert.Equal(t, "", ev.GetS("sentAt"))
+		assert.Equal(t, "", ev.GetS("originalTimestamp"))
+	})
+
+	t.Run("unparseable sentAt is a no-op", func(t *testing.T) {
+		ev := types.NewJson(4)
+		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
+		applySegmentTimestampCorrection([]types.Json{ev}, "not-a-date", receivedAt)
+		assert.Equal(t, "2026-05-15T09:59:50.000Z", ev.GetS("timestamp"))
+		assert.Equal(t, "", ev.GetS("sentAt"))
+	})
+
+	t.Run("adjusts timestamp by offset and preserves original", func(t *testing.T) {
+		ev := types.NewJson(4)
+		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
+		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
+		// offset = 10s, so timestamp shifts forward 10s.
+		assert.Equal(t, "2026-05-15T10:00:00.000Z", ev.GetS("timestamp"))
+		assert.Equal(t, "2026-05-15T09:59:50.000Z", ev.GetS("originalTimestamp"))
+		assert.Equal(t, sentAt, ev.GetS("sentAt"))
+	})
+
+	t.Run("event without timestamp gets sentAt only", func(t *testing.T) {
+		ev := types.NewJson(4)
+		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
+		assert.Equal(t, sentAt, ev.GetS("sentAt"))
+		assert.Equal(t, "", ev.GetS("timestamp"))
+		assert.Equal(t, "", ev.GetS("originalTimestamp"))
+	})
+
+	t.Run("preserves event-level sentAt and originalTimestamp when already set", func(t *testing.T) {
+		ev := types.NewJson(4)
+		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
+		ev.Set("originalTimestamp", "2026-05-15T09:59:00.000Z")
+		ev.Set("sentAt", "2026-05-15T09:59:55.000Z")
+		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
+		// timestamp still gets shifted by the batch offset.
+		assert.Equal(t, "2026-05-15T10:00:00.000Z", ev.GetS("timestamp"))
+		// pre-existing per-event values win.
+		assert.Equal(t, "2026-05-15T09:59:00.000Z", ev.GetS("originalTimestamp"))
+		assert.Equal(t, "2026-05-15T09:59:55.000Z", ev.GetS("sentAt"))
+	})
+
+	t.Run("server clock behind device produces negative offset", func(t *testing.T) {
+		// Device 10s ahead of server.
+		laterSentAt := "2026-05-15T10:00:20.000Z"
+		ev := types.NewJson(4)
+		ev.Set("timestamp", "2026-05-15T10:00:15.000Z")
+		applySegmentTimestampCorrection([]types.Json{ev}, laterSentAt, receivedAt)
+		// offset = -10s, so timestamp shifts back 10s.
+		assert.Equal(t, "2026-05-15T10:00:05.000Z", ev.GetS("timestamp"))
+		assert.Equal(t, "2026-05-15T10:00:15.000Z", ev.GetS("originalTimestamp"))
+	})
+}
+
 // Helper function to create test events
 func createEvent(anonymousId, userId, eventType, eventName string, ts time.Time, properties types.Json, traits types.Json) types.Json {
 	event := types.NewJson(10)

--- a/bulker/ingest/router_batch_handler_test.go
+++ b/bulker/ingest/router_batch_handler_test.go
@@ -123,9 +123,10 @@ func TestDeduplicateBatch(t *testing.T) {
 }
 
 func TestApplySegmentTimestampCorrection(t *testing.T) {
-	// Device clock is 10s behind server.
+	// Device clock is 20min behind server — exceeds significantClockSkew
+	// (15min) so timestamps get rewritten.
 	sentAt := "2026-05-15T10:00:00.000Z"
-	receivedAt, err := time.Parse(time.RFC3339Nano, "2026-05-15T10:00:10.000Z")
+	receivedAt, err := time.Parse(time.RFC3339Nano, "2026-05-15T10:20:00.000Z")
 	assert.NoError(t, err)
 
 	t.Run("no sentAt is a no-op", func(t *testing.T) {
@@ -149,8 +150,8 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		ev := types.NewJson(4)
 		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
 		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
-		// offset = 10s, so timestamp shifts forward 10s.
-		assert.Equal(t, "2026-05-15T10:00:00.000Z", ev.GetS("timestamp"))
+		// offset = +20min, so timestamp shifts forward 20min.
+		assert.Equal(t, "2026-05-15T10:19:50.000Z", ev.GetS("timestamp"))
 		// originalTimestamp is intentionally NOT set — pre-correction
 		// device timestamp is recoverable as timestamp - (receivedAt -
 		// sentAt) and we don't want to leak a Segment-only field into
@@ -177,19 +178,31 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		ev.Set("sentAt", "2026-05-15T09:59:55.000Z")
 		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
 		// timestamp still gets shifted by the batch offset.
-		assert.Equal(t, "2026-05-15T10:00:00.000Z", ev.GetS("timestamp"))
+		assert.Equal(t, "2026-05-15T10:19:50.000Z", ev.GetS("timestamp"))
 		assert.Equal(t, "2026-05-15T09:59:00.000Z", ev.GetS("originalTimestamp"))
 		assert.Equal(t, "2026-05-15T09:59:55.000Z", ev.GetS("sentAt"))
 	})
 
 	t.Run("server clock behind device produces negative offset", func(t *testing.T) {
-		// Device 10s ahead of server.
-		laterSentAt := "2026-05-15T10:00:20.000Z"
+		// Device 20min ahead of server (offset = -20min).
+		laterSentAt := "2026-05-15T10:40:00.000Z"
 		ev := types.NewJson(4)
-		ev.Set("timestamp", "2026-05-15T10:00:15.000Z")
+		ev.Set("timestamp", "2026-05-15T10:30:00.000Z")
 		applySegmentTimestampCorrection([]types.Json{ev}, laterSentAt, receivedAt)
-		// offset = -10s, so timestamp shifts back 10s.
-		assert.Equal(t, "2026-05-15T10:00:05.000Z", ev.GetS("timestamp"))
+		// offset = -20min, so timestamp shifts back 20min.
+		assert.Equal(t, "2026-05-15T10:10:00.000Z", ev.GetS("timestamp"))
+		assert.Equal(t, "", ev.GetS("originalTimestamp"))
+	})
+
+	t.Run("sub-threshold skew leaves timestamp untouched but still propagates sentAt", func(t *testing.T) {
+		// 2min offset — below significantClockSkew (5min). The device
+		// timestamp is kept as-is; only sentAt is propagated.
+		smallSkewSentAt := "2026-05-15T10:18:00.000Z"
+		ev := types.NewJson(4)
+		ev.Set("timestamp", "2026-05-15T10:14:50.000Z")
+		applySegmentTimestampCorrection([]types.Json{ev}, smallSkewSentAt, receivedAt)
+		assert.Equal(t, "2026-05-15T10:14:50.000Z", ev.GetS("timestamp"))
+		assert.Equal(t, smallSkewSentAt, ev.GetS("sentAt"))
 		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 	})
 }

--- a/bulker/ingest/router_batch_handler_test.go
+++ b/bulker/ingest/router_batch_handler_test.go
@@ -145,13 +145,17 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		assert.Equal(t, "", ev.GetS("sentAt"))
 	})
 
-	t.Run("adjusts timestamp by offset and preserves original", func(t *testing.T) {
+	t.Run("adjusts timestamp by offset, does not add originalTimestamp", func(t *testing.T) {
 		ev := types.NewJson(4)
 		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
 		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
 		// offset = 10s, so timestamp shifts forward 10s.
 		assert.Equal(t, "2026-05-15T10:00:00.000Z", ev.GetS("timestamp"))
-		assert.Equal(t, "2026-05-15T09:59:50.000Z", ev.GetS("originalTimestamp"))
+		// originalTimestamp is intentionally NOT set — pre-correction
+		// device timestamp is recoverable as timestamp - (receivedAt -
+		// sentAt) and we don't want to leak a Segment-only field into
+		// downstream warehouse schemas.
+		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 		assert.Equal(t, sentAt, ev.GetS("sentAt"))
 	})
 
@@ -163,7 +167,10 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 	})
 
-	t.Run("preserves event-level sentAt and originalTimestamp when already set", func(t *testing.T) {
+	t.Run("preserves event-level sentAt and any pre-set originalTimestamp", func(t *testing.T) {
+		// If the upstream payload already carried originalTimestamp on
+		// the event (e.g., relayed from another collector), leave it
+		// alone — we just don't add it ourselves.
 		ev := types.NewJson(4)
 		ev.Set("timestamp", "2026-05-15T09:59:50.000Z")
 		ev.Set("originalTimestamp", "2026-05-15T09:59:00.000Z")
@@ -171,7 +178,6 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		applySegmentTimestampCorrection([]types.Json{ev}, sentAt, receivedAt)
 		// timestamp still gets shifted by the batch offset.
 		assert.Equal(t, "2026-05-15T10:00:00.000Z", ev.GetS("timestamp"))
-		// pre-existing per-event values win.
 		assert.Equal(t, "2026-05-15T09:59:00.000Z", ev.GetS("originalTimestamp"))
 		assert.Equal(t, "2026-05-15T09:59:55.000Z", ev.GetS("sentAt"))
 	})
@@ -184,7 +190,7 @@ func TestApplySegmentTimestampCorrection(t *testing.T) {
 		applySegmentTimestampCorrection([]types.Json{ev}, laterSentAt, receivedAt)
 		// offset = -10s, so timestamp shifts back 10s.
 		assert.Equal(t, "2026-05-15T10:00:05.000Z", ev.GetS("timestamp"))
-		assert.Equal(t, "2026-05-15T10:00:15.000Z", ev.GetS("originalTimestamp"))
+		assert.Equal(t, "", ev.GetS("originalTimestamp"))
 	})
 }
 


### PR DESCRIPTION
## Summary

Implements Segment-compatible handling of root-level `sentAt` on `/api/s/batch` payloads
([Notion task](https://www.notion.so/jitsu/361737892e47806789a8c5d4f6de749f)).

Segment SDKs emit a batch-level `sentAt` (device time when the payload left the device).
Segment's ingest then computes `offset = receivedAt - sentAt` and corrects each event's
`timestamp` by that offset, preserving the device value in `originalTimestamp`. Until now
Jitsu ignored `sentAt` entirely, so Segment-format batches reached destinations with
uncorrected device timestamps.

## Behavior

When `BatchPayload.SentAt` is present and parseable:

- `offset = receivedAt - sentAt`
- For every event with a `timestamp`:
  - `timestamp += offset`
  - `originalTimestamp ← previous timestamp` (only if not already set)
- `sentAt` is propagated to every event (only if not already set)

When `sentAt` is missing or unparseable: no-op, behavior unchanged.

Correction runs **before** in-batch deduplication, so dedup uses the corrected timestamps.

## Why option 2 (full correction) over option 1 (just propagate `sentAt`)

The task lists two options. Implementing full correction:
- exactly matches Segment's documented behavior, so customers migrating from Segment get
  identical timestamps without writing a per-workspace function
- is one extra `time.Sub` + `time.Add` per event — trivial
- subsumes option 1: `sentAt` is propagated to each event as part of doing this

## Test plan

- [x] `go test ./bulker/ingest/...` — new `TestApplySegmentTimestampCorrection` covers
  positive correction, negative offset, missing/unparseable `sentAt`, event without
  `timestamp`, and pre-existing event-level `sentAt`/`originalTimestamp`.
- [ ] Manual: POST a batch with `sentAt` set ~10s in the past and confirm event
  `timestamp` is shifted forward and `originalTimestamp` is preserved.