### PR TITLE
fix(webapps): harden HTTP security headers

### DIFF
--- a/webapps/console/next.config.js
+++ b/webapps/console/next.config.js
@@ -8,6 +8,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 });
 
 module.exports = withBundleAnalyzer({
+  poweredByHeader: false,
   transpilePackages: ["juava", "@jitsu/protocols", "@jitsu/core-functions-lib", "@jitsu/destination-functions", "@jitsu-internal/webapps-shared", "@jitsu/js"],
   // Allow portless dev hosts (https://console[-branch].jitsu.localhost) to
   // load /_next/* resources. Without this Next 15+ blocks them as cross-origin.
@@ -49,7 +50,6 @@ module.exports = withBundleAnalyzer({
   //   },
   // },
   async headers() {
-    //set cors headers
     return [
       {
         source: "/:path*{/}?",
@@ -61,6 +61,14 @@ module.exports = withBundleAnalyzer({
           {
             key: "X-Content-Type-Options",
             value: "nosniff",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
           },
         ],
       },

--- a/webapps/console/public/.well-known/security.txt
+++ b/webapps/console/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:security@jitsu.com
+Expires: 2027-05-19T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://use.jitsu.com/.well-known/security.txt

--- a/webapps/console/public/robots.txt
+++ b/webapps/console/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/webapps/ee-api/next.config.js
+++ b/webapps/ee-api/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const path = require("path");
 module.exports =  {
+  poweredByHeader: false,
   transpilePackages: ["juava"],
   turbopack: {
     // See webapps/console/next.config.js for the rationale.
@@ -28,6 +29,10 @@ module.exports =  {
           {
             key: "X-Content-Type-Options",
             value: "nosniff",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
           },
         ],
       },


### PR DESCRIPTION
## Summary

Bundles the trivial config / static-file remediations from the April 2026
pen test (Upbeat Security) — [tracking page](https://www.notion.so/365737892e4780899817ebc70828d7e6).
These are low-risk, no-logic-change fixes:

- [JITSU-009](https://www.notion.so/365737892e47817aa547c95f533b16f3) —
  `poweredByHeader: false` on console and ee-api (drop the
  `X-Powered-By: Next.js` header).
- [JITSU-005](https://www.notion.so/365737892e47818a826dd6f6e008b516) — add
  `Referrer-Policy: strict-origin-when-cross-origin` and `Permissions-Policy`
  to the console; add `Referrer-Policy` to ee-api. Existing
  `X-Frame-Options` / `X-Content-Type-Options` kept.
- [JITSU-010](https://www.notion.so/365737892e4781dfaf6efda2e7efcb61) —
  publish an RFC 9116 `/.well-known/security.txt`.
- [JITSU-012](https://www.notion.so/365737892e478108bb17c14127bb3640) — add a
  disallow-all `robots.txt` to the console (admin UI, nothing should be
  indexed).

### Deliberately out of scope

- **CSP** (part of JITSU-005) — a real Content-Security-Policy for the
  console needs nonce wiring and iteration to avoid breaking the app;
  tracked separately, not a one-line config change.
- CORS, JWT error messages, healthcheck trimming, NextAuth route removal —
  those are logic changes, handled in their own PRs.

### Note

`security.txt` uses `mailto:security@jitsu.com` and an `Expires` one year
out — confirm the contact address before merge.

## Test plan

- [ ] `pnpm console:dev` — confirm responses carry `Referrer-Policy` /
  `Permissions-Policy` and no `X-Powered-By`.
- [ ] `GET /robots.txt` and `GET /.well-known/security.txt` return the new
  files.
- [ ] ee-api responses no longer carry `X-Powered-By`.
