### PR TITLE
fix(kafka): replace router-side backpressure with ErrQueueFull retry

### DIFF
--- a/bulker/admin/deadletter_reprocessor.go
+++ b/bulker/admin/deadletter_reprocessor.go
@@ -195,6 +195,7 @@ func (r *DeadLetterReprocessor) Reprocess(ctx context.Context, cfg DeadLetterRep
 			kafka.PartitionAny,
 			fmt.Sprintf("dl-%s-%d", record.ActorId, record.Timestamp.UnixNano()),
 			false,
+			30*time.Second,
 		)
 		if err != nil {
 			result.ErrorCount++

--- a/bulker/bulkerapp/app/abstract_consumer.go
+++ b/bulker/bulkerapp/app/abstract_consumer.go
@@ -74,7 +74,7 @@ func (ac *AbstractConsumer) SendMetrics(metricsMeta string, status string, event
 	meta["timestamp"] = timestamp.ToISOFormat(time.Now().UTC().Truncate(time.Minute))
 	payload, _ := jsoniter.Marshal(meta)
 	//ac.Infof("Sending metrics to topic %s: %+v", topicId, meta)
-	err = ac.bulkerProducer.ProduceAsync(topicId, uuid.New(), payload, nil, kafka2.PartitionAny, "", false)
+	err = ac.bulkerProducer.ProduceAsync(topicId, uuid.New(), payload, nil, kafka2.PartitionAny, "", false, 30*time.Second)
 	if err != nil {
 		ac.Errorf("Error producing metrics to metrics destination: %v", err)
 		return

--- a/bulker/bulkerapp/app/batch_consumer.go
+++ b/bulker/bulkerapp/app/batch_consumer.go
@@ -391,12 +391,12 @@ func (bc *BatchConsumerImpl) processFailed(firstPosition *kafka.TopicPartition, 
 			kafkabase.PutKafkaHeader(&headers, originalTopicHeader, bc.topicId)
 			kafkabase.PutKafkaHeader(&headers, retriesCountHeader, strconv.Itoa(retries))
 			kafkabase.PutKafkaHeader(&headers, retryTimeHeader, timestamp.ToISOFormat(RetryBackOffTime(bc.config, retries+1).UTC()))
-			err = producer.Produce(&kafka.Message{
+			err = kafkabase.ProduceWithBackpressure(producer, &kafka.Message{
 				Key:            message.Key,
 				TopicPartition: kafka.TopicPartition{Topic: &failedTopic, Partition: kafka.PartitionAny},
 				Headers:        headers,
 				Value:          message.Value,
-			}, nil)
+			}, bc.config.ProducerLingerMs/2, 30*time.Second)
 
 			if err != nil {
 				return counters, fmt.Errorf("failed to put message to producer: %v", err)

--- a/bulker/bulkerapp/app/retry_consumer.go
+++ b/bulker/bulkerapp/app/retry_consumer.go
@@ -182,12 +182,12 @@ func (rc *RetryConsumer) processBatchImpl(_ *Destination, _, _, _, retryBatchSiz
 		originalError := kafkabase.GetKafkaHeader(message, errorHeader)
 		kafkabase.PutKafkaHeader(&headers, errorHeader, utils.ShortenStringWithEllipsis(originalError, 256))
 		kafkabase.PutKafkaHeader(&headers, retriesCountHeader, strconv.Itoa(retries))
-		err = producer.Produce(&kafka.Message{
+		err = kafkabase.ProduceWithBackpressure(producer, &kafka.Message{
 			Key:            message.Key,
 			TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
 			Headers:        headers,
 			Value:          message.Value,
-		}, nil)
+		}, rc.config.ProducerLingerMs/2, 30*time.Second)
 		if err != nil {
 			if strings.Contains(err.Error(), "Message size too large") {
 				rc.Errorf("Message size too large: %d. Headers: %+v Skipping message", len(message.Value), headers)

--- a/bulker/bulkerapp/app/router.go
+++ b/bulker/bulkerapp/app/router.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/jitsucom/bulker/jitsubase/logging"
@@ -44,8 +43,6 @@ type Router struct {
 	producer         *Producer
 	eventsLogService eventslog.EventsLogService
 	fastStore        *FastStore
-
-	backPressureMs atomic.Int32
 }
 
 func NewRouter(appContext *Context) *Router {
@@ -110,29 +107,13 @@ func (r *Router) Health(c *gin.Context) {
 	}
 	size, err := r.producer.QueueSize()
 	if err != nil {
-		r.backPressureMs.Store(0)
-		metrics.ProducerBackPressureDelayMs.Set(0)
 		logging.Errorf("Health check: FAILED: producer queue size error: %v", err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "fail", "output": "producer queue size error: " + err.Error()})
 		return
 	}
-	if r.config.ProducerBackPressureMaxDelayMs > 0 {
-		threshold := r.config.ProducerBackPressureThreshold
-		filled := float64(size) / float64(r.config.ProducerQueueSize)
-		if filled > threshold {
-			backPressure := (filled - threshold) / (1 - threshold)
-			backPressureMs := int32(backPressure * float64(r.config.ProducerBackPressureMaxDelayMs))
-			r.backPressureMs.Store(backPressureMs)
-			metrics.ProducerBackPressureDelayMs.Set(float64(backPressureMs))
-		} else {
-			r.backPressureMs.Store(0)
-			metrics.ProducerBackPressureDelayMs.Set(0)
-		}
-	}
-	if float64(size) > r.config.ProducerQueueSizeThreshold*float64(r.config.ProducerQueueSize) {
-		// we need to start worrying about the queue size before it reaches the limit
-		logging.Errorf("Health check: FAILED: producer queue size: %d", size)
-		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "fail", "output": fmt.Sprintf("producer queue size: %d", size)})
+	if size >= r.config.ProducerQueueSize {
+		logging.Errorf("Health check: FAILED: producer queue full: %d/%d", size, r.config.ProducerQueueSize)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "fail", "output": fmt.Sprintf("producer queue full: %d/%d", size, r.config.ProducerQueueSize)})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "pass", "producerQueueSize": size, "topicsUpdatedAt": updatedAt})
@@ -202,14 +183,10 @@ func (r *Router) EventsHandler(c *gin.Context) {
 	if streamOptions != "" {
 		headers[streamOptionsKeyHeader] = streamOptions
 	}
-	err = r.producer.ProduceAsync(topicId, uuid.New(), body, headers, kafka.PartitionAny, "", false)
+	err = r.producer.ProduceAsync(topicId, uuid.New(), body, headers, kafka.PartitionAny, "", false, 5*time.Second)
 	if err != nil {
 		rError = r.ResponseError(c, http.StatusInternalServerError, "producer error", true, err, true, true, false)
 		return
-	}
-	backPressureMs := r.backPressureMs.Load()
-	if backPressureMs > 0 {
-		time.Sleep(time.Duration(backPressureMs) * time.Millisecond)
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "ok"})
 }
@@ -233,7 +210,7 @@ func (r *Router) ProfilesHandler(c *gin.Context) {
 		return
 	}
 
-	err = r.producer.ProduceAsync(topicId, profileId, nil, nil, kafka.PartitionAny, "", false)
+	err = r.producer.ProduceAsync(topicId, profileId, nil, nil, kafka.PartitionAny, "", false, 5*time.Second)
 	if err != nil {
 		rError = r.ResponseError(c, http.StatusInternalServerError, "producer error", true, err, true, true, false)
 		return

--- a/bulker/bulkerapp/metrics/metrics.go
+++ b/bulker/bulkerapp/metrics/metrics.go
@@ -184,12 +184,6 @@ var (
 		return panics
 	}
 
-	ProducerBackPressureDelayMs = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "bulkerapp",
-		Subsystem: "producer",
-		Name:      "back_pressure_delay_ms",
-		Help:      "Current back pressure delay applied to producer requests in milliseconds",
-	})
 )
 
 func KafkaErrorCode(err error) string {

--- a/bulker/ingest/router.go
+++ b/bulker/ingest/router.go
@@ -294,7 +294,7 @@ func (r *Router) sendToRotor(c *gin.Context, messageId string, ingestMessageByte
 	var err error
 	if stream.BackupEnabled {
 		backupTopic := fmt.Sprintf("%sin.id.%s_backup.m.batch.t.backup", r.config.KafkaTopicPrefix, stream.Stream.WorkspaceId)
-		err2 := r.producer.ProduceAsync(backupTopic, uuid.New(), ingestMessageBytes, nil, kafka.PartitionAny, messageId, false)
+		err2 := r.producer.ProduceAsync(backupTopic, uuid.New(), ingestMessageBytes, nil, kafka.PartitionAny, messageId, false, 0)
 		if err2 != nil {
 			r.Errorf("Error producing to backup topic %s: %v", backupTopic, err2)
 		}
@@ -319,7 +319,7 @@ func (r *Router) sendToRotor(c *gin.Context, messageId string, ingestMessageByte
 			partition = r.partitionSelector.SelectPartition()
 		}
 		messageKey := uuid.New()
-		err = r.producer.ProduceAsync(topic, messageKey, ingestMessageBytes, map[string]string{ConnectionIdsHeader: strings.Join(asyncDestinations, ",")}, partition, messageId, true)
+		err = r.producer.ProduceAsync(topic, messageKey, ingestMessageBytes, map[string]string{ConnectionIdsHeader: strings.Join(asyncDestinations, ",")}, partition, messageId, true, 0)
 		if err != nil {
 			for _, id := range asyncDestinations {
 				IngestedMessages(id, "error", "producer error").Inc()

--- a/bulker/ingest/router_batch_handler.go
+++ b/bulker/ingest/router_batch_handler.go
@@ -312,7 +312,7 @@ func (r *Router) BatchHandler(c *gin.Context) {
 			obj := map[string]any{"body": string(ingestMessageBytes), "error": rError.PublicError.Error(), "status": utils.Ternary(rError.ErrorType == ErrThrottledType, "SKIPPED", "FAILED")}
 			r.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeIncoming, Level: eventslog.LevelError, ActorId: metricsId, Event: obj})
 			IngestHandlerRequests(domain, utils.Ternary(rError.ErrorType == ErrThrottledType, "throttled", "error"), rError.ErrorType).Inc()
-			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false)
+			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false, 0)
 			errors = append(errors, fmt.Sprintf("Message ID: %s: %v", messageId, rError.PublicError))
 		} else {
 			obj := map[string]any{"body": string(ingestMessageBytes), "asyncDestinations": asyncDestinations, "tags": tagsDestinations}

--- a/bulker/ingest/router_classic_handler.go
+++ b/bulker/ingest/router_classic_handler.go
@@ -187,7 +187,7 @@ func (r *Router) ClassicHandler(c *gin.Context) {
 			obj := map[string]any{"body": string(ingestMessageBytes), "error": rError.PublicError.Error(), "status": utils.Ternary(rError.ErrorType == ErrThrottledType, "SKIPPED", "FAILED")}
 			r.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeIncoming, Level: eventslog.LevelError, ActorId: metricsId, Event: obj})
 			IngestHandlerRequests(domain, utils.Ternary(rError.ErrorType == ErrThrottledType, "throttled", "error"), rError.ErrorType).Inc()
-			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false)
+			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false, 0)
 		} else {
 			obj := map[string]any{"body": string(ingestMessageBytes), "asyncDestinations": asyncDestinations}
 			if len(asyncDestinations) > 0 {

--- a/bulker/ingest/router_funcs_handler.go
+++ b/bulker/ingest/router_funcs_handler.go
@@ -40,7 +40,7 @@ func (r *Router) FuncsHandler(c *gin.Context) {
 			obj := map[string]any{"body": string(ingestMessageBytes), "error": rError.PublicError.Error(), "status": utils.Ternary(rError.ErrorType == ErrThrottledType, "SKIPPED", "FAILED")}
 			r.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeIncoming, Level: eventslog.LevelError, ActorId: metricsId, Event: obj})
 			IngestHandlerRequests(domain, utils.Ternary(rError.ErrorType == ErrThrottledType, "throttled", "error"), rError.ErrorType).Inc()
-			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false)
+			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false, 0)
 		} else {
 			obj := map[string]any{"body": string(ingestMessageBytes)}
 			obj["status"] = "SUCCESS"

--- a/bulker/ingest/router_ingest_handler.go
+++ b/bulker/ingest/router_ingest_handler.go
@@ -44,7 +44,7 @@ func (r *Router) IngestHandler(c *gin.Context) {
 			obj := map[string]any{"body": string(ingestMessageBytes), "error": rError.PublicError.Error(), "status": utils.Ternary(rError.ErrorType == ErrThrottledType, "SKIPPED", "FAILED")}
 			r.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeIncoming, Level: eventslog.LevelError, ActorId: metricsId, Event: obj})
 			IngestHandlerRequests(domain, utils.Ternary(rError.ErrorType == ErrThrottledType, "throttled", "error"), rError.ErrorType).Inc()
-			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false)
+			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false, 0)
 		} else {
 			obj := map[string]any{"body": string(ingestMessageBytes), "asyncDestinations": asyncDestinations, "tags": tagsDestinations}
 			if len(asyncDestinations) > 0 || len(tagsDestinations) > 0 {

--- a/bulker/ingest/router_pixel_handler.go
+++ b/bulker/ingest/router_pixel_handler.go
@@ -53,7 +53,7 @@ func (r *Router) PixelHandler(c *gin.Context) {
 			obj := map[string]any{"body": string(ingestMessageBytes), "error": rError.PublicError.Error(), "status": utils.Ternary(rError.ErrorType == ErrThrottledType, "SKIPPED", "FAILED")}
 			r.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeIncoming, Level: eventslog.LevelError, ActorId: metricsId, Event: obj})
 			IngestHandlerRequests(domain, utils.Ternary(rError.ErrorType == ErrThrottledType, "throttled", "error"), rError.ErrorType).Inc()
-			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false)
+			_ = r.producer.ProduceAsync(r.config.KafkaDestinationsDeadLetterTopicName, uuid.New(), utils.TruncateBytes(ingestMessageBytes, r.config.MaxIngestPayloadSize), map[string]string{"error": rError.Error.Error()}, kafka2.PartitionAny, messageId, false, 0)
 		} else {
 			obj := map[string]any{"body": string(ingestMessageBytes), "asyncDestinations": asyncDestinations}
 			if len(asyncDestinations) > 0 {

--- a/bulker/kafkabase/kafka_config.go
+++ b/bulker/kafkabase/kafka_config.go
@@ -44,15 +44,10 @@ type KafkaConfig struct {
 
 	// ProducerWaitForDeliveryMs For ProduceSync only is a timeout for producer to wait for delivery report.
 	ProducerQueueSize int `mapstructure:"PRODUCER_QUEUE_SIZE" default:"100000"`
-	// ProducerQueueSizeThreshold when queue size reaches this value, health check will return unhealthy
-	ProducerQueueSizeThreshold float64 `mapstructure:"PRODUCER_QUEUE_SIZE_THRESHOLD" default:"0.5"`
-	ProducerBatchSize          int     `mapstructure:"PRODUCER_BATCH_SIZE" default:"65535"`
+	ProducerBatchSize int `mapstructure:"PRODUCER_BATCH_SIZE" default:"65535"`
 	ProducerLingerMs           int     `mapstructure:"PRODUCER_LINGER_MS" default:"1000"`
 	ProducerDeliveryTimeoutMs  int     `mapstructure:"PRODUCER_DELIVERY_TIMEOUT_MS" default:"300000"`
 	ProducerWaitForDeliveryMs  int     `mapstructure:"PRODUCER_WAIT_FOR_DELIVERY_MS" default:"1000"`
-
-	ProducerBackPressureMaxDelayMs int     `mapstructure:"PRODUCER_BACK_PRESSURE_MAX_DELAY_MS" default:"0"`
-	ProducerBackPressureThreshold  float64 `mapstructure:"PRODUCER_BACK_PRESSURE_THRESHOLD" default:"0.25"`
 
 	// ProducerStatisticsIntervalMs is the interval in ms for librdkafka internal statistics reporting. 0 disables.
 	ProducerStatisticsIntervalMs int `mapstructure:"PRODUCER_STATISTICS_INTERVAL_MS" default:"0"`

--- a/bulker/kafkabase/producer.go
+++ b/bulker/kafkabase/producer.go
@@ -2,6 +2,7 @@ package kafkabase
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -14,6 +15,35 @@ import (
 )
 
 const MessageIdHeader = "message_id"
+
+// ProduceWithBackpressure submits msg via producer.Produce, retrying on
+// kafka.ErrQueueFull until the outbound queue drains or maxWait elapses.
+// ErrQueueFull is a transient back-pressure signal from librdkafka, not a
+// fatal error; Flush blocks (bounded) while in-flight messages get sent to
+// the broker and free queue slots. flushTimeoutMs is the per-iteration Flush
+// wait; maxWait caps total wall-clock time before giving up. Any non-queue-full
+// error is returned verbatim; a deadline-exceeded queue-full is wrapped.
+func ProduceWithBackpressure(producer *kafka.Producer, msg *kafka.Message, flushTimeoutMs int, maxWait time.Duration) error {
+	if flushTimeoutMs < 10 {
+		flushTimeoutMs = 10
+	}
+	deadline := time.Now().Add(maxWait)
+	for {
+		err := producer.Produce(msg, nil)
+		if err == nil {
+			return nil
+		}
+		var kerr kafka.Error
+		if errors.As(err, &kerr) && kerr.Code() == kafka.ErrQueueFull {
+			if time.Now().After(deadline) {
+				return fmt.Errorf("producer queue still full after %s: %w", maxWait, err)
+			}
+			producer.Flush(flushTimeoutMs)
+			continue
+		}
+		return err
+	}
+}
 
 type MetricsLabelsFunc func(topicId string, status, errText string) (topic, destinationId, mode, tableName, st string, err string)
 
@@ -216,17 +246,21 @@ func (p *Producer) ProduceSync(topic string, event kafka.Message) error {
 }
 
 // ProduceAsync TODO: transactional delivery?
-// produces messages to kafka
-func (p *Producer) ProduceAsync(topic string, messageKey string, event []byte, headers map[string]string, partition int32, messageId string, failover bool) error {
+// produces messages to kafka. When backpressureMaxWait > 0 and librdkafka's
+// local queue is full, the call blocks up to backpressureMaxWait while the
+// producer drains rather than returning ErrQueueFull immediately. Callers on
+// latency-sensitive paths (ingest HTTP handlers) should pass 0; bulkerapp HTTP
+// handlers ~5s; backend services / consumers / maintenance tasks ~30s.
+func (p *Producer) ProduceAsync(topic string, messageKey string, event []byte, headers map[string]string, partition int32, messageId string, failover bool, backpressureMaxWait time.Duration) error {
 	if p.isClosed() {
 		return p.NewError("producer is closed")
 	}
-	errors := multierror.Error{}
+	errs := multierror.Error{}
 	var key []byte
 	if messageKey != "" {
 		key = []byte(messageKey)
 	}
-	err := p.producer.Produce(&kafka.Message{
+	msg := &kafka.Message{
 		Key: key,
 		Headers: utils.MapToSlice(headers, func(k string, v string) kafka.Header {
 			return kafka.Header{Key: k, Value: []byte(v)}
@@ -237,10 +271,16 @@ func (p *Producer) ProduceAsync(topic string, messageKey string, event []byte, h
 			MessageIdHeader: messageId,
 			"failover":      failover,
 		},
-	}, nil)
+	}
+	var err error
+	if backpressureMaxWait > 0 {
+		err = ProduceWithBackpressure(p.producer, msg, p.config.ProducerLingerMs/2, backpressureMaxWait)
+	} else {
+		err = p.producer.Produce(msg, nil)
+	}
 	if err != nil {
 		ProducerMessages(p.metricsLabelFunc(topic, "error", KafkaErrorCode(err))).Inc()
-		errors.Errors = append(errors.Errors, err)
+		errs.Errors = append(errs.Errors, err)
 
 		// Log to failover logger for async production errors
 		if failover && p.failoverLogger != nil && p.failoverLogger.ShouldLog(err) {
@@ -251,7 +291,7 @@ func (p *Producer) ProduceAsync(topic string, messageKey string, event []byte, h
 	} else {
 		ProducerMessages(p.metricsLabelFunc(topic, "produced", "")).Inc()
 	}
-	return errors.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 // Close closes producer

--- a/bulker/reprocessing-worker/main.go
+++ b/bulker/reprocessing-worker/main.go
@@ -559,7 +559,7 @@ func sendBatch(batch []map[string]interface{}, producer *kafkabase.Producer, top
 			continue
 		}
 
-		err = producer.ProduceAsync(topic, uuid.New(), messageBytes, headers, kafka.PartitionAny, "", false)
+		err = producer.ProduceAsync(topic, uuid.New(), messageBytes, headers, kafka.PartitionAny, "", false, 30*time.Second)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Move kafka producer backpressure into shared `kafkabase.ProduceWithBackpressure` — Flush-and-retry on `kafka.ErrQueueFull` only when the queue is actually full, instead of proactively sleeping in `EventsHandler` based on a queue-fill ratio.
- `Producer.ProduceAsync` gains a `backpressureMaxWait time.Duration` parameter (replaces the previous `bool`). Per-caller routing: bulkerapp HTTP handlers `5s`, consumers / admin reprocessor / reprocessing-worker `30s`, all ingest paths `0` (must stay fail-fast). Per-iteration `Flush` timeout is `PRODUCER_LINGER_MS / 2`.
- Fix the original symptom: `bulker/bulkerapp/app/batch_consumer.go` no longer kills the whole retry batch on the first `Local: Queue full` from `producer.Produce`. The transactional `processFailed` path uses the new helper directly with a 30s wait.
- Health endpoint now fails only when the producer queue is **at capacity** (`size >= PRODUCER_QUEUE_SIZE`), not at a fractional threshold.
- Drop unused config + metric: `PRODUCER_QUEUE_SIZE_THRESHOLD`, `PRODUCER_BACK_PRESSURE_MAX_DELAY_MS`, `PRODUCER_BACK_PRESSURE_THRESHOLD`, and `bulkerapp_producer_back_pressure_delay_ms`.

## Why

We were hitting:

> `Failed to put unsuccessful batch to 'failed' producer: failed to put message to producer: Local: Queue full`

inside `processFailed` whenever a 10k retry batch of large messages exceeded the producer's effective byte cap (`queue.buffering.max.kbytes`, librdkafka default 1 GB). The old behavior failed the whole batch on the first `ErrQueueFull`, then the deferred `AbortTransaction` purged every already-enqueued message — which also explained the cascading `Local: Purged in queue` errors in the goroutine that consumes producer delivery reports.

The old router-side backpressure (queue-fill ratio computed in `Health`, applied as `time.Sleep` in `EventsHandler`) added latency proactively even when brokers were healthy, and didn't help the transactional retry path at all.

## Op notes / behavior deltas

- If any deployment was setting `PRODUCER_QUEUE_SIZE_THRESHOLD`, `PRODUCER_BACK_PRESSURE_MAX_DELAY_MS`, or `PRODUCER_BACK_PRESSURE_THRESHOLD`, those env vars become no-ops. Nothing breaks — unknown env keys are silently ignored — but worth cleaning up Helm/manifests when convenient.
- The Grafana panel `bulkerapp_producer_back_pressure_delay_ms` will go dark. Replace with `bulkerapp_producer_queue_length` if you want pressure visibility.
- Bulkerapp HTTP handlers (`/post/:destinationId`, `/profiles/...`) can now block up to **5s** on a wedged broker (previously bounded by the optional `PRODUCER_BACK_PRESSURE_MAX_DELAY_MS`, default 0). Keep an eye on tail latency post-deploy.

## Test plan

- [ ] `go vet ./kafkabase/ ./bulkerapp/... ./ingest/... ./reprocessing-worker/` passes
- [ ] Deploy to staging; trigger a large retry batch and confirm `processFailed` completes without `Local: Queue full` failing the batch
- [ ] Confirm `bulker` `/health` returns 503 when queue is at capacity
- [ ] Verify ingest HTTP handlers still return fast (no blocking) under broker pressure
- [ ] Confirm `Local: Purged in queue` log spam from transactional retry path is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)