### PR TITLE
feat(console): rebuild Firebase signup and email-verification flow

### DIFF
--- a/webapps/console/components/SignInOrUp/EmailFirstLogin.tsx
+++ b/webapps/console/components/SignInOrUp/EmailFirstLogin.tsx
@@ -176,7 +176,6 @@ export const EmailFirstLogin: React.FC<EmailFirstLoginProps> = ({ onPasswordLogi
             onPressEnter={checkAuthMethod}
             disabled={checkingEmail || loading}
           />
-          <div className="mt-2 text-sm text-textLight">Use this for SSO and password based logins</div>
         </div>
 
         {!authMethod && (

--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -1,36 +1,14 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Alert, Button, Input } from "antd";
-import { GithubOutlined } from "@ant-design/icons";
+import { Alert, Button, Divider, Input } from "antd";
 import { branding } from "../../lib/branding";
 import { useFirebaseSession } from "../../lib/firebase-client";
 import { safeRedirect } from "../../lib/auth-redirect";
 import { useJitsu } from "@jitsu/jitsu-react";
+import { OAuthButtons } from "./OAuthButtons";
 import { AuthType, handleFirebaseError } from "./SignInOrUp";
 import { useQueryStringCopy } from "./use-query-string-copy";
-
-/** Full-colour Google "G" mark for the OAuth button. */
-const GoogleG: React.FC = () => (
-  <svg viewBox="0 0 48 48" width="18" height="18" xmlns="http://www.w3.org/2000/svg">
-    <path
-      fill="#4285F4"
-      d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
-    />
-    <path
-      fill="#34A853"
-      d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
-    />
-    <path
-      fill="#FBBC05"
-      d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34A21.99 21.99 0 0 0 2 24c0 3.55.85 6.91 2.34 9.88l7.35-5.7z"
-    />
-    <path
-      fill="#EA4335"
-      d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
-    />
-  </svg>
-);
 
 const panelFeatures = [
   {
@@ -52,9 +30,90 @@ const panelFeatures = [
 
 const customers = ["Investing.com", "PandaDoc", "Rarible", "Census", "Embeddables"];
 
-/** Syntax-coloured token helpers for the code sample. */
-const Kw: React.FC<{ children: ReactNode }> = ({ children }) => <span className="text-[#c792ea]">{children}</span>;
-const Fn: React.FC<{ children: ReactNode }> = ({ children }) => <span className="text-[#82aaff]">{children}</span>;
+const snippets = [
+  {
+    file: "enrich.ts",
+    badge: "JITSU FUNCTION",
+    code: `export default async function (event, { store }) {
+  const geo = await store.get(event.ip);
+  event.country = geo?.country ?? "unknown";
+  return event;
+}`,
+  },
+  {
+    file: "track.ts",
+    badge: "BROWSER SDK",
+    code: `import { jitsuAnalytics } from "@jitsu/js";
+
+const jitsu = jitsuAnalytics({ writeKey: "KEY" });
+jitsu.identify("user_42", { email });
+jitsu.track("Signup Completed", { plan: "pro" });`,
+  },
+];
+
+// Tiny token highlighter for the (fixed, trusted) code samples — keeps the
+// snippets as plain strings instead of hand-written colored JSX.
+const CODE_TOKEN =
+  /(`[^`]*`|"[^"]*"|'[^']*'|\b(?:import|from|export|default|async|function|const|await|return|new)\b)/g;
+const KEYWORD = /^(?:import|from|export|default|async|function|const|await|return|new)$/;
+
+function highlightLine(line: string): ReactNode {
+  if (line === "") {
+    return " ";
+  }
+  return line.split(CODE_TOKEN).map((part, i) => {
+    if (!part) {
+      return null;
+    }
+    if (part[0] === "`" || part[0] === '"' || part[0] === "'") {
+      return (
+        <span key={i} className="text-[#c3e88d]">
+          {part}
+        </span>
+      );
+    }
+    if (KEYWORD.test(part)) {
+      return (
+        <span key={i} className="text-[#c792ea]">
+          {part}
+        </span>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
+/** Code card that auto-cycles through the snippets like switching tabs. */
+const CodeShowcase: React.FC = () => {
+  const [active, setActive] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setActive(a => (a + 1) % snippets.length), 4500);
+    return () => clearInterval(t);
+  }, []);
+  const snippet = snippets[active];
+  return (
+    <div className="rounded-xl border border-white/10 overflow-hidden" style={{ background: "#0e0d18" }}>
+      <div className="flex items-center justify-between border-b border-white/10 px-4 py-2.5">
+        <div className="flex items-center gap-3 font-mono text-xs">
+          <span className="h-2 w-2 rounded-full bg-green-400" />
+          {snippets.map((s, i) => (
+            <span key={s.file} className={i === active ? "text-white" : "text-white/30"}>
+              {s.file}
+            </span>
+          ))}
+        </div>
+        <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">
+          {snippet.badge}
+        </span>
+      </div>
+      <div className="whitespace-pre overflow-x-auto p-4 font-mono text-[12px] leading-[1.7] text-slate-200">
+        {snippet.code.split("\n").map((line, i) => (
+          <div key={i}>{highlightLine(line)}</div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 /** Left-hand testimonial / proof panel. Hidden below `lg`. */
 const MarketingPanel: React.FC = () => (
@@ -62,8 +121,8 @@ const MarketingPanel: React.FC = () => (
     className="hidden lg:flex lg:w-1/2 p-10 xl:p-14 text-white overflow-y-auto"
     style={{ background: "linear-gradient(155deg, #1c1640 0%, #2a1b53 55%, #211a48 100%)" }}
   >
-    {/* one column — every section shares the testimonial's width */}
-    <div className="flex w-full max-w-xl flex-col justify-between gap-9">
+    {/* one column — every section shares the same width */}
+    <div className="flex w-full max-w-2xl flex-col justify-between gap-9">
       {/* header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -102,59 +161,8 @@ const MarketingPanel: React.FC = () => (
         </div>
       </div>
 
-      {/* cards */}
-      <div className="flex gap-4">
-        <div
-          className="flex-[2] min-w-0 rounded-xl border border-white/10 overflow-hidden"
-          style={{ background: "#0e0d18" }}
-        >
-          <div className="flex items-center justify-between px-4 py-2.5 border-b border-white/10">
-            <div className="flex items-center gap-2 font-mono text-xs text-white/60">
-              <span className="h-2 w-2 rounded-full bg-green-400" />
-              enrich.ts
-            </div>
-            <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">
-              JITSU FUNCTION
-            </span>
-          </div>
-          <div className="p-4 font-mono text-[11px] leading-[1.8] whitespace-pre text-slate-200 overflow-x-auto">
-            <div>
-              <Kw>export default async function</Kw>
-              {" (event, { store, fetch }) {"}
-            </div>
-            <div>
-              {"  "}
-              <Kw>const</Kw>
-              {" geo = "}
-              <Kw>await</Kw>
-              {" store."}
-              <Fn>get</Fn>
-              {"(event.ip)"}
-            </div>
-            <div>
-              {"    ?? "}
-              <Kw>await</Kw> <Fn>fetch</Fn>
-              {"("}
-              <span className="text-[#c3e88d]">{"`/geo/${event.ip}`"}</span>
-              {");"}
-            </div>
-            <div>{"  event.properties.country = geo.country;"}</div>
-            <div>
-              {"  "}
-              <Kw>return</Kw>
-              {" event;"}
-            </div>
-            <div>{"}"}</div>
-          </div>
-        </div>
-        <div className="flex-1 min-w-0 rounded-xl border border-white/10 bg-white/5 p-4 flex flex-col">
-          <div className="text-[10px] tracking-[0.18em] text-white/45">TIME TO FIRST EVENT</div>
-          <div className="mt-auto pt-6">
-            <span className="text-4xl font-bold">43</span>
-            <span className="ml-1 text-sm text-white/55">sec</span>
-          </div>
-        </div>
-      </div>
+      {/* code showcase */}
+      <CodeShowcase />
 
       {/* features */}
       <div className="grid grid-cols-3 gap-6 border-t border-white/10 pt-6">
@@ -202,7 +210,6 @@ export const FirebaseSignup: React.FC = () => {
   const [error, setError] = useState<ReactNode | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [emailConfirmed, setEmailConfirmed] = useState(false);
-  const [oauthLoading, setOauthLoading] = useState<AuthType | null>(null);
 
   const callbackUrl = (router.query.callbackUrl as string) || "/";
 
@@ -280,7 +287,6 @@ export const FirebaseSignup: React.FC = () => {
   // OAuth signup is the same popup path as sign-in — Firebase creates the account
   // on first login. signInWith already records the login and fires analytics.
   const handleSSOLogin = async (provider: AuthType) => {
-    setOauthLoading(provider);
     setError(null);
     try {
       await firebaseSession.signInWith(provider === "firebase-google" ? "google.com" : "github.com");
@@ -292,8 +298,6 @@ export const FirebaseSignup: React.FC = () => {
         loginProvider: `firebase/${provider}`,
         message: e?.message || "Unknown error",
       });
-    } finally {
-      setOauthLoading(null);
     }
   };
 
@@ -318,32 +322,17 @@ export const FirebaseSignup: React.FC = () => {
             </h1>
             <p className="mt-3 text-textLight">Free for 200k events/month. No credit card required.</p>
 
-            <div className="mt-7 grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <Button
-                size="large"
-                icon={<GoogleG />}
-                loading={oauthLoading === "firebase-google"}
-                disabled={!!oauthLoading}
-                onClick={() => handleSSOLogin("firebase-google")}
-              >
-                Continue with Google
-              </Button>
-              <Button
-                size="large"
-                icon={<GithubOutlined />}
-                loading={oauthLoading === "firebase-github"}
-                disabled={!!oauthLoading}
-                onClick={() => handleSSOLogin("firebase-github")}
-              >
-                Continue with GitHub
-              </Button>
+            <div className="mt-4">
+              <OAuthButtons
+                prefix="Continue"
+                providers={["firebase-google", "firebase-github"]}
+                onSSOLogin={handleSSOLogin}
+              />
             </div>
 
-            <div className="my-6 flex items-center gap-3 text-[11px] tracking-[0.18em] text-textLight">
-              <div className="h-px flex-1 bg-backgroundDark" />
-              OR WITH EMAIL
-              <div className="h-px flex-1 bg-backgroundDark" />
-            </div>
+            <Divider plain>
+              <span className="text-xs uppercase tracking-widest text-textLight">or with email</span>
+            </Divider>
 
             <div className="space-y-4">
               <div>
@@ -424,31 +413,32 @@ export const FirebaseSignup: React.FC = () => {
                   >
                     Create account →
                   </Button>
-                  <p className="text-center text-xs text-textLight">
-                    By creating an account, you agree to our{" "}
-                    <a
-                      className="underline hover:text-primary"
-                      href="https://jitsu.com/tos"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Terms
-                    </a>{" "}
-                    and{" "}
-                    <a
-                      className="underline hover:text-primary"
-                      href="https://jitsu.com/privacy"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Privacy Policy
-                    </a>
-                    .
-                  </p>
                 </>
               )}
 
               {error && <Alert type="error" message={error} closable onClose={() => setError(null)} />}
+
+              <p className="text-center text-xs text-textLight">
+                By signing up, you agree to our{" "}
+                <a
+                  className="underline hover:text-primary"
+                  href="https://jitsu.com/tos"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Terms of Service
+                </a>{" "}
+                and{" "}
+                <a
+                  className="underline hover:text-primary"
+                  href="https://jitsu.com/privacy"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Privacy Policy
+                </a>
+                .
+              </p>
             </div>
           </div>
         </div>

--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -108,8 +108,19 @@ export const FirebaseSignup: React.FC = () => {
   const [confirm, setConfirm] = useState("");
   const [error, setError] = useState<ReactNode | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [emailConfirmed, setEmailConfirmed] = useState(false);
 
   const callbackUrl = (router.query.callbackUrl as string) || "/";
+
+  // Step 1 → 2: reveal the password fields only once a plausible email is entered.
+  const handleContinue = () => {
+    if (!email || !email.includes("@")) {
+      setError("Please enter a valid email address");
+      return;
+    }
+    setError(null);
+    setEmailConfirmed(true);
+  };
 
   const validate = (): string | null => {
     if (!email || !email.includes("@")) {
@@ -224,65 +235,83 @@ export const FirebaseSignup: React.FC = () => {
                 onChange={e => {
                   setEmail(e.target.value);
                   setError(null);
+                  setEmailConfirmed(false);
                 }}
                 placeholder="Enter your email address"
-                disabled={submitting}
-              />
-            </div>
-            <div>
-              <FieldLabel icon={<LockOutlined />}>Password</FieldLabel>
-              <Input.Password
-                size="large"
-                autoComplete="new-password"
-                value={password}
-                onChange={e => {
-                  setPassword(e.target.value);
-                  setError(null);
-                }}
-                placeholder="Create a password (min 6 characters)"
-                disabled={submitting}
-              />
-            </div>
-            <div>
-              <FieldLabel icon={<LockOutlined />}>Confirm password</FieldLabel>
-              <Input.Password
-                size="large"
-                autoComplete="new-password"
-                value={confirm}
-                onChange={e => {
-                  setConfirm(e.target.value);
-                  setError(null);
-                }}
-                placeholder="Re-enter your password"
-                onPressEnter={handleSignup}
+                onPressEnter={handleContinue}
                 disabled={submitting}
               />
             </div>
 
-            <Button
-              className="w-full"
-              type="primary"
-              size="large"
-              loading={submitting}
-              onClick={handleSignup}
-              disabled={!email || !password || !confirm}
-            >
-              Create account
-            </Button>
+            {!emailConfirmed && (
+              <Button
+                className="w-full"
+                type="primary"
+                size="large"
+                onClick={handleContinue}
+                disabled={!email || !email.includes("@")}
+              >
+                Continue
+              </Button>
+            )}
+
+            {emailConfirmed && (
+              <>
+                <div>
+                  <FieldLabel icon={<LockOutlined />}>Password</FieldLabel>
+                  <Input.Password
+                    size="large"
+                    autoFocus
+                    autoComplete="new-password"
+                    value={password}
+                    onChange={e => {
+                      setPassword(e.target.value);
+                      setError(null);
+                    }}
+                    placeholder="Create a password (min 6 characters)"
+                    disabled={submitting}
+                  />
+                </div>
+                <div>
+                  <FieldLabel icon={<LockOutlined />}>Confirm password</FieldLabel>
+                  <Input.Password
+                    size="large"
+                    autoComplete="new-password"
+                    value={confirm}
+                    onChange={e => {
+                      setConfirm(e.target.value);
+                      setError(null);
+                    }}
+                    placeholder="Re-enter your password"
+                    onPressEnter={handleSignup}
+                    disabled={submitting}
+                  />
+                </div>
+                <Button
+                  className="w-full"
+                  type="primary"
+                  size="large"
+                  loading={submitting}
+                  onClick={handleSignup}
+                  disabled={!password || !confirm}
+                >
+                  Create account
+                </Button>
+                <div className="text-xs text-textLight text-center">
+                  By creating an account you agree to our{" "}
+                  <a className="hover:text-primary" href="https://jitsu.com/tos" target="_blank" rel="noreferrer">
+                    Terms
+                  </a>{" "}
+                  and{" "}
+                  <a className="hover:text-primary" href="https://jitsu.com/privacy" target="_blank" rel="noreferrer">
+                    Privacy Policy
+                  </a>
+                  .
+                </div>
+              </>
+            )}
 
             {error && <Alert type="error" message={error} closable onClose={() => setError(null)} />}
-
-            <div className="text-xs text-textLight text-center">
-              By creating an account you agree to our{" "}
-              <a className="hover:text-primary" href="https://jitsu.com/tos" target="_blank" rel="noreferrer">
-                Terms
-              </a>{" "}
-              and{" "}
-              <a className="hover:text-primary" href="https://jitsu.com/privacy" target="_blank" rel="noreferrer">
-                Privacy Policy
-              </a>
-              .
-            </div>
           </div>
 
           <div className="text-center mt-8 text-textLight">

--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -1,0 +1,298 @@
+import React, { ReactNode, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { Alert, Button, Input } from "antd";
+import { CheckCircleOutlined, LockOutlined, MailOutlined } from "@ant-design/icons";
+import { branding } from "../../lib/branding";
+import { useFirebaseSession } from "../../lib/firebase-client";
+import { safeRedirect } from "../../lib/auth-redirect";
+import { useJitsu } from "@jitsu/jitsu-react";
+import { OAuthButtons } from "./OAuthButtons";
+import { AuthType, handleFirebaseError } from "./SignInOrUp";
+import { useQueryStringCopy } from "./use-query-string-copy";
+
+const JITSU_PURPLE = "#AA00FF";
+
+type Feature = { title: string; description: string; href: string };
+
+// Every feature links to the matching jitsu.com page (no doc-less claims).
+const features: Feature[] = [
+  {
+    title: "Real-time event streaming",
+    description: "Stream events to your data warehouse the moment they happen.",
+    href: "https://jitsu.com/features/event-streaming",
+  },
+  {
+    title: "Jitsu Functions",
+    description: "Transform and enrich events in-flight with TypeScript.",
+    href: "https://jitsu.com/features/functions",
+  },
+  {
+    title: "Identity stitching",
+    description: "Resolve anonymous and known users into one identity automatically.",
+    href: "https://jitsu.com/features/identity-stitching",
+  },
+  {
+    title: "Segment-compatible SDKs",
+    description: "Drop-in replacement for Segment — keep your existing instrumentation.",
+    href: "https://jitsu.com/features/segment-compatibility",
+  },
+];
+
+const customers = ["PandaDoc", "Investing.com", "Rarible", "Census", "Embeddables"];
+
+const MarketingPanel: React.FC = () => (
+  <div
+    className="hidden lg:flex lg:w-1/2 flex-col justify-between p-12 xl:p-16 text-white"
+    style={{ background: `linear-gradient(160deg, ${JITSU_PURPLE} 0%, #7C00C0 100%)` }}
+  >
+    <div className="flex items-center gap-2">
+      <div className="h-9 w-9 bg-white rounded-lg p-1 flex items-center justify-center">{branding.logo}</div>
+      <span className="text-2xl font-bold tracking-tight">{branding.productName}</span>
+    </div>
+
+    <div className="max-w-md">
+      <h2 className="text-3xl xl:text-4xl font-header font-bold leading-tight">Capture event data into your stack</h2>
+      <p className="mt-4 text-white/80">
+        Collect events from web, app, and server — and stream them to your data warehouse in real time.
+      </p>
+      <div className="mt-8 flex flex-col gap-1">
+        {features.map(f => (
+          <a
+            key={f.href}
+            href={f.href}
+            target="_blank"
+            rel="noreferrer"
+            className="group flex items-start gap-3 rounded-lg p-2 -mx-2 transition-colors hover:bg-white/10"
+          >
+            <CheckCircleOutlined className="mt-1 text-lg text-white/90" />
+            <span>
+              <span className="font-semibold group-hover:underline">{f.title}</span>
+              <span className="block text-sm text-white/70">{f.description}</span>
+            </span>
+          </a>
+        ))}
+      </div>
+    </div>
+
+    <div>
+      <div className="text-xs uppercase tracking-wider text-white/60">Trusted by data teams at</div>
+      <div className="mt-2 text-sm text-white/90">{customers.join("  ·  ")}</div>
+      <a
+        href="https://jitsu.com/customers"
+        target="_blank"
+        rel="noreferrer"
+        className="mt-2 inline-block text-sm font-semibold text-white hover:underline"
+      >
+        Read customer stories →
+      </a>
+    </div>
+  </div>
+);
+
+const FieldLabel: React.FC<{ icon: ReactNode; children: ReactNode }> = ({ icon, children }) => (
+  <div className="font-bold text-textLight tracking-wide pb-2 flex items-center">
+    <span className="mr-2">{icon}</span>
+    {children}
+  </div>
+);
+
+export const FirebaseSignup: React.FC = () => {
+  const router = useRouter();
+  const firebaseSession = useFirebaseSession();
+  const { analytics } = useJitsu();
+  const queryStringCopy = useQueryStringCopy();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<ReactNode | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const callbackUrl = (router.query.callbackUrl as string) || "/";
+
+  const validate = (): string | null => {
+    if (!email || !email.includes("@")) {
+      return "Please enter a valid email address";
+    }
+    if (password.length < 6) {
+      return "Password must be at least 6 characters";
+    }
+    if (password !== confirm) {
+      return "Passwords do not match";
+    }
+    return null;
+  };
+
+  const mapSignupError = (e: any): ReactNode => {
+    const code = e?.code;
+    if (code === "auth/email-already-in-use") {
+      return (
+        <>
+          An account with this email already exists.{" "}
+          <Link className="font-bold underline" href={`/signin${queryStringCopy}`}>
+            Sign in
+          </Link>{" "}
+          instead.
+        </>
+      );
+    }
+    if (code === "auth/weak-password") {
+      return "Password is too weak. Use at least 6 characters.";
+    }
+    if (code === "auth/invalid-email") {
+      return "Please enter a valid email address";
+    }
+    return handleFirebaseError(e);
+  };
+
+  const handleSignup = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await firebaseSession.signUp(email, password);
+      await analytics.track("sign_up", { email, loginProvider: "firebase/email" });
+      // The new account is single-provider `password` + unverified, so the route
+      // gate (FirebaseAuthorizer) takes over and renders VerifyEmailGate.
+      safeRedirect(router, callbackUrl);
+    } catch (e: any) {
+      setError(mapSignupError(e));
+      await analytics.track("sign_up_error", {
+        email,
+        loginProvider: "firebase/email",
+        message: e?.message || "Unknown error",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // OAuth signup is the same popup path as sign-in — Firebase creates the account
+  // on first login. signInWith already records the login and fires analytics.
+  const handleSSOLogin = async (provider: AuthType) => {
+    try {
+      await firebaseSession.signInWith(provider === "firebase-google" ? "google.com" : "github.com");
+      safeRedirect(router, callbackUrl);
+    } catch (e: any) {
+      setError(handleFirebaseError(e));
+      await analytics.track("login_error", {
+        type: "social",
+        loginProvider: `firebase/${provider}`,
+        message: e?.message || "Unknown error",
+      });
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <MarketingPanel />
+      <div className="flex-1 flex flex-col overflow-y-auto bg-backgroundLight">
+        <div className="m-auto w-full max-w-[400px] px-6 py-12">
+          <div className="flex flex-col items-center text-center mb-8">
+            <div className="h-12 w-12">{branding.logo}</div>
+            <h1 className="mt-4 text-3xl font-header font-bold text-textDark">Create your account</h1>
+          </div>
+
+          <OAuthButtons
+            prefix="Sign Up"
+            providers={["firebase-google", "firebase-github"]}
+            onSSOLogin={handleSSOLogin}
+          />
+
+          <div className="relative mt-6 mb-6">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-backgroundLight text-gray-500">Or sign up with email</span>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <FieldLabel icon={<MailOutlined />}>Email</FieldLabel>
+              <Input
+                size="large"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={e => {
+                  setEmail(e.target.value);
+                  setError(null);
+                }}
+                placeholder="Enter your email address"
+                disabled={submitting}
+              />
+            </div>
+            <div>
+              <FieldLabel icon={<LockOutlined />}>Password</FieldLabel>
+              <Input.Password
+                size="large"
+                autoComplete="new-password"
+                value={password}
+                onChange={e => {
+                  setPassword(e.target.value);
+                  setError(null);
+                }}
+                placeholder="Create a password (min 6 characters)"
+                disabled={submitting}
+              />
+            </div>
+            <div>
+              <FieldLabel icon={<LockOutlined />}>Confirm password</FieldLabel>
+              <Input.Password
+                size="large"
+                autoComplete="new-password"
+                value={confirm}
+                onChange={e => {
+                  setConfirm(e.target.value);
+                  setError(null);
+                }}
+                placeholder="Re-enter your password"
+                onPressEnter={handleSignup}
+                disabled={submitting}
+              />
+            </div>
+
+            <Button
+              className="w-full"
+              type="primary"
+              size="large"
+              loading={submitting}
+              onClick={handleSignup}
+              disabled={!email || !password || !confirm}
+            >
+              Create account
+            </Button>
+
+            {error && <Alert type="error" message={error} closable onClose={() => setError(null)} />}
+
+            <div className="text-xs text-textLight text-center">
+              By creating an account you agree to our{" "}
+              <a className="hover:text-primary" href="https://jitsu.com/tos" target="_blank" rel="noreferrer">
+                Terms
+              </a>{" "}
+              and{" "}
+              <a className="hover:text-primary" href="https://jitsu.com/privacy" target="_blank" rel="noreferrer">
+                Privacy Policy
+              </a>
+              .
+            </div>
+          </div>
+
+          <div className="text-center mt-8 text-textLight">
+            Already have an account?{" "}
+            <Link className="font-bold text-primary" href={`/signin${queryStringCopy}`}>
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Alert, Button, Divider, Input } from "antd";
@@ -7,196 +7,9 @@ import { useFirebaseSession } from "../../lib/firebase-client";
 import { safeRedirect } from "../../lib/auth-redirect";
 import { useJitsu } from "@jitsu/jitsu-react";
 import { OAuthButtons } from "./OAuthButtons";
+import { SignupMarketingPanel } from "./SignupMarketingPanel";
 import { AuthType, handleFirebaseError } from "./SignInOrUp";
 import { useQueryStringCopy } from "./use-query-string-copy";
-
-const panelFeatures = [
-  {
-    title: "Jitsu Functions",
-    href: "https://jitsu.com/features/functions",
-    description: "Transform, enrich, and route events in-flight with TypeScript — call APIs, persist state.",
-  },
-  {
-    title: "Real-time streaming",
-    href: "https://jitsu.com/features/event-streaming",
-    description: "Land events in your warehouse the moment they happen.",
-  },
-  {
-    title: "Drop-in for Segment",
-    href: "https://jitsu.com/features/segment-compatibility",
-    description: "Same SDK shape — keep your existing instrumentation.",
-  },
-];
-
-const customers = ["Investing.com", "PandaDoc", "Rarible", "Census", "Embeddables"];
-
-const snippets = [
-  {
-    file: "enrich.ts",
-    badge: "JITSU FUNCTION",
-    code: `export default async function (event, { store }) {
-  const geo = await store.get(event.ip);
-  event.country = geo?.country ?? "unknown";
-  return event;
-}`,
-  },
-  {
-    file: "track.ts",
-    badge: "BROWSER SDK",
-    code: `import { jitsuAnalytics } from "@jitsu/js";
-
-const jitsu = jitsuAnalytics({ writeKey: "KEY" });
-jitsu.identify("user_42", { email });
-jitsu.track("Signup Completed", { plan: "pro" });`,
-  },
-];
-
-// Tiny token highlighter for the (fixed, trusted) code samples — keeps the
-// snippets as plain strings instead of hand-written colored JSX.
-const CODE_TOKEN =
-  /(`[^`]*`|"[^"]*"|'[^']*'|\b(?:import|from|export|default|async|function|const|await|return|new)\b)/g;
-const KEYWORD = /^(?:import|from|export|default|async|function|const|await|return|new)$/;
-
-function highlightLine(line: string): ReactNode {
-  if (line === "") {
-    return " ";
-  }
-  return line.split(CODE_TOKEN).map((part, i) => {
-    if (!part) {
-      return null;
-    }
-    if (part[0] === "`" || part[0] === '"' || part[0] === "'") {
-      return (
-        <span key={i} className="text-[#c3e88d]">
-          {part}
-        </span>
-      );
-    }
-    if (KEYWORD.test(part)) {
-      return (
-        <span key={i} className="text-[#c792ea]">
-          {part}
-        </span>
-      );
-    }
-    return <span key={i}>{part}</span>;
-  });
-}
-
-/** Code card that auto-cycles through the snippets like switching tabs. */
-const CodeShowcase: React.FC = () => {
-  const [active, setActive] = useState(0);
-  useEffect(() => {
-    const t = setInterval(() => setActive(a => (a + 1) % snippets.length), 4500);
-    return () => clearInterval(t);
-  }, []);
-  const snippet = snippets[active];
-  return (
-    <div className="rounded-xl border border-white/10 overflow-hidden" style={{ background: "#0e0d18" }}>
-      <div className="flex items-center justify-between border-b border-white/10 px-4 py-2.5">
-        <div className="flex items-center gap-3 font-mono text-xs">
-          <span className="h-2 w-2 rounded-full bg-green-400" />
-          {snippets.map((s, i) => (
-            <span key={s.file} className={i === active ? "text-white" : "text-white/30"}>
-              {s.file}
-            </span>
-          ))}
-        </div>
-        <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">
-          {snippet.badge}
-        </span>
-      </div>
-      <div className="whitespace-pre overflow-x-auto p-4 font-mono text-[12px] leading-[1.7] text-slate-200">
-        {snippet.code.split("\n").map((line, i) => (
-          <div key={i}>{highlightLine(line)}</div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-/** Left-hand testimonial / proof panel. Hidden below `lg`. */
-const MarketingPanel: React.FC = () => (
-  <div
-    className="hidden lg:flex lg:w-1/2 p-10 xl:p-14 text-white overflow-y-auto"
-    style={{ background: "linear-gradient(155deg, #1c1640 0%, #2a1b53 55%, #211a48 100%)" }}
-  >
-    {/* one column — every section shares the same width */}
-    <div className="flex w-full max-w-2xl flex-col justify-between gap-9">
-      {/* header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <div className="h-7 w-7">{branding.logo}</div>
-          <span className="text-xl font-bold tracking-tight">jitsu</span>
-        </div>
-        <a href="https://jitsu.com" className="text-sm text-white/55 hover:text-white transition-colors">
-          ‹ Back to jitsu.com
-        </a>
-      </div>
-
-      {/* testimonial */}
-      <div>
-        <div className="font-serif text-[80px] leading-[0.6] text-white/25">“</div>
-        <p className="mt-5 text-2xl xl:text-3xl font-medium leading-snug">
-          Jitsu Functions let us enrich events server-side with external APIs and a persistent KV store —{" "}
-          <span className="text-white/45">killing the client-side code duplication across web, iOS, and Android.</span>
-        </p>
-        <div className="mt-8 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div
-              className="h-11 w-11 rounded-full flex items-center justify-center text-sm font-semibold"
-              style={{ background: "linear-gradient(135deg, #a855f7, #7c3aed)" }}
-            >
-              YA
-            </div>
-            <div>
-              <div className="font-semibold">Yonatan Adest</div>
-              <div className="text-sm text-white/55">CTO · Investing.com</div>
-            </div>
-          </div>
-          <div className="text-right">
-            <div className="text-3xl font-bold leading-none">5B</div>
-            <div className="mt-1 text-[10px] tracking-[0.2em] text-white/50">EVENTS / MONTH</div>
-          </div>
-        </div>
-      </div>
-
-      {/* code showcase */}
-      <CodeShowcase />
-
-      {/* features */}
-      <div className="grid grid-cols-3 gap-6 border-t border-white/10 pt-6">
-        {panelFeatures.map(f => (
-          <div key={f.title}>
-            <a
-              href={f.href}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-1.5 font-semibold hover:underline"
-            >
-              <span className="text-[#c3e88d]">✓</span>
-              {f.title}
-            </a>
-            <p className="mt-1.5 text-sm text-white/55">{f.description}</p>
-          </div>
-        ))}
-      </div>
-
-      {/* social proof */}
-      <div className="border-t border-white/10 pt-6">
-        <div className="text-[10px] tracking-[0.18em] text-white/40">IN PRODUCTION AT</div>
-        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-white/80">
-          {customers.map((c, i) => (
-            <React.Fragment key={c}>
-              {i > 0 && <span className="text-white/25">·</span>}
-              <span>{c}</span>
-            </React.Fragment>
-          ))}
-        </div>
-      </div>
-    </div>
-  </div>
-);
 
 export const FirebaseSignup: React.FC = () => {
   const router = useRouter();
@@ -303,7 +116,7 @@ export const FirebaseSignup: React.FC = () => {
 
   return (
     <div className="flex min-h-screen">
-      <MarketingPanel />
+      <SignupMarketingPanel />
 
       <div className="flex w-full flex-col bg-white lg:w-1/2 overflow-y-auto">
         <div className="shrink-0 p-6 text-right text-sm text-textLight">

--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -2,98 +2,180 @@ import React, { ReactNode, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Alert, Button, Input } from "antd";
-import { CheckCircleOutlined, LockOutlined, MailOutlined } from "@ant-design/icons";
+import { GithubOutlined } from "@ant-design/icons";
 import { branding } from "../../lib/branding";
 import { useFirebaseSession } from "../../lib/firebase-client";
 import { safeRedirect } from "../../lib/auth-redirect";
 import { useJitsu } from "@jitsu/jitsu-react";
-import { OAuthButtons } from "./OAuthButtons";
 import { AuthType, handleFirebaseError } from "./SignInOrUp";
 import { useQueryStringCopy } from "./use-query-string-copy";
 
-const JITSU_PURPLE = "#AA00FF";
+/** Full-colour Google "G" mark for the OAuth button. */
+const GoogleG: React.FC = () => (
+  <svg viewBox="0 0 48 48" width="18" height="18" xmlns="http://www.w3.org/2000/svg">
+    <path
+      fill="#4285F4"
+      d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
+    />
+    <path
+      fill="#34A853"
+      d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34A21.99 21.99 0 0 0 2 24c0 3.55.85 6.91 2.34 9.88l7.35-5.7z"
+    />
+    <path
+      fill="#EA4335"
+      d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
+    />
+  </svg>
+);
 
-type Feature = { title: string; description: string; href: string };
-
-// Every feature links to the matching jitsu.com page (no doc-less claims).
-const features: Feature[] = [
-  {
-    title: "Real-time event streaming",
-    description: "Stream events to your data warehouse the moment they happen.",
-    href: "https://jitsu.com/features/event-streaming",
-  },
+const panelFeatures = [
   {
     title: "Jitsu Functions",
-    description: "Transform and enrich events in-flight with TypeScript.",
-    href: "https://jitsu.com/features/functions",
+    description: "Transform, enrich, and route events in-flight with TypeScript — call APIs, persist state.",
   },
   {
-    title: "Identity stitching",
-    description: "Resolve anonymous and known users into one identity automatically.",
-    href: "https://jitsu.com/features/identity-stitching",
+    title: "Real-time streaming",
+    description: "Land events in your warehouse the moment they happen.",
   },
   {
-    title: "Segment-compatible SDKs",
-    description: "Drop-in replacement for Segment — keep your existing instrumentation.",
-    href: "https://jitsu.com/features/segment-compatibility",
+    title: "Drop-in for Segment",
+    description: "Same SDK shape — keep your existing instrumentation.",
   },
 ];
 
-const customers = ["PandaDoc", "Investing.com", "Rarible", "Census", "Embeddables"];
+const customers = ["Investing.com", "PandaDoc", "Rarible", "Census", "Embeddables"];
 
+/** Syntax-coloured token helpers for the code sample. */
+const Kw: React.FC<{ children: ReactNode }> = ({ children }) => <span className="text-[#c792ea]">{children}</span>;
+const Fn: React.FC<{ children: ReactNode }> = ({ children }) => <span className="text-[#82aaff]">{children}</span>;
+
+/** Left-hand testimonial / proof panel. Hidden below `lg`. */
 const MarketingPanel: React.FC = () => (
   <div
-    className="hidden lg:flex lg:w-1/2 flex-col justify-between p-12 xl:p-16 text-white"
-    style={{ background: `linear-gradient(160deg, ${JITSU_PURPLE} 0%, #7C00C0 100%)` }}
+    className="hidden lg:flex lg:w-1/2 flex-col justify-between gap-9 p-10 xl:p-14 text-white overflow-y-auto"
+    style={{ background: "linear-gradient(155deg, #1c1640 0%, #2a1b53 55%, #211a48 100%)" }}
   >
-    <div className="flex items-center gap-2">
-      <div className="h-9 w-9 bg-white rounded-lg p-1 flex items-center justify-center">{branding.logo}</div>
-      <span className="text-2xl font-bold tracking-tight">{branding.productName}</span>
+    {/* header */}
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <div className="h-7 w-7">{branding.logo}</div>
+        <span className="text-xl font-bold tracking-tight">jitsu</span>
+      </div>
+      <a href="https://jitsu.com" className="text-sm text-white/55 hover:text-white transition-colors">
+        ‹ Back to jitsu.com
+      </a>
     </div>
 
-    <div className="max-w-md">
-      <h2 className="text-3xl xl:text-4xl font-header font-bold leading-tight">Capture event data into your stack</h2>
-      <p className="mt-4 text-white/80">
-        Collect events from web, app, and server — and stream them to your data warehouse in real time.
+    {/* testimonial */}
+    <div className="max-w-xl">
+      <div className="font-serif text-[80px] leading-[0.6] text-white/25">“</div>
+      <p className="mt-5 text-2xl xl:text-3xl font-medium leading-snug">
+        Jitsu Functions let us enrich events server-side with external APIs and a persistent KV store —{" "}
+        <span className="text-white/45">killing the client-side code duplication across web, iOS, and Android.</span>
       </p>
-      <div className="mt-8 flex flex-col gap-1">
-        {features.map(f => (
-          <a
-            key={f.href}
-            href={f.href}
-            target="_blank"
-            rel="noreferrer"
-            className="group flex items-start gap-3 rounded-lg p-2 -mx-2 transition-colors hover:bg-white/10"
+      <div className="mt-8 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div
+            className="h-11 w-11 rounded-full flex items-center justify-center text-sm font-semibold"
+            style={{ background: "linear-gradient(135deg, #a855f7, #7c3aed)" }}
           >
-            <CheckCircleOutlined className="mt-1 text-lg text-white/90" />
-            <span>
-              <span className="font-semibold group-hover:underline">{f.title}</span>
-              <span className="block text-sm text-white/70">{f.description}</span>
-            </span>
-          </a>
-        ))}
+            YA
+          </div>
+          <div>
+            <div className="font-semibold">Yonatan Adest</div>
+            <div className="text-sm text-white/55">CTO · Investing.com</div>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-3xl font-bold leading-none">5B</div>
+          <div className="mt-1 text-[10px] tracking-[0.2em] text-white/50">EVENTS / MONTH</div>
+        </div>
       </div>
     </div>
 
-    <div>
-      <div className="text-xs uppercase tracking-wider text-white/60">Trusted by data teams at</div>
-      <div className="mt-2 text-sm text-white/90">{customers.join("  ·  ")}</div>
-      <a
-        href="https://jitsu.com/customers"
-        target="_blank"
-        rel="noreferrer"
-        className="mt-2 inline-block text-sm font-semibold text-white hover:underline"
+    {/* cards */}
+    <div className="flex gap-4">
+      <div
+        className="flex-[2] min-w-0 rounded-xl border border-white/10 overflow-hidden"
+        style={{ background: "#0e0d18" }}
       >
-        Read customer stories →
-      </a>
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-white/10">
+          <div className="flex items-center gap-2 font-mono text-xs text-white/60">
+            <span className="h-2 w-2 rounded-full bg-green-400" />
+            enrich.ts
+          </div>
+          <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">
+            JITSU FUNCTION
+          </span>
+        </div>
+        <div className="p-4 font-mono text-[11px] leading-[1.8] text-slate-200 overflow-x-auto">
+          <div>
+            <Kw>export default async function</Kw>
+            {" (event, { store, fetch }) {"}
+          </div>
+          <div>
+            {"  "}
+            <Kw>const</Kw>
+            {" geo = "}
+            <Kw>await</Kw>
+            {" store."}
+            <Fn>get</Fn>
+            {"(event.ip)"}
+          </div>
+          <div>
+            {"    ?? "}
+            <Kw>await</Kw> <Fn>fetch</Fn>
+            {"("}
+            <span className="text-[#c3e88d]">{"`/geo/${event.ip}`"}</span>
+            {");"}
+          </div>
+          <div>{"  event.properties.country = geo.country;"}</div>
+          <div>
+            {"  "}
+            <Kw>return</Kw>
+            {" event;"}
+          </div>
+          <div>{"}"}</div>
+        </div>
+      </div>
+      <div className="flex-1 min-w-0 rounded-xl border border-white/10 bg-white/5 p-4 flex flex-col">
+        <div className="text-[10px] tracking-[0.18em] text-white/45">TIME TO FIRST EVENT</div>
+        <div className="mt-auto pt-6">
+          <span className="text-4xl font-bold">43</span>
+          <span className="ml-1 text-sm text-white/55">sec</span>
+        </div>
+      </div>
     </div>
-  </div>
-);
 
-const FieldLabel: React.FC<{ icon: ReactNode; children: ReactNode }> = ({ icon, children }) => (
-  <div className="font-bold text-textLight tracking-wide pb-2 flex items-center">
-    <span className="mr-2">{icon}</span>
-    {children}
+    {/* features */}
+    <div className="grid grid-cols-3 gap-6 border-t border-white/10 pt-6">
+      {panelFeatures.map(f => (
+        <div key={f.title}>
+          <div className="flex items-center gap-1.5 font-semibold">
+            <span className="text-[#c3e88d]">✓</span>
+            {f.title}
+          </div>
+          <p className="mt-1.5 text-sm text-white/55">{f.description}</p>
+        </div>
+      ))}
+    </div>
+
+    {/* social proof */}
+    <div className="border-t border-white/10 pt-6">
+      <div className="text-[10px] tracking-[0.18em] text-white/40">IN PRODUCTION AT</div>
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-white/80">
+        {customers.map((c, i) => (
+          <React.Fragment key={c}>
+            {i > 0 && <span className="text-white/25">·</span>}
+            <span>{c}</span>
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
   </div>
 );
 
@@ -109,6 +191,7 @@ export const FirebaseSignup: React.FC = () => {
   const [error, setError] = useState<ReactNode | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [emailConfirmed, setEmailConfirmed] = useState(false);
+  const [oauthLoading, setOauthLoading] = useState<AuthType | null>(null);
 
   const callbackUrl = (router.query.callbackUrl as string) || "/";
 
@@ -186,6 +269,8 @@ export const FirebaseSignup: React.FC = () => {
   // OAuth signup is the same popup path as sign-in — Firebase creates the account
   // on first login. signInWith already records the login and fires analytics.
   const handleSSOLogin = async (provider: AuthType) => {
+    setOauthLoading(provider);
+    setError(null);
     try {
       await firebaseSession.signInWith(provider === "firebase-google" ? "google.com" : "github.com");
       safeRedirect(router, callbackUrl);
@@ -196,129 +281,164 @@ export const FirebaseSignup: React.FC = () => {
         loginProvider: `firebase/${provider}`,
         message: e?.message || "Unknown error",
       });
+    } finally {
+      setOauthLoading(null);
     }
   };
 
   return (
     <div className="flex min-h-screen">
       <MarketingPanel />
-      <div className="flex-1 flex flex-col overflow-y-auto bg-backgroundLight">
-        <div className="m-auto w-full max-w-[400px] px-6 py-12">
-          <div className="flex flex-col items-center text-center mb-8">
-            <div className="h-12 w-12">{branding.logo}</div>
-            <h1 className="mt-4 text-3xl font-header font-bold text-textDark">Create your account</h1>
-          </div>
 
-          <OAuthButtons
-            prefix="Sign Up"
-            providers={["firebase-google", "firebase-github"]}
-            onSSOLogin={handleSSOLogin}
-          />
+      <div className="flex w-full flex-col bg-white lg:w-1/2 overflow-y-auto">
+        <div className="shrink-0 p-6 text-right text-sm text-textLight">
+          Already have an account?{" "}
+          <Link className="font-semibold text-primary" href={`/signin${queryStringCopy}`}>
+            Sign in →
+          </Link>
+        </div>
 
-          <div className="relative mt-6 mb-6">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-300" />
-            </div>
-            <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-backgroundLight text-gray-500">Or sign up with email</span>
-            </div>
-          </div>
+        <div className="flex flex-1 justify-center px-6">
+          <div className="my-auto w-full max-w-[420px] py-8">
+            <div className="mb-6 h-12 w-12 drop-shadow-sm">{branding.logo}</div>
 
-          <div className="space-y-4">
-            <div>
-              <FieldLabel icon={<MailOutlined />}>Email</FieldLabel>
-              <Input
-                size="large"
-                type="email"
-                autoComplete="email"
-                value={email}
-                onChange={e => {
-                  setEmail(e.target.value);
-                  setError(null);
-                  setEmailConfirmed(false);
-                }}
-                placeholder="Enter your email address"
-                onPressEnter={handleContinue}
-                disabled={submitting}
-              />
-            </div>
+            <h1 className="font-header text-3xl xl:text-4xl font-bold leading-tight text-textDark">
+              Join 8,000+ teams shipping data with Jitsu.
+            </h1>
+            <p className="mt-3 text-textLight">Free for 200k events/month. No credit card required.</p>
 
-            {!emailConfirmed && (
+            <div className="mt-7 grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Button
-                className="w-full"
-                type="primary"
                 size="large"
-                onClick={handleContinue}
-                disabled={!email || !email.includes("@")}
+                icon={<GoogleG />}
+                loading={oauthLoading === "firebase-google"}
+                disabled={!!oauthLoading}
+                onClick={() => handleSSOLogin("firebase-google")}
               >
-                Continue
+                Continue with Google
               </Button>
-            )}
+              <Button
+                size="large"
+                icon={<GithubOutlined />}
+                loading={oauthLoading === "firebase-github"}
+                disabled={!!oauthLoading}
+                onClick={() => handleSSOLogin("firebase-github")}
+              >
+                Continue with GitHub
+              </Button>
+            </div>
 
-            {emailConfirmed && (
-              <>
-                <div>
-                  <FieldLabel icon={<LockOutlined />}>Password</FieldLabel>
-                  <Input.Password
-                    size="large"
-                    autoFocus
-                    autoComplete="new-password"
-                    value={password}
-                    onChange={e => {
-                      setPassword(e.target.value);
-                      setError(null);
-                    }}
-                    placeholder="Create a password (min 6 characters)"
-                    disabled={submitting}
-                  />
-                </div>
-                <div>
-                  <FieldLabel icon={<LockOutlined />}>Confirm password</FieldLabel>
-                  <Input.Password
-                    size="large"
-                    autoComplete="new-password"
-                    value={confirm}
-                    onChange={e => {
-                      setConfirm(e.target.value);
-                      setError(null);
-                    }}
-                    placeholder="Re-enter your password"
-                    onPressEnter={handleSignup}
-                    disabled={submitting}
-                  />
-                </div>
+            <div className="my-6 flex items-center gap-3 text-[11px] tracking-[0.18em] text-textLight">
+              <div className="h-px flex-1 bg-backgroundDark" />
+              OR WITH EMAIL
+              <div className="h-px flex-1 bg-backgroundDark" />
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold text-textDark">Work email</label>
+                <Input
+                  size="large"
+                  variant="filled"
+                  type="email"
+                  autoComplete="email"
+                  placeholder="you@company.com"
+                  value={email}
+                  onChange={e => {
+                    setEmail(e.target.value);
+                    setError(null);
+                    setEmailConfirmed(false);
+                  }}
+                  onPressEnter={handleContinue}
+                  disabled={submitting}
+                />
+              </div>
+
+              {!emailConfirmed && (
                 <Button
-                  className="w-full"
+                  block
                   type="primary"
                   size="large"
-                  loading={submitting}
-                  onClick={handleSignup}
-                  disabled={!password || !confirm}
+                  onClick={handleContinue}
+                  disabled={!email || !email.includes("@")}
                 >
-                  Create account
+                  Continue →
                 </Button>
-                <div className="text-xs text-textLight text-center">
-                  By creating an account you agree to our{" "}
-                  <a className="hover:text-primary" href="https://jitsu.com/tos" target="_blank" rel="noreferrer">
-                    Terms
-                  </a>{" "}
-                  and{" "}
-                  <a className="hover:text-primary" href="https://jitsu.com/privacy" target="_blank" rel="noreferrer">
-                    Privacy Policy
-                  </a>
-                  .
-                </div>
-              </>
-            )}
+              )}
 
-            {error && <Alert type="error" message={error} closable onClose={() => setError(null)} />}
-          </div>
+              {emailConfirmed && (
+                <>
+                  <div>
+                    <div className="mb-1.5 flex items-center justify-between">
+                      <label className="text-sm font-semibold text-textDark">Password</label>
+                      <span className="text-xs text-textLight">min. 6 chars</span>
+                    </div>
+                    <Input.Password
+                      size="large"
+                      variant="filled"
+                      autoFocus
+                      autoComplete="new-password"
+                      placeholder="At least 6 characters"
+                      value={password}
+                      onChange={e => {
+                        setPassword(e.target.value);
+                        setError(null);
+                      }}
+                      disabled={submitting}
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-semibold text-textDark">Confirm password</label>
+                    <Input.Password
+                      size="large"
+                      variant="filled"
+                      autoComplete="new-password"
+                      placeholder="Re-enter password"
+                      value={confirm}
+                      onChange={e => {
+                        setConfirm(e.target.value);
+                        setError(null);
+                      }}
+                      onPressEnter={handleSignup}
+                      disabled={submitting}
+                    />
+                  </div>
+                  <Button
+                    block
+                    type="primary"
+                    size="large"
+                    loading={submitting}
+                    onClick={handleSignup}
+                    disabled={!password || !confirm}
+                  >
+                    Create account →
+                  </Button>
+                  <p className="text-center text-xs text-textLight">
+                    By creating an account, you agree to our{" "}
+                    <a
+                      className="underline hover:text-primary"
+                      href="https://jitsu.com/tos"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Terms
+                    </a>{" "}
+                    and{" "}
+                    <a
+                      className="underline hover:text-primary"
+                      href="https://jitsu.com/privacy"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Privacy Policy
+                    </a>
+                    .
+                  </p>
+                </>
+              )}
 
-          <div className="text-center mt-8 text-textLight">
-            Already have an account?{" "}
-            <Link className="font-bold text-primary" href={`/signin${queryStringCopy}`}>
-              Sign in
-            </Link>
+              {error && <Alert type="error" message={error} closable onClose={() => setError(null)} />}
+            </div>
           </div>
         </div>
       </div>

--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -35,14 +35,17 @@ const GoogleG: React.FC = () => (
 const panelFeatures = [
   {
     title: "Jitsu Functions",
+    href: "https://jitsu.com/features/functions",
     description: "Transform, enrich, and route events in-flight with TypeScript — call APIs, persist state.",
   },
   {
     title: "Real-time streaming",
+    href: "https://jitsu.com/features/event-streaming",
     description: "Land events in your warehouse the moment they happen.",
   },
   {
     title: "Drop-in for Segment",
+    href: "https://jitsu.com/features/segment-compatibility",
     description: "Same SDK shape — keep your existing instrumentation.",
   },
 ];
@@ -56,124 +59,132 @@ const Fn: React.FC<{ children: ReactNode }> = ({ children }) => <span className=
 /** Left-hand testimonial / proof panel. Hidden below `lg`. */
 const MarketingPanel: React.FC = () => (
   <div
-    className="hidden lg:flex lg:w-1/2 flex-col justify-between gap-9 p-10 xl:p-14 text-white overflow-y-auto"
+    className="hidden lg:flex lg:w-1/2 p-10 xl:p-14 text-white overflow-y-auto"
     style={{ background: "linear-gradient(155deg, #1c1640 0%, #2a1b53 55%, #211a48 100%)" }}
   >
-    {/* header */}
-    <div className="flex items-center justify-between">
-      <div className="flex items-center gap-2">
-        <div className="h-7 w-7">{branding.logo}</div>
-        <span className="text-xl font-bold tracking-tight">jitsu</span>
+    {/* one column — every section shares the testimonial's width */}
+    <div className="flex w-full max-w-xl flex-col justify-between gap-9">
+      {/* header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="h-7 w-7">{branding.logo}</div>
+          <span className="text-xl font-bold tracking-tight">jitsu</span>
+        </div>
+        <a href="https://jitsu.com" className="text-sm text-white/55 hover:text-white transition-colors">
+          ‹ Back to jitsu.com
+        </a>
       </div>
-      <a href="https://jitsu.com" className="text-sm text-white/55 hover:text-white transition-colors">
-        ‹ Back to jitsu.com
-      </a>
-    </div>
 
-    {/* testimonial */}
-    <div className="max-w-xl">
-      <div className="font-serif text-[80px] leading-[0.6] text-white/25">“</div>
-      <p className="mt-5 text-2xl xl:text-3xl font-medium leading-snug">
-        Jitsu Functions let us enrich events server-side with external APIs and a persistent KV store —{" "}
-        <span className="text-white/45">killing the client-side code duplication across web, iOS, and Android.</span>
-      </p>
-      <div className="mt-8 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div
-            className="h-11 w-11 rounded-full flex items-center justify-center text-sm font-semibold"
-            style={{ background: "linear-gradient(135deg, #a855f7, #7c3aed)" }}
-          >
-            YA
+      {/* testimonial */}
+      <div>
+        <div className="font-serif text-[80px] leading-[0.6] text-white/25">“</div>
+        <p className="mt-5 text-2xl xl:text-3xl font-medium leading-snug">
+          Jitsu Functions let us enrich events server-side with external APIs and a persistent KV store —{" "}
+          <span className="text-white/45">killing the client-side code duplication across web, iOS, and Android.</span>
+        </p>
+        <div className="mt-8 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div
+              className="h-11 w-11 rounded-full flex items-center justify-center text-sm font-semibold"
+              style={{ background: "linear-gradient(135deg, #a855f7, #7c3aed)" }}
+            >
+              YA
+            </div>
+            <div>
+              <div className="font-semibold">Yonatan Adest</div>
+              <div className="text-sm text-white/55">CTO · Investing.com</div>
+            </div>
           </div>
-          <div>
-            <div className="font-semibold">Yonatan Adest</div>
-            <div className="text-sm text-white/55">CTO · Investing.com</div>
+          <div className="text-right">
+            <div className="text-3xl font-bold leading-none">5B</div>
+            <div className="mt-1 text-[10px] tracking-[0.2em] text-white/50">EVENTS / MONTH</div>
           </div>
-        </div>
-        <div className="text-right">
-          <div className="text-3xl font-bold leading-none">5B</div>
-          <div className="mt-1 text-[10px] tracking-[0.2em] text-white/50">EVENTS / MONTH</div>
-        </div>
-      </div>
-    </div>
-
-    {/* cards */}
-    <div className="flex gap-4">
-      <div
-        className="flex-[2] min-w-0 rounded-xl border border-white/10 overflow-hidden"
-        style={{ background: "#0e0d18" }}
-      >
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-white/10">
-          <div className="flex items-center gap-2 font-mono text-xs text-white/60">
-            <span className="h-2 w-2 rounded-full bg-green-400" />
-            enrich.ts
-          </div>
-          <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">
-            JITSU FUNCTION
-          </span>
-        </div>
-        <div className="p-4 font-mono text-[11px] leading-[1.8] text-slate-200 overflow-x-auto">
-          <div>
-            <Kw>export default async function</Kw>
-            {" (event, { store, fetch }) {"}
-          </div>
-          <div>
-            {"  "}
-            <Kw>const</Kw>
-            {" geo = "}
-            <Kw>await</Kw>
-            {" store."}
-            <Fn>get</Fn>
-            {"(event.ip)"}
-          </div>
-          <div>
-            {"    ?? "}
-            <Kw>await</Kw> <Fn>fetch</Fn>
-            {"("}
-            <span className="text-[#c3e88d]">{"`/geo/${event.ip}`"}</span>
-            {");"}
-          </div>
-          <div>{"  event.properties.country = geo.country;"}</div>
-          <div>
-            {"  "}
-            <Kw>return</Kw>
-            {" event;"}
-          </div>
-          <div>{"}"}</div>
         </div>
       </div>
-      <div className="flex-1 min-w-0 rounded-xl border border-white/10 bg-white/5 p-4 flex flex-col">
-        <div className="text-[10px] tracking-[0.18em] text-white/45">TIME TO FIRST EVENT</div>
-        <div className="mt-auto pt-6">
-          <span className="text-4xl font-bold">43</span>
-          <span className="ml-1 text-sm text-white/55">sec</span>
+
+      {/* cards */}
+      <div className="flex gap-4">
+        <div
+          className="flex-[2] min-w-0 rounded-xl border border-white/10 overflow-hidden"
+          style={{ background: "#0e0d18" }}
+        >
+          <div className="flex items-center justify-between px-4 py-2.5 border-b border-white/10">
+            <div className="flex items-center gap-2 font-mono text-xs text-white/60">
+              <span className="h-2 w-2 rounded-full bg-green-400" />
+              enrich.ts
+            </div>
+            <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">
+              JITSU FUNCTION
+            </span>
+          </div>
+          <div className="p-4 font-mono text-[11px] leading-[1.8] whitespace-pre text-slate-200 overflow-x-auto">
+            <div>
+              <Kw>export default async function</Kw>
+              {" (event, { store, fetch }) {"}
+            </div>
+            <div>
+              {"  "}
+              <Kw>const</Kw>
+              {" geo = "}
+              <Kw>await</Kw>
+              {" store."}
+              <Fn>get</Fn>
+              {"(event.ip)"}
+            </div>
+            <div>
+              {"    ?? "}
+              <Kw>await</Kw> <Fn>fetch</Fn>
+              {"("}
+              <span className="text-[#c3e88d]">{"`/geo/${event.ip}`"}</span>
+              {");"}
+            </div>
+            <div>{"  event.properties.country = geo.country;"}</div>
+            <div>
+              {"  "}
+              <Kw>return</Kw>
+              {" event;"}
+            </div>
+            <div>{"}"}</div>
+          </div>
+        </div>
+        <div className="flex-1 min-w-0 rounded-xl border border-white/10 bg-white/5 p-4 flex flex-col">
+          <div className="text-[10px] tracking-[0.18em] text-white/45">TIME TO FIRST EVENT</div>
+          <div className="mt-auto pt-6">
+            <span className="text-4xl font-bold">43</span>
+            <span className="ml-1 text-sm text-white/55">sec</span>
+          </div>
         </div>
       </div>
-    </div>
 
-    {/* features */}
-    <div className="grid grid-cols-3 gap-6 border-t border-white/10 pt-6">
-      {panelFeatures.map(f => (
-        <div key={f.title}>
-          <div className="flex items-center gap-1.5 font-semibold">
-            <span className="text-[#c3e88d]">✓</span>
-            {f.title}
+      {/* features */}
+      <div className="grid grid-cols-3 gap-6 border-t border-white/10 pt-6">
+        {panelFeatures.map(f => (
+          <div key={f.title}>
+            <a
+              href={f.href}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 font-semibold hover:underline"
+            >
+              <span className="text-[#c3e88d]">✓</span>
+              {f.title}
+            </a>
+            <p className="mt-1.5 text-sm text-white/55">{f.description}</p>
           </div>
-          <p className="mt-1.5 text-sm text-white/55">{f.description}</p>
-        </div>
-      ))}
-    </div>
-
-    {/* social proof */}
-    <div className="border-t border-white/10 pt-6">
-      <div className="text-[10px] tracking-[0.18em] text-white/40">IN PRODUCTION AT</div>
-      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-white/80">
-        {customers.map((c, i) => (
-          <React.Fragment key={c}>
-            {i > 0 && <span className="text-white/25">·</span>}
-            <span>{c}</span>
-          </React.Fragment>
         ))}
+      </div>
+
+      {/* social proof */}
+      <div className="border-t border-white/10 pt-6">
+        <div className="text-[10px] tracking-[0.18em] text-white/40">IN PRODUCTION AT</div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-white/80">
+          {customers.map((c, i) => (
+            <React.Fragment key={c}>
+              {i > 0 && <span className="text-white/25">·</span>}
+              <span>{c}</span>
+            </React.Fragment>
+          ))}
+        </div>
       </div>
     </div>
   </div>

--- a/webapps/console/components/SignInOrUp/SignInOrUp.tsx
+++ b/webapps/console/components/SignInOrUp/SignInOrUp.tsx
@@ -253,7 +253,7 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
   );
 };
 
-function handleFirebaseError(error: any): string {
+export function handleFirebaseError(error: any): string {
   const code = error?.code;
   if (code === "auth/account-exists-with-different-credential") {
     const email = error?.customData?.email;

--- a/webapps/console/components/SignInOrUp/SignInOrUp.tsx
+++ b/webapps/console/components/SignInOrUp/SignInOrUp.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/router";
 import { EmailFirstLogin } from "./EmailFirstLogin";
 import { OAuthButtons } from "./OAuthButtons";
 import { signIn } from "next-auth/react";
-import { useFirebaseSession } from "../../lib/firebase-client";
+import { EmailNotVerifiedError, useFirebaseSession } from "../../lib/firebase-client";
 import { useJitsu } from "@jitsu/jitsu-react";
 import { useAppConfig } from "../../lib/context";
 import { safeRedirect } from "../../lib/auth-redirect";
@@ -125,6 +125,12 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
         setError("Unsupported authentication method");
       }
     } catch (e: any) {
+      if (e instanceof EmailNotVerifiedError) {
+        // Sign-in succeeded but the email is unverified — hand off to the route
+        // gate (FirebaseAuthorizer), which renders the verification screen.
+        safeRedirect(router, callbackUrl);
+        return;
+      }
       if (type === "firebase-password") {
         setError(handleFirebaseError(e));
         await analytics.track("login_error", {
@@ -261,6 +267,11 @@ function handleFirebaseError(error: any): string {
   } else if (code === "auth/wrong-password") {
     return "Invalid email or password";
   } else if (code === "auth/user-not-found") {
+    return "Invalid email or password";
+  } else if (code === "auth/invalid-credential" || code === "auth/invalid-login-credentials") {
+    // JITSU-019: with Firebase email-enumeration protection enabled, a failed
+    // email/password sign-in returns this generic code instead of
+    // auth/wrong-password or auth/user-not-found.
     return "Invalid email or password";
   } else if (code === "auth/too-many-requests") {
     return "Too many signin attempts. Try later, or reset password now";

--- a/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
+++ b/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
@@ -124,7 +124,8 @@ export const SignupMarketingPanel: React.FC = () => (
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <div className="h-7 w-7">{branding.logo}</div>
-          <span className="text-xl font-bold tracking-tight">jitsu</span>
+          {/* fill-white overrides the one hardcoded fill="black" path in the wordmark */}
+          <div className="h-5 w-[84px] [&_path]:fill-white">{branding.wordmark}</div>
         </div>
         <a
           href="https://jitsu.com"

--- a/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
+++ b/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
@@ -80,13 +80,25 @@ function highlightLine(line: string): ReactNode {
   });
 }
 
-/** Code card that auto-cycles through the snippets like switching tabs. */
+/** Code card that auto-cycles through the snippets; a manual click pins it. */
 const CodeShowcase: React.FC = () => {
   const [active, setActive] = useState(0);
+  const [autoSwitch, setAutoSwitch] = useState(true);
+
   useEffect(() => {
+    if (!autoSwitch) {
+      return;
+    }
     const t = setInterval(() => setActive(a => (a + 1) % snippets.length), 4500);
     return () => clearInterval(t);
-  }, []);
+  }, [autoSwitch]);
+
+  // A manual pick stops the auto-cycle for good.
+  const selectTab = (i: number) => {
+    setActive(i);
+    setAutoSwitch(false);
+  };
+
   const snippet = snippets[active];
   return (
     <div className="rounded-xl border border-white/10 overflow-hidden" style={{ background: "#0e0d18" }}>
@@ -94,9 +106,16 @@ const CodeShowcase: React.FC = () => {
         <div className="flex items-center gap-3 font-mono text-xs">
           <span className="h-2 w-2 rounded-full bg-green-400" />
           {snippets.map((s, i) => (
-            <span key={s.file} className={i === active ? "text-white" : "text-white/30"}>
+            <button
+              key={s.file}
+              type="button"
+              onClick={() => selectTab(i)}
+              className={`cursor-pointer p-0 transition-colors ${
+                i === active ? "text-white" : "text-white/30 hover:text-white/70"
+              }`}
+            >
               {s.file}
-            </span>
+            </button>
           ))}
         </div>
         <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">

--- a/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
+++ b/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
@@ -19,7 +19,13 @@ const panelFeatures = [
   },
 ];
 
-const customers = ["Investing.com", "PandaDoc", "Rarible", "Census", "Embeddables"];
+const customers: { name: string; href?: string }[] = [
+  { name: "Investing.com", href: "https://jitsu.com/customers/investing" },
+  { name: "PandaDoc" },
+  { name: "Rarible" },
+  { name: "Census" },
+  { name: "Embeddables" },
+];
 
 const snippets = [
   {
@@ -120,7 +126,10 @@ export const SignupMarketingPanel: React.FC = () => (
           <div className="h-7 w-7">{branding.logo}</div>
           <span className="text-xl font-bold tracking-tight">jitsu</span>
         </div>
-        <a href="https://jitsu.com" className="text-sm text-white/55 hover:text-white transition-colors">
+        <a
+          href="https://jitsu.com"
+          className="text-sm text-white/55 hover:text-white hover:underline transition-colors"
+        >
           ‹ Back to jitsu.com
         </a>
       </div>
@@ -133,7 +142,12 @@ export const SignupMarketingPanel: React.FC = () => (
           <span className="text-white/45">killing the client-side code duplication across web, iOS, and Android.</span>
         </p>
         <div className="mt-8 flex items-center justify-between">
-          <div className="flex items-center gap-3">
+          <a
+            href="https://jitsu.com/customers/investing"
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-3 hover:underline"
+          >
             <div
               className="h-11 w-11 rounded-full flex items-center justify-center text-sm font-semibold"
               style={{ background: "linear-gradient(135deg, #a855f7, #7c3aed)" }}
@@ -144,7 +158,7 @@ export const SignupMarketingPanel: React.FC = () => (
               <div className="font-semibold">Yonatan Adest</div>
               <div className="text-sm text-white/55">CTO · Investing.com</div>
             </div>
-          </div>
+          </a>
           <div className="text-right">
             <div className="text-3xl font-bold leading-none">5B</div>
             <div className="mt-1 text-[10px] tracking-[0.2em] text-white/50">EVENTS / MONTH</div>
@@ -175,12 +189,25 @@ export const SignupMarketingPanel: React.FC = () => (
 
       {/* social proof */}
       <div className="border-t border-white/10 pt-6">
-        <div className="text-[10px] tracking-[0.18em] text-white/40">IN PRODUCTION AT</div>
+        <a
+          href="https://jitsu.com/customers"
+          target="_blank"
+          rel="noreferrer"
+          className="text-[10px] tracking-[0.18em] text-white/40 hover:underline"
+        >
+          IN PRODUCTION AT
+        </a>
         <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-white/80">
           {customers.map((c, i) => (
-            <React.Fragment key={c}>
+            <React.Fragment key={c.name}>
               {i > 0 && <span className="text-white/25">·</span>}
-              <span>{c}</span>
+              {c.href ? (
+                <a href={c.href} target="_blank" rel="noreferrer" className="hover:underline">
+                  {c.name}
+                </a>
+              ) : (
+                <span>{c.name}</span>
+              )}
             </React.Fragment>
           ))}
         </div>

--- a/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
+++ b/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
@@ -146,18 +146,9 @@ export const SignupMarketingPanel: React.FC = () => (
             href="https://jitsu.com/customers/investing"
             target="_blank"
             rel="noreferrer"
-            className="flex items-center gap-3 hover:underline"
+            className="font-semibold hover:underline"
           >
-            <div
-              className="h-11 w-11 rounded-full flex items-center justify-center text-sm font-semibold"
-              style={{ background: "linear-gradient(135deg, #a855f7, #7c3aed)" }}
-            >
-              YA
-            </div>
-            <div>
-              <div className="font-semibold">Yonatan Adest</div>
-              <div className="text-sm text-white/55">CTO · Investing.com</div>
-            </div>
+            Investing.com
           </a>
           <div className="text-right">
             <div className="text-3xl font-bold leading-none">5B</div>

--- a/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
+++ b/webapps/console/components/SignInOrUp/SignupMarketingPanel.tsx
@@ -1,0 +1,190 @@
+import React, { ReactNode, useEffect, useState } from "react";
+import { branding } from "../../lib/branding";
+
+const panelFeatures = [
+  {
+    title: "Jitsu Functions",
+    href: "https://jitsu.com/features/functions",
+    description: "Transform, enrich, and route events in-flight with TypeScript — call APIs, persist state.",
+  },
+  {
+    title: "Real-time streaming",
+    href: "https://jitsu.com/features/event-streaming",
+    description: "Land events in your warehouse the moment they happen.",
+  },
+  {
+    title: "Drop-in for Segment",
+    href: "https://jitsu.com/features/segment-compatibility",
+    description: "Same SDK shape — keep your existing instrumentation.",
+  },
+];
+
+const customers = ["Investing.com", "PandaDoc", "Rarible", "Census", "Embeddables"];
+
+const snippets = [
+  {
+    file: "enrich.ts",
+    badge: "JITSU FUNCTION",
+    code: `export default async function (event, { store }) {
+  const geo = await store.get(event.ip);
+  event.country = geo?.country ?? "unknown";
+  return event;
+}`,
+  },
+  {
+    file: "track.ts",
+    badge: "BROWSER SDK",
+    code: `import { jitsuAnalytics } from "@jitsu/js";
+
+const jitsu = jitsuAnalytics({ writeKey: "KEY" });
+jitsu.identify("user_42", { email });
+jitsu.track("Signup Completed", { plan: "pro" });`,
+  },
+];
+
+// Tiny token highlighter for the (fixed, trusted) code samples — keeps the
+// snippets as plain strings instead of hand-written colored JSX.
+const CODE_TOKEN =
+  /(`[^`]*`|"[^"]*"|'[^']*'|\b(?:import|from|export|default|async|function|const|await|return|new)\b)/g;
+const KEYWORD = /^(?:import|from|export|default|async|function|const|await|return|new)$/;
+
+function highlightLine(line: string): ReactNode {
+  if (line === "") {
+    return " ";
+  }
+  return line.split(CODE_TOKEN).map((part, i) => {
+    if (!part) {
+      return null;
+    }
+    if (part[0] === "`" || part[0] === '"' || part[0] === "'") {
+      return (
+        <span key={i} className="text-[#c3e88d]">
+          {part}
+        </span>
+      );
+    }
+    if (KEYWORD.test(part)) {
+      return (
+        <span key={i} className="text-[#c792ea]">
+          {part}
+        </span>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
+/** Code card that auto-cycles through the snippets like switching tabs. */
+const CodeShowcase: React.FC = () => {
+  const [active, setActive] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setActive(a => (a + 1) % snippets.length), 4500);
+    return () => clearInterval(t);
+  }, []);
+  const snippet = snippets[active];
+  return (
+    <div className="rounded-xl border border-white/10 overflow-hidden" style={{ background: "#0e0d18" }}>
+      <div className="flex items-center justify-between border-b border-white/10 px-4 py-2.5">
+        <div className="flex items-center gap-3 font-mono text-xs">
+          <span className="h-2 w-2 rounded-full bg-green-400" />
+          {snippets.map((s, i) => (
+            <span key={s.file} className={i === active ? "text-white" : "text-white/30"}>
+              {s.file}
+            </span>
+          ))}
+        </div>
+        <span className="rounded border border-white/15 px-1.5 py-0.5 text-[10px] tracking-[0.15em] text-white/40">
+          {snippet.badge}
+        </span>
+      </div>
+      <div className="whitespace-pre overflow-x-auto p-4 font-mono text-[12px] leading-[1.7] text-slate-200">
+        {snippet.code.split("\n").map((line, i) => (
+          <div key={i}>{highlightLine(line)}</div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/** Left-hand testimonial / proof panel of the signup page. Hidden below `lg`. */
+export const SignupMarketingPanel: React.FC = () => (
+  <div
+    className="hidden lg:flex lg:w-1/2 p-10 xl:p-14 text-white overflow-y-auto"
+    style={{ background: "linear-gradient(155deg, #1c1640 0%, #2a1b53 55%, #211a48 100%)" }}
+  >
+    {/* one column — every section shares the same width */}
+    <div className="flex w-full max-w-2xl flex-col justify-between gap-9">
+      {/* header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="h-7 w-7">{branding.logo}</div>
+          <span className="text-xl font-bold tracking-tight">jitsu</span>
+        </div>
+        <a href="https://jitsu.com" className="text-sm text-white/55 hover:text-white transition-colors">
+          ‹ Back to jitsu.com
+        </a>
+      </div>
+
+      {/* testimonial */}
+      <div>
+        <div className="font-serif text-[80px] leading-[0.6] text-white/25">“</div>
+        <p className="mt-5 text-2xl xl:text-3xl font-medium leading-snug">
+          Jitsu Functions let us enrich events server-side with external APIs and a persistent KV store —{" "}
+          <span className="text-white/45">killing the client-side code duplication across web, iOS, and Android.</span>
+        </p>
+        <div className="mt-8 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div
+              className="h-11 w-11 rounded-full flex items-center justify-center text-sm font-semibold"
+              style={{ background: "linear-gradient(135deg, #a855f7, #7c3aed)" }}
+            >
+              YA
+            </div>
+            <div>
+              <div className="font-semibold">Yonatan Adest</div>
+              <div className="text-sm text-white/55">CTO · Investing.com</div>
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-3xl font-bold leading-none">5B</div>
+            <div className="mt-1 text-[10px] tracking-[0.2em] text-white/50">EVENTS / MONTH</div>
+          </div>
+        </div>
+      </div>
+
+      {/* code showcase */}
+      <CodeShowcase />
+
+      {/* features */}
+      <div className="grid grid-cols-3 gap-6 border-t border-white/10 pt-6">
+        {panelFeatures.map(f => (
+          <div key={f.title}>
+            <a
+              href={f.href}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 font-semibold hover:underline"
+            >
+              <span className="text-[#c3e88d]">✓</span>
+              {f.title}
+            </a>
+            <p className="mt-1.5 text-sm text-white/55">{f.description}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* social proof */}
+      <div className="border-t border-white/10 pt-6">
+        <div className="text-[10px] tracking-[0.18em] text-white/40">IN PRODUCTION AT</div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-white/80">
+          {customers.map((c, i) => (
+            <React.Fragment key={c}>
+              {i > 0 && <span className="text-white/25">·</span>}
+              <span>{c}</span>
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/webapps/console/components/SignInOrUp/VerifyEmailGate.tsx
+++ b/webapps/console/components/SignInOrUp/VerifyEmailGate.tsx
@@ -29,8 +29,12 @@ export const VerifyEmailGate: React.FC<{ email: string }> = ({ email }) => {
         type: "success",
         message: `Verification email sent to ${email}. Check your inbox and spam folder.`,
       });
-    } catch (e) {
-      setFeedback({ type: "error", message: `Failed to send verification email: ${getErrorMessage(e)}` });
+    } catch (e: any) {
+      const message =
+        e?.code === "auth/too-many-requests"
+          ? "Too many requests. Please wait a few minutes before requesting another email."
+          : `Failed to send verification email: ${getErrorMessage(e)}`;
+      setFeedback({ type: "error", message });
     } finally {
       setResending(false);
     }

--- a/webapps/console/components/SignInOrUp/VerifyEmailGate.tsx
+++ b/webapps/console/components/SignInOrUp/VerifyEmailGate.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import { Alert, Button } from "antd";
+import { useRouter } from "next/router";
+import { getErrorMessage } from "juava";
+import { SigninLayout } from "./SignInOrUp";
+import { useFirebaseSession } from "../../lib/firebase-client";
+
+type Feedback = { type: "success" | "error"; message: string };
+
+/**
+ * Shown by the Firebase authorizer (JITSU-018) when an email+password account
+ * signs in before verifying its email address. The user cannot reach the app
+ * until the address is verified; from here they can re-send the verification
+ * email, re-check the status, or sign out.
+ */
+export const VerifyEmailGate: React.FC<{ email: string }> = ({ email }) => {
+  const router = useRouter();
+  const firebaseSession = useFirebaseSession();
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [resending, setResending] = useState(false);
+  const [checking, setChecking] = useState(false);
+
+  const resend = async () => {
+    setResending(true);
+    setFeedback(null);
+    try {
+      await firebaseSession.sendVerificationEmail();
+      setFeedback({
+        type: "success",
+        message: `Verification email sent to ${email}. Check your inbox and spam folder.`,
+      });
+    } catch (e) {
+      setFeedback({ type: "error", message: `Failed to send verification email: ${getErrorMessage(e)}` });
+    } finally {
+      setResending(false);
+    }
+  };
+
+  const recheck = async () => {
+    setChecking(true);
+    setFeedback(null);
+    try {
+      const verified = await firebaseSession.reloadEmailVerified();
+      if (verified) {
+        // Re-mount the authorizer so it resolves the now-verified user.
+        window.location.reload();
+      } else {
+        setFeedback({
+          type: "error",
+          message: "Your email still looks unverified. Click the link in the email, then try again.",
+        });
+      }
+    } catch (e) {
+      setFeedback({ type: "error", message: `Could not refresh verification status: ${getErrorMessage(e)}` });
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const signOut = async () => {
+    try {
+      await firebaseSession.signOut();
+    } finally {
+      router.push("/signin");
+    }
+  };
+
+  return (
+    <SigninLayout
+      title={<div className="text-2xl">Verify your email</div>}
+      footer={
+        <div className="text-center mt-4">
+          Wrong account?{" "}
+          <Button type="link" className="font-bold p-0" onClick={signOut}>
+            Sign out
+          </Button>
+        </div>
+      }
+    >
+      <div className="max-w-[350px]">
+        <p className="text-textLight">
+          We sent a verification link to <span className="font-bold">{email}</span>. Open that email and click the link,
+          then continue.
+        </p>
+        {feedback && (
+          <div className="mt-4">
+            <Alert type={feedback.type} message={feedback.message} closable onClose={() => setFeedback(null)} />
+          </div>
+        )}
+        <div className="flex flex-col gap-2 mt-6">
+          <Button type="primary" loading={checking} onClick={recheck}>
+            {"I've verified my email — continue"}
+          </Button>
+          <Button loading={resending} onClick={resend}>
+            Resend verification email
+          </Button>
+        </div>
+      </div>
+    </SigninLayout>
+  );
+};

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -50,6 +50,14 @@ export function useFirebaseConfig(): FirebaseClientSettings {
 export interface FirebaseSession {
   signIn(username: string, password): Promise<boolean>;
 
+  /**
+   * Creates a new email+password Firebase account and sends a verification
+   * email. After this resolves the user is signed in but unverified — callers
+   * should redirect to a protected route so FirebaseAuthorizer renders
+   * VerifyEmailGate. See JITSU-018.
+   */
+  signUp(email: string, password: string): Promise<void>;
+
   signInWith(type: string): Promise<void>;
 
   signOut(): Promise<void>;
@@ -93,10 +101,11 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiRe
   const email = requireDefined(currentUser.email, "email of firebase user is undefined");
   // JITSU-018: email+password sign-up issues a valid Firebase JWT before the
   // address is verified. Block such accounts here — before any internal user or
-  // session is minted. OAuth providers verify the email themselves, so the gate
-  // only applies to the `password` provider.
-  const providerId = currentUser.providerData[0]?.providerId;
-  if (providerId === "password" && !currentUser.emailVerified) {
+  // session is minted. The gate applies only to single-provider `password`
+  // accounts; if Google/GitHub is also linked the address is already trusted.
+  const providerData = currentUser.providerData;
+  const isPasswordOnly = providerData.length === 1 && providerData[0]?.providerId === "password";
+  if (isPasswordOnly && !currentUser.emailVerified) {
     throw new EmailNotVerifiedError(email);
   }
   let internalId = await getCustomClaim(currentUser, "internalId");
@@ -174,6 +183,9 @@ export function useFirebaseSession(): FirebaseSession {
   if (!config.enabled) {
     return {
       signIn: async () => {
+        throw new Error("Firebase auth is not enabled");
+      },
+      signUp: async () => {
         throw new Error("Firebase auth is not enabled");
       },
       signInWith: async () => {
@@ -260,6 +272,12 @@ export function useFirebaseSession(): FirebaseSession {
         await recordFirebaseLogin(userCredential.user);
       }
       return !!userCredential?.user;
+    },
+    async signUp(email: string, password: string): Promise<void> {
+      const userCredential = await auth.createUserWithEmailAndPassword(a.getAuth(), email, password);
+      if (userCredential?.user) {
+        await auth.sendEmailVerification(userCredential.user);
+      }
     },
     async resetPassword(username: string): Promise<void> {
       await auth.sendPasswordResetEmail(a.getAuth(), username);

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -76,6 +76,15 @@ export interface FirebaseSession {
    */
   reloadEmailVerified(): Promise<boolean>;
 
+  /** Applies an email-action code (email verification, or email-change recovery). */
+  applyActionCode(oobCode: string): Promise<void>;
+
+  /** Verifies a password-reset code and returns the account's email address. */
+  verifyPasswordResetCode(oobCode: string): Promise<string>;
+
+  /** Completes a password reset, setting a new password for the code's account. */
+  confirmPasswordReset(oobCode: string, newPassword: string): Promise<void>;
+
   /**
    * Waits until auth state of the user is resolved
    */
@@ -221,6 +230,15 @@ export function useFirebaseSession(): FirebaseSession {
       reloadEmailVerified: async () => {
         throw new Error("Firebase auth is not enabled");
       },
+      applyActionCode: async () => {
+        throw new Error("Firebase auth is not enabled");
+      },
+      verifyPasswordResetCode: async () => {
+        throw new Error("Firebase auth is not enabled");
+      },
+      confirmPasswordReset: async () => {
+        throw new Error("Firebase auth is not enabled");
+      },
       resolveUser: () => {
         throw new Error("Firebase auth is not enabled");
       },
@@ -315,6 +333,15 @@ export function useFirebaseSession(): FirebaseSession {
         await currentUser.getIdToken(true);
       }
       return currentUser.emailVerified;
+    },
+    async applyActionCode(oobCode: string): Promise<void> {
+      await auth.applyActionCode(a.getAuth(), oobCode);
+    },
+    async verifyPasswordResetCode(oobCode: string): Promise<string> {
+      return await auth.verifyPasswordResetCode(a.getAuth(), oobCode);
+    },
+    async confirmPasswordReset(oobCode: string, newPassword: string): Promise<void> {
+      await auth.confirmPasswordReset(a.getAuth(), oobCode, newPassword);
     },
   };
 }

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -10,6 +10,22 @@ export type FirebaseProviderInstance =
   | { enabled: false; settings?: never }
   | { enabled: true; settings: FirebaseClientSettings };
 
+/**
+ * Thrown by {@link getUserFromFirebase} when an email+password account signs in
+ * before its email address has been verified. OAuth providers (Google, GitHub)
+ * verify the address themselves, so the check only applies to the `password`
+ * provider. See JITSU-018.
+ */
+export class EmailNotVerifiedError extends Error {
+  readonly email: string;
+
+  constructor(email: string) {
+    super(`Email ${email} is not verified`);
+    this.name = "EmailNotVerifiedError";
+    this.email = email;
+  }
+}
+
 const FirebaseContext = createContext<FirebaseProviderInstance | null>(null);
 
 const log = getLog("firebase");
@@ -41,6 +57,18 @@ export interface FirebaseSession {
   resetPassword(username: string): Promise<void>;
 
   /**
+   * Re-sends the Firebase email-verification message to the signed-in user.
+   */
+  sendVerificationEmail(): Promise<void>;
+
+  /**
+   * Reloads the signed-in user from Firebase and returns whether the email
+   * address is now verified. Also refreshes the ID token so its claims are
+   * up to date once the address is verified.
+   */
+  reloadEmailVerified(): Promise<boolean>;
+
+  /**
    * Waits until auth state of the user is resolved
    */
   resolveUser(token?: string): { user: Promise<ContextApiResponse["user"] | null>; cleanup: () => void };
@@ -63,6 +91,14 @@ function getCSRFToken(cookieName: string) {
 
 async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiResponse["user"]> {
   const email = requireDefined(currentUser.email, "email of firebase user is undefined");
+  // JITSU-018: email+password sign-up issues a valid Firebase JWT before the
+  // address is verified. Block such accounts here — before any internal user or
+  // session is minted. OAuth providers verify the email themselves, so the gate
+  // only applies to the `password` provider.
+  const providerId = currentUser.providerData[0]?.providerId;
+  if (providerId === "password" && !currentUser.emailVerified) {
+    throw new EmailNotVerifiedError(email);
+  }
   let internalId = await getCustomClaim(currentUser, "internalId");
   let shouldRefreshToken = false;
   if (!internalId) {
@@ -149,6 +185,12 @@ export function useFirebaseSession(): FirebaseSession {
       resetPassword: async () => {
         throw new Error("Firebase auth is not enabled");
       },
+      sendVerificationEmail: async () => {
+        throw new Error("Firebase auth is not enabled");
+      },
+      reloadEmailVerified: async () => {
+        throw new Error("Firebase auth is not enabled");
+      },
       resolveUser: () => {
         throw new Error("Firebase auth is not enabled");
       },
@@ -184,8 +226,16 @@ export function useFirebaseSession(): FirebaseSession {
           auth.getAuth(),
           async user => {
             log.atDebug().log(`Firebase auth result`, user);
-            resolve(user ? await getUserFromFirebase(user) : null);
-            unregister();
+            try {
+              resolve(user ? await getUserFromFirebase(user) : null);
+            } catch (e) {
+              // getUserFromFirebase rejecting (e.g. EmailNotVerifiedError) must
+              // reject the outer promise — without this catch the throw escapes
+              // the async callback as an unhandled rejection and the caller hangs.
+              reject(e);
+            } finally {
+              unregister();
+            }
           },
           error => {
             log.atError().withCause(error).log(`Firebase auth error`);
@@ -213,6 +263,22 @@ export function useFirebaseSession(): FirebaseSession {
     },
     async resetPassword(username: string): Promise<void> {
       await auth.sendPasswordResetEmail(a.getAuth(), username);
+    },
+    async sendVerificationEmail(): Promise<void> {
+      const currentUser = requireDefined(a.getAuth().currentUser, "No signed-in firebase user");
+      await auth.sendEmailVerification(currentUser);
+    },
+    async reloadEmailVerified(): Promise<boolean> {
+      const currentUser = a.getAuth().currentUser;
+      if (!currentUser) {
+        return false;
+      }
+      await currentUser.reload();
+      if (currentUser.emailVerified) {
+        // Force a token refresh so downstream claims (email_verified) are fresh.
+        await currentUser.getIdToken(true);
+      }
+      return currentUser.emailVerified;
     },
   };
 }

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -97,6 +97,24 @@ function getCSRFToken(cookieName: string) {
   return token;
 }
 
+/**
+ * Continue URL for Firebase email actions (verification / reset). After the user
+ * completes the action on Firebase's hosted handler, it shows a button back to
+ * this URL. Firebase rejects a continue URL whose domain isn't an authorized
+ * domain, so it is only set for jitsu.com / localhost origins — dev branch hosts
+ * (`*.jitsu.localhost`) fall back to no continue URL.
+ */
+function emailActionSettings(): auth.ActionCodeSettings | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  const { origin, hostname } = window.location;
+  if (hostname === "jitsu.com" || hostname.endsWith(".jitsu.com") || hostname === "localhost") {
+    return { url: `${origin}/` };
+  }
+  return undefined;
+}
+
 async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiResponse["user"]> {
   const email = requireDefined(currentUser.email, "email of firebase user is undefined");
   // JITSU-018: email+password sign-up issues a valid Firebase JWT before the
@@ -276,7 +294,7 @@ export function useFirebaseSession(): FirebaseSession {
     async signUp(email: string, password: string): Promise<void> {
       const userCredential = await auth.createUserWithEmailAndPassword(a.getAuth(), email, password);
       if (userCredential?.user) {
-        await auth.sendEmailVerification(userCredential.user);
+        await auth.sendEmailVerification(userCredential.user, emailActionSettings());
       }
     },
     async resetPassword(username: string): Promise<void> {
@@ -284,7 +302,7 @@ export function useFirebaseSession(): FirebaseSession {
     },
     async sendVerificationEmail(): Promise<void> {
       const currentUser = requireDefined(a.getAuth().currentUser, "No signed-in firebase user");
-      await auth.sendEmailVerification(currentUser);
+      await auth.sendEmailVerification(currentUser, emailActionSettings());
     },
     async reloadEmailVerified(): Promise<boolean> {
       const currentUser = a.getAuth().currentUser;

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -142,7 +142,10 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiRe
     await rpc(`/api/fb-auth/create-user`, {
       body: {},
       headers: {
-        Authorization: `Bearer ${await currentUser.getIdToken()}`,
+        // Force-refresh so the token's email_verified claim is current. The
+        // server (JITSU-018) rejects a stale token still carrying
+        // email_verified:false for an account that has since verified.
+        Authorization: `Bearer ${await currentUser.getIdToken(true)}`,
       },
     });
     const newToken = await currentUser.getIdTokenResult(true);

--- a/webapps/console/lib/server/firebase-server.ts
+++ b/webapps/console/lib/server/firebase-server.ts
@@ -95,6 +95,16 @@ export async function signOut(firebaseUserId: string): Promise<void> {
   await firebase().auth().revokeRefreshTokens(firebaseUserId);
 }
 
+/**
+ * JITSU-018: an email+password account whose address is not verified must not
+ * receive server-side access. OAuth providers (Google / GitHub) verify the
+ * address themselves, so the check is scoped to the `password` sign-in provider.
+ * Server-side counterpart of the client gate in firebase-client.tsx.
+ */
+export function isUnverifiedPasswordAccount(decoded: admin.auth.DecodedIdToken): boolean {
+  return decoded.firebase?.sign_in_provider === "password" && decoded.email_verified === false;
+}
+
 export async function getFirebaseUser(req: NextApiRequest, checkRevoked?: boolean): Promise<SessionUser | undefined> {
   const authToken = getFirebaseToken(req);
   if (!authToken) {
@@ -116,6 +126,13 @@ export async function getFirebaseUser(req: NextApiRequest, checkRevoked?: boolea
       .withCause(e)
       .log(`Failed to verify firebase token: ${getErrorMessage(e)}`);
     return;
+  }
+
+  // JITSU-018: reject an unverified email+password account even if the
+  // client-side gate was bypassed — no session, no internal user.
+  if (isUnverifiedPasswordAccount(decodedIdToken)) {
+    getServerLog().atWarn().log(`Rejecting unverified email+password account: ${decodedIdToken.email}`);
+    return undefined;
   }
 
   const user = await firebase().auth().getUser(decodedIdToken.uid);

--- a/webapps/console/pages/_app.tsx
+++ b/webapps/console/pages/_app.tsx
@@ -25,7 +25,8 @@ import { AntdTheme } from "../components/AntdTheme/AntdTheme";
 import { AntdModalProvider } from "../lib/modal";
 import Head from "next/head";
 import { JitsuProvider, useJitsu } from "@jitsu/jitsu-react";
-import { FirebaseProvider, useFirebaseSession } from "../lib/firebase-client";
+import { EmailNotVerifiedError, FirebaseProvider, useFirebaseSession } from "../lib/firebase-client";
+import { VerifyEmailGate } from "../components/SignInOrUp/VerifyEmailGate";
 import { JitsuButton } from "../components/JitsuButton/JitsuButton";
 import { BillingProvider } from "../components/Billing/BillingProvider";
 import { useConfigObjectList, useConfigObjectsUpdater, useLoadedWorkspace } from "../lib/store";
@@ -104,6 +105,9 @@ const FirebaseAuthorizer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   if (loading) {
     return <GlobalLoader title={"Authorizing"} />;
   } else if (authError) {
+    if (authError instanceof EmailNotVerifiedError) {
+      return <VerifyEmailGate email={authError.email} />;
+    }
     return <GlobalError error={authError} title={"Authorization error"} />;
   } else if (user) {
     return (

--- a/webapps/console/pages/api/fb-auth/create-session.ts
+++ b/webapps/console/pages/api/fb-auth/create-session.ts
@@ -1,6 +1,11 @@
 import { Api, inferUrl, nextJsApiHandler } from "../../../lib/api";
 import { z } from "zod";
-import { createSessionCookie, firebaseAuthCookieName } from "../../../lib/server/firebase-server";
+import {
+  createSessionCookie,
+  firebase,
+  firebaseAuthCookieName,
+  isUnverifiedPasswordAccount,
+} from "../../../lib/server/firebase-server";
 import { ApiError } from "../../../lib/shared/errors";
 import { SerializeOptions, serialize } from "cookie";
 import { getAppEndpoint } from "../../../lib/domains";
@@ -29,6 +34,12 @@ export const api: Api = {
           .atError()
           .log(`CSRF cookie (${csrfCookie}) doesn't match provided token ${csrfToken}`, JSON.stringify(req.cookies));
         throw new ApiError("CSRF error", {}, { status: 401 });
+      }
+      // JITSU-018: never mint a session cookie for an unverified email+password
+      // account, even if the client-side gate was bypassed.
+      const decodedIdToken = await firebase().auth().verifyIdToken(idToken);
+      if (isUnverifiedPasswordAccount(decodedIdToken)) {
+        throw new ApiError("Email address is not verified", {}, { status: 403 });
       }
       const { cookie, expiresIn } = await createSessionCookie(idToken);
 

--- a/webapps/console/pages/auth/action.tsx
+++ b/webapps/console/pages/auth/action.tsx
@@ -1,0 +1,204 @@
+import React, { ReactNode, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import Link from "next/link";
+import { Alert, Button, Input, Spin } from "antd";
+import { getErrorMessage } from "juava";
+import { SigninLayout } from "../../components/SignInOrUp/SignInOrUp";
+import { useFirebaseSession } from "../../lib/firebase-client";
+
+export async function getServerSideProps() {
+  return { props: { publicPage: true } };
+}
+
+/**
+ * Custom Firebase email-action handler. Firebase's `callbackUri` points here, so
+ * verification / password-reset / email-recovery links land in the console
+ * instead of Firebase's bare hosted page — and we can redirect into the app once
+ * the action completes. See JITSU-018.
+ */
+type ActionState =
+  | { status: "working" }
+  | { status: "verified" }
+  | { status: "recovered" }
+  | { status: "reset-form"; email: string }
+  | { status: "reset-done" }
+  | { status: "error"; message: string };
+
+function explainActionError(e: any): string {
+  switch (e?.code) {
+    case "auth/expired-action-code":
+      return "This link has expired. Request a new email and try again.";
+    case "auth/invalid-action-code":
+      return "This link is invalid or has already been used.";
+    case "auth/user-disabled":
+      return "This account has been disabled.";
+    case "auth/user-not-found":
+      return "No account was found for this link.";
+    case "auth/weak-password":
+      return "Password is too weak. Use at least 6 characters.";
+    default:
+      return getErrorMessage(e);
+  }
+}
+
+const REDIRECT_DELAY_MS = 2500;
+
+const AuthActionPage = () => {
+  const router = useRouter();
+  const firebaseSession = useFirebaseSession();
+  const [state, setState] = useState<ActionState>({ status: "working" });
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const mode = typeof router.query.mode === "string" ? router.query.mode : undefined;
+  const oobCode = typeof router.query.oobCode === "string" ? router.query.oobCode : undefined;
+
+  // Apply the action code once the route query is available.
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+    if (!mode || !oobCode) {
+      setState({ status: "error", message: "This link is missing required parameters." });
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        if (mode === "verifyEmail") {
+          await firebaseSession.applyActionCode(oobCode);
+          if (!cancelled) setState({ status: "verified" });
+        } else if (mode === "recoverEmail") {
+          await firebaseSession.applyActionCode(oobCode);
+          if (!cancelled) setState({ status: "recovered" });
+        } else if (mode === "resetPassword") {
+          const email = await firebaseSession.verifyPasswordResetCode(oobCode);
+          if (!cancelled) setState({ status: "reset-form", email });
+        } else {
+          if (!cancelled) setState({ status: "error", message: `Unsupported action: ${mode}` });
+        }
+      } catch (e) {
+        if (!cancelled) setState({ status: "error", message: explainActionError(e) });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, mode, oobCode]);
+
+  // Once the action is done, send the user to sign in.
+  useEffect(() => {
+    if (state.status === "verified" || state.status === "recovered" || state.status === "reset-done") {
+      const t = setTimeout(() => router.replace("/signin"), REDIRECT_DELAY_MS);
+      return () => clearTimeout(t);
+    }
+  }, [state.status, router]);
+
+  const submitNewPassword = async () => {
+    if (state.status !== "reset-form" || !oobCode) {
+      return;
+    }
+    if (password.length < 6) {
+      setFormError("Password must be at least 6 characters");
+      return;
+    }
+    if (password !== confirm) {
+      setFormError("Passwords do not match");
+      return;
+    }
+    setFormError(null);
+    setSubmitting(true);
+    try {
+      await firebaseSession.confirmPasswordReset(oobCode, password);
+      setState({ status: "reset-done" });
+    } catch (e) {
+      setFormError(explainActionError(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (state.status === "working") {
+    return (
+      <SigninLayout title={<div className="text-2xl">One moment…</div>}>
+        <div className="max-w-[350px] flex justify-center py-4">
+          <Spin size="large" />
+        </div>
+      </SigninLayout>
+    );
+  }
+
+  if (state.status === "reset-form") {
+    return (
+      <SigninLayout title={<div className="text-2xl">Set a new password</div>}>
+        <div className="max-w-[350px]">
+          <p className="text-textLight">
+            Choose a new password for <span className="font-bold">{state.email}</span>.
+          </p>
+          <div className="mt-4 space-y-3">
+            <Input.Password
+              size="large"
+              autoFocus
+              autoComplete="new-password"
+              placeholder="New password (min 6 characters)"
+              value={password}
+              onChange={e => {
+                setPassword(e.target.value);
+                setFormError(null);
+              }}
+            />
+            <Input.Password
+              size="large"
+              autoComplete="new-password"
+              placeholder="Confirm new password"
+              value={confirm}
+              onChange={e => {
+                setConfirm(e.target.value);
+                setFormError(null);
+              }}
+              onPressEnter={submitNewPassword}
+            />
+            {formError && <Alert type="error" message={formError} />}
+            <Button block type="primary" size="large" loading={submitting} onClick={submitNewPassword}>
+              Update password
+            </Button>
+          </div>
+        </div>
+      </SigninLayout>
+    );
+  }
+
+  const screens: Record<"verified" | "recovered" | "reset-done" | "error", { title: string; body: ReactNode }> = {
+    verified: { title: "Email verified", body: "Your email address is verified. Taking you to sign in…" },
+    recovered: { title: "Email change reverted", body: "Your sign-in email has been restored. Taking you to sign in…" },
+    "reset-done": { title: "Password updated", body: "Your password has been changed. Taking you to sign in…" },
+    error: { title: "Link problem", body: state.status === "error" ? state.message : "" },
+  };
+  const screen = screens[state.status];
+
+  return (
+    <SigninLayout
+      title={<div className="text-2xl">{screen.title}</div>}
+      footer={
+        <div className="text-center mt-4">
+          <Link className="font-bold text-primary" href="/signin">
+            Go to sign in →
+          </Link>
+        </div>
+      }
+    >
+      <div className="max-w-[350px]">
+        {state.status === "error" ? (
+          <Alert type="error" message={screen.body} />
+        ) : (
+          <p className="text-textLight">{screen.body}</p>
+        )}
+      </div>
+    </SigninLayout>
+  );
+};
+
+export default AuthActionPage;

--- a/webapps/console/pages/signup.tsx
+++ b/webapps/console/pages/signup.tsx
@@ -1,7 +1,13 @@
 import { SignInOrUp } from "../components/SignInOrUp/SignInOrUp";
+import { FirebaseSignup } from "../components/SignInOrUp/FirebaseSignup";
+import { useAppConfig } from "../lib/context";
 
 const SignUpPage = () => {
-  return <SignInOrUp signup />;
+  const appConfig = useAppConfig();
+  // The marketing-led signup page is Cloud-only (Firebase auth). Self-hosted
+  // (NextAuth) signup keeps the plain shared component.
+  const useNewSignup = !!appConfig.auth?.firebasePublic && !appConfig.disableSignup;
+  return useNewSignup ? <FirebaseSignup /> : <SignInOrUp signup />;
 };
 
 export async function getServerSideProps() {


### PR DESCRIPTION
## Summary

Remediates two findings from the **April 2026 Upbeat Security pen test**
([Notion tracker](https://www.notion.so/365737892e4780899817ebc70828d7e6)), and rebuilds the
Firebase signup / email-verification flow that fixing them exposed as broken:

- **JITSU-018** — require a verified email before app access, enforced client- **and** server-side
- **JITSU-019 follow-up** — map the new generic auth error code in the console UI
- **Firebase email signup** — `/signup` never created accounts; rebuilt as a real two-column page
- **Email action links** — moved off the stale `eventnative.com` domain, with an in-console handler

## JITSU-018 — require a verified email

[Notion subtask](https://www.notion.so/365737892e4781de9b1ff807b642c3ae)

**Finding.** Firebase email+password sign-up issues a valid Firebase JWT immediately, before the
address is verified. The console accepted that JWT and minted an internal session — anyone could
reach the app with an unverified or unowned address.

**Client gate.** `getUserFromFirebase` throws a new `EmailNotVerifiedError` for an unverified
account before any internal user or session is created. `FirebaseAuthorizer` (`_app.tsx`) catches
it and renders a `VerifyEmailGate` (resend / re-check / sign out) — covering fresh sign-in, an
existing session cookie, and direct navigation. Scoped to **single-provider `password`
accounts**: an account that also has Google/GitHub linked has a provider-verified address and is
trusted.

**Server gate.** `getFirebaseUser` and the session-cookie endpoint (`create-session`) reject an
unverified email+password token (`isUnverifiedPasswordAccount`) — so a bypassed client still gets
no session and no internal user. The client route gate is UX; the server is the security
boundary. (`getUserFromFirebase` force-refreshes the ID token before `create-user` so a
just-verified account isn't rejected on a stale `email_verified` claim.)

**Who this affects** — checked against the live Firebase project `tracker-285220`:

| Group | Count |
|---|---|
| Total Firebase users | 8,964 |
| Google / GitHub users — never gated (OAuth) | ~7,990 |
| Password-provider users | 973 — verified 266, **unverified 707** |

**707 existing password accounts** hit the gate on next sign-in; the resend button is their path
through. No data migration (out of scope per the Notion subtask).

Also fixes a latent `resolveUser` bug — an error thrown inside the `onAuthStateChanged` async
callback escaped as an unhandled rejection and hung the caller on "Authorizing…"; it now rejects
the outer promise.

## JITSU-019 follow-up — error-code mapping

[Notion subtask](https://www.notion.so/365737892e478197bd3bc4d4f58fd8ec)

JITSU-019 turned on Firebase email-enumeration protection for `tracker-285220`. With it on, a
failed email/password sign-in returns the generic code `auth/invalid-credential` instead of
`auth/wrong-password` / `auth/user-not-found`. `handleFirebaseError` now maps
`auth/invalid-credential` and `auth/invalid-login-credentials` → "Invalid email or password".

## Firebase email signup — rebuilt

Fixing JITSU-018 surfaced that **email signup never worked**: `/signup` reused the `SignInOrUp`
component and there was no `createUserWithEmailAndPassword` anywhere — a new user typing an email
was shown a sign-*in* password field and the submit failed.

- `FirebaseSession.signUp()` — `createUserWithEmailAndPassword` + `sendEmailVerification`.
- A new dedicated **`/signup`** for the Firebase (Cloud) variant — two columns:
  - **`SignupMarketingPanel`** — testimonial / proof panel: quote, an auto-cycling code sample
    (a Jitsu function and the browser SDK; click a tab to pin it), linked feature list, customer
    logos.
  - **`FirebaseSignup`** — the form: OAuth buttons (shared `OAuthButtons`), then email-first — a
    Continue button reveals **password + confirm-password**. Terms / Privacy notice always shown.
    Built from standard antd components.
- Self-hosted (NextAuth) `/signup` keeps the existing shared component.
- After email signup the account is single-provider `password` + unverified → the redirect lands
  straight on `VerifyEmailGate`; signup and the gate share one screen.
- `auth/email-already-in-use` → a friendly message with an inline "Sign in" link.
- Dropped the misleading "Use this for SSO and password based logins" line from the sign-in form.

## Email action links — jitsu.com domain + in-console handler

Firebase's email action handler (`callbackUri` — one setting shared by verification, password
reset, and email change) pointed at `back1.eventnative.com/__/auth/action`, a stale
EventNative-brand domain. Repointed to **`backbase.jitsu.com/__/auth/action`** — a jitsu.com
Firebase Hosting domain on the same project.

A new **`/auth/action`** page is a custom Firebase email-action handler: it applies the `oobCode`
(verify email / password reset / email recovery) and redirects to `/signin`, instead of leaving
the user on Firebase's bare hosted page. `applyActionCode` only relays the code — Firebase's
backend validates it and sets `email_verified`, exactly as Firebase's own handler does.
`sendEmailVerification` also passes a continue URL, and `VerifyEmailGate` maps
`auth/too-many-requests` to a readable message.

> **Post-deploy step:** once this PR is live, repoint `callbackUri` to
> `https://use.jitsu.com/auth/action` so the in-console handler takes over. Repointing before
> deploy would 404 production auth emails.

## Firebase project-config changes (applied out of band)

Not part of the code diff — applied to `tracker-285220` via the Identity Toolkit admin API:

- JITSU-019 — email-enumeration protection (already live).
- `callbackUri`: `back1.eventnative.com` → `backbase.jitsu.com`.

## Not included (deliberate)

- **EE API enforcement.** The console rejects unverified tokens server-side; applying the same
  `email_verified` check inside the separate EE API app is left as a follow-up.

## Testing

Local CI green — `format:check:all`, `typecheck`, `lint` (0 errors), console unit tests. Manual
checklist:

1. Email+password signup with a throwaway address → redirect to the verify-email gate.
2. The verification email links to `backbase.jitsu.com`; clicking it verifies and redirects.
3. "I've verified my email — continue" → access granted.
4. Signup with an existing email → "account already exists" + inline Sign in link.
5. Mismatched / under-6-char passwords → inline validation, no Firebase call.
6. Google / GitHub signup → straight into the app, no gate.
7. A wrong-password login shows "Invalid email or password", not a raw Firebase string.

## Files

All under `webapps/console/`.

| File | Change |
|------|--------|
| `lib/firebase-client.tsx` | `EmailNotVerifiedError`, single-provider gate, `signUp`, email-verification + action-code methods, continue-URL, force-refresh before `create-user`, `resolveUser` fix |
| `lib/server/firebase-server.ts` | `isUnverifiedPasswordAccount` — server-side reject in `getFirebaseUser` |
| `pages/api/fb-auth/create-session.ts` | Reject unverified accounts before minting a session cookie |
| `pages/_app.tsx` | Render `VerifyEmailGate` from `FirebaseAuthorizer` |
| `pages/signup.tsx` | Render `FirebaseSignup` for the Firebase variant |
| `pages/auth/action.tsx` | **New** — custom Firebase email-action handler (verify / reset / recover → `/signin`) |
| `components/SignInOrUp/FirebaseSignup.tsx` | **New** — Firebase signup page / form |
| `components/SignInOrUp/SignupMarketingPanel.tsx` | **New** — signup testimonial / proof panel |
| `components/SignInOrUp/VerifyEmailGate.tsx` | **New** — verify-email gate screen |
| `components/SignInOrUp/SignInOrUp.tsx` | `auth/invalid-credential` mapping, redirect on `EmailNotVerifiedError`, export `handleFirebaseError` |
| `components/SignInOrUp/EmailFirstLogin.tsx` | Remove the misleading helper line |

---

Part of [🛡️ Remediate April 2026 pen test findings](https://www.notion.so/365737892e4780899817ebc70828d7e6).
