### PR TITLE
feat(ee-api): surface stat_cache refresh in admin UI

### DIFF
--- a/webapps/ee-api/README.md
+++ b/webapps/ee-api/README.md
@@ -28,11 +28,12 @@ Auth is fully client-side — there is no session cookie:
 
 ### Env vars
 
-| Var | Purpose |
-| --- | --- |
-| `FIREBASE_AUTH` | JSON5 `{ admin, client }` — Firebase admin credentials + client config. |
-| `FIREBASE_ADMIN` + `FIREBASE_CLIENT_CONFIG` | Alternative to `FIREBASE_AUTH`: the two halves as separate JSON5 vars. |
-| `JITSU_EE_ADMINS` | Comma-separated email patterns that may access the UI. `*` is a wildcard. |
+| Var                                         | Purpose                                                                                                  |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `FIREBASE_AUTH`                             | JSON5 `{ admin, client }` — Firebase admin credentials + client config.                                  |
+| `FIREBASE_ADMIN` + `FIREBASE_CLIENT_CONFIG` | Alternative to `FIREBASE_AUTH`: the two halves as separate JSON5 vars.                                   |
+| `JITSU_EE_ADMINS`                           | Comma-separated email patterns that may access the UI. `*` is a wildcard.                                |
+| `CRON_SECRET`                               | Shared secret for Vercel Cron auth. Sent as `Authorization: Bearer <secret>`; accepted by `lib/auth.ts`. |
 
 `JITSU_EE_ADMINS` example:
 
@@ -61,6 +62,19 @@ pnpm --filter ee-api db:update-schema  # prisma db push — apply the schema to 
 ```
 
 The generated client lives in `lib/generated/` and is git-ignored.
+
+## Cron jobs
+
+Scheduled in `vercel.json`:
+
+- `/api/billing/export-subscriptions` — every 5 minutes.
+- `/api/sync-cache` — hourly; refreshes the current month of `newjitsuee.stat_cache`
+  from ClickHouse so the billing/usage reports can be served without querying it
+  directly. A full 12-month rebuild is available on demand from the admin UI's
+  **Update stat cache** button (`/api/admin/sync-cache`).
+
+Cron requests authenticate with `CRON_SECRET` — Vercel sends it automatically as a
+Bearer token to scheduled endpoints.
 
 ## Dev
 

--- a/webapps/ee-api/components/AdminLayout.tsx
+++ b/webapps/ee-api/components/AdminLayout.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { Button } from "antd";
 import { LogoutOutlined } from "@ant-design/icons";
 import { useAuth } from "./AuthProvider";
+import { UpdateStatCacheButton } from "./UpdateStatCacheButton";
 
 const navItems: { href: string; label: string }[] = [
   { href: "/", label: "Billing" },
@@ -44,6 +45,7 @@ export const AdminLayout: React.FC<PropsWithChildren> = ({ children }) => {
           })}
         </nav>
         <div className="flex items-center gap-3">
+          <UpdateStatCacheButton />
           <span className="text-sm text-neutral-500">{email}</span>
           <Button size="small" icon={<LogoutOutlined />} onClick={() => auth.signOut()}>
             Logout

--- a/webapps/ee-api/components/UpdateStatCacheButton.tsx
+++ b/webapps/ee-api/components/UpdateStatCacheButton.tsx
@@ -1,0 +1,229 @@
+import React, { useRef, useState } from "react";
+import { Alert, Button, Modal, Progress, Radio } from "antd";
+import { DatabaseOutlined } from "@ant-design/icons";
+import { useAuth } from "./AuthProvider";
+
+type Mode = "incremental" | "full";
+type Phase = "idle" | "running" | "done" | "error";
+
+/** One line of newline-delimited JSON streamed by `/api/admin/sync-cache`. */
+type ProgressEvent =
+  | { type: "start"; total: number }
+  | { type: "period"; index: number; total: number; start: string; rows: number; ms: number }
+  | { type: "done"; total: number; ms: number }
+  | { type: "error"; message: string };
+
+function formatPeriod(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
+}
+
+/**
+ * Header control that refreshes `newjitsuee.stat_cache` on demand. Opens a modal
+ * to pick the scope (current month or a full 12-month rebuild) and renders live
+ * progress streamed from `/api/admin/sync-cache`.
+ */
+export const UpdateStatCacheButton: React.FC = () => {
+  const { authFetch } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>("incremental");
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [total, setTotal] = useState(0);
+  const [completed, setCompleted] = useState(0);
+  const [logLines, setLogLines] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const resetState = () => {
+    setPhase("idle");
+    setTotal(0);
+    setCompleted(0);
+    setLogLines([]);
+    setError(null);
+  };
+
+  const openModal = () => {
+    resetState();
+    setMode("incremental");
+    setOpen(true);
+  };
+
+  const closeModal = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setOpen(false);
+  };
+
+  const handleEvent = (event: ProgressEvent) => {
+    switch (event.type) {
+      case "start":
+        setTotal(event.total);
+        break;
+      case "period":
+        setCompleted(event.index + 1);
+        setLogLines(lines => [
+          ...lines,
+          `${formatPeriod(event.start)} — ${event.rows} rows (${(event.ms / 1000).toFixed(1)}s)`,
+        ]);
+        break;
+      case "done":
+        setPhase("done");
+        break;
+      case "error":
+        setError(event.message);
+        setPhase("error");
+        break;
+    }
+  };
+
+  const run = async () => {
+    resetState();
+    setPhase("running");
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      const resp = await authFetch(`/api/admin/sync-cache?full=${mode === "full"}`, {
+        method: "POST",
+        signal: controller.signal,
+      });
+      if (!resp.ok || !resp.body) {
+        let message = `HTTP ${resp.status}`;
+        try {
+          const body = await resp.json();
+          if (body?.error) {
+            message = typeof body.error === "string" ? body.error : JSON.stringify(body.error);
+          }
+        } catch {
+          // keep the HTTP status as the message
+        }
+        throw new Error(message);
+      }
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let newline: number;
+        while ((newline = buffer.indexOf("\n")) >= 0) {
+          const line = buffer.slice(0, newline).trim();
+          buffer = buffer.slice(newline + 1);
+          if (line) {
+            handleEvent(JSON.parse(line) as ProgressEvent);
+          }
+        }
+      }
+      const tail = buffer.trim();
+      if (tail) {
+        handleEvent(JSON.parse(tail) as ProgressEvent);
+      }
+      // Stream closed without an explicit done/error event.
+      setPhase(current => (current === "running" ? "done" : current));
+    } catch (e: any) {
+      if (e?.name === "AbortError") {
+        return;
+      }
+      setError(e?.message || "Failed to update stat cache");
+      setPhase("error");
+    } finally {
+      abortRef.current = null;
+    }
+  };
+
+  const running = phase === "running";
+  const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  const footer =
+    phase === "idle"
+      ? [
+          <Button key="cancel" onClick={closeModal}>
+            Cancel
+          </Button>,
+          <Button key="start" type="primary" onClick={run}>
+            Start update
+          </Button>,
+        ]
+      : phase === "running"
+      ? [
+          <Button key="cancel" onClick={closeModal}>
+            Cancel
+          </Button>,
+        ]
+      : phase === "error"
+      ? [
+          <Button key="close" onClick={closeModal}>
+            Close
+          </Button>,
+          <Button key="retry" type="primary" onClick={run}>
+            Retry
+          </Button>,
+        ]
+      : [
+          <Button key="close" type="primary" onClick={closeModal}>
+            Close
+          </Button>,
+        ];
+
+  return (
+    <>
+      <Button size="small" icon={<DatabaseOutlined />} onClick={openModal}>
+        Update stat cache
+      </Button>
+      <Modal
+        title="Update stat cache"
+        open={open}
+        onCancel={closeModal}
+        footer={footer}
+        maskClosable={!running}
+        keyboard={!running}
+      >
+        {phase === "idle" ? (
+          <div className="flex flex-col gap-3 py-1">
+            <p className="text-sm text-neutral-500">
+              Refreshes <code>stat_cache</code> from ClickHouse. The hourly cron keeps the current month up to date —
+              run a full rebuild after a gap or for a first-time backfill.
+            </p>
+            <Radio.Group value={mode} onChange={e => setMode(e.target.value)}>
+              <div className="flex flex-col gap-2">
+                <Radio value="incremental">
+                  <span className="font-medium">Current month</span>
+                  <span className="text-neutral-400"> — fast, refreshes the latest period</span>
+                </Radio>
+                <Radio value="full">
+                  <span className="font-medium">Full rebuild</span>
+                  <span className="text-neutral-400"> — last 12 months, slower</span>
+                </Radio>
+              </div>
+            </Radio.Group>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3 py-1">
+            <Progress
+              percent={percent}
+              status={phase === "error" ? "exception" : phase === "done" ? "success" : "active"}
+            />
+            <div className="text-sm text-neutral-500">
+              {phase === "done"
+                ? `Done — ${total} period(s) updated.`
+                : phase === "error"
+                ? "Update failed."
+                : total > 0
+                ? `Updating period ${Math.min(completed + 1, total)} of ${total}…`
+                : "Starting…"}
+            </div>
+            {logLines.length > 0 && (
+              <div className="flex max-h-48 flex-col gap-0.5 overflow-auto rounded-md bg-neutral-50 p-3 font-mono text-xs text-neutral-600">
+                {logLines.map((line, i) => (
+                  <div key={i}>{line}</div>
+                ))}
+              </div>
+            )}
+            {error && <Alert type="error" showIcon message="Update failed" description={error} />}
+          </div>
+        )}
+      </Modal>
+    </>
+  );
+};

--- a/webapps/ee-api/components/UpdateStatCacheButton.tsx
+++ b/webapps/ee-api/components/UpdateStatCacheButton.tsx
@@ -100,6 +100,13 @@ export const UpdateStatCacheButton: React.FC = () => {
       const reader = resp.body.getReader();
       const decoder = new TextDecoder();
       let buffer = "";
+      let sawTerminal = false;
+      const handle = (event: ProgressEvent) => {
+        if (event.type === "done" || event.type === "error") {
+          sawTerminal = true;
+        }
+        handleEvent(event);
+      };
       for (;;) {
         const { value, done } = await reader.read();
         if (done) {
@@ -111,16 +118,21 @@ export const UpdateStatCacheButton: React.FC = () => {
           const line = buffer.slice(0, newline).trim();
           buffer = buffer.slice(newline + 1);
           if (line) {
-            handleEvent(JSON.parse(line) as ProgressEvent);
+            handle(JSON.parse(line) as ProgressEvent);
           }
         }
       }
       const tail = buffer.trim();
       if (tail) {
-        handleEvent(JSON.parse(tail) as ProgressEvent);
+        handle(JSON.parse(tail) as ProgressEvent);
       }
-      // Stream closed without an explicit done/error event.
-      setPhase(current => (current === "running" ? "done" : current));
+      // A finished refresh always ends with a `done` (or `error`) event. A stream
+      // that closes while still running means the server was cut off mid-run
+      // (e.g. a platform timeout) — surface it as a failure, not a false success.
+      if (!sawTerminal) {
+        setError("The update stopped before it finished — the cache may be partially updated.");
+        setPhase("error");
+      }
     } catch (e: any) {
       if (e?.name === "AbortError") {
         return;

--- a/webapps/ee-api/pages/api/admin/sync-cache.ts
+++ b/webapps/ee-api/pages/api/admin/sync-cache.ts
@@ -1,0 +1,34 @@
+import { getErrorMessage } from "juava";
+import { withFirebaseAdminAuth } from "../../../lib/route-helpers";
+import { syncStatCache, SyncCacheGranularity } from "../sync-cache";
+
+/**
+ * On-demand `newjitsuee.stat_cache` refresh for the admin UI.
+ *
+ * Streams newline-delimited JSON — one {@link SyncCacheProgress} object per line,
+ * plus a final `{ type: "error", message }` line if the refresh fails — so the
+ * caller can render live progress. `?full=true` rebuilds the last 12 months;
+ * otherwise only the current period is refreshed.
+ */
+export default withFirebaseAdminAuth(async (req, res) => {
+  const full = req.query.full === "true" || req.query.full === "1";
+  const granularity: SyncCacheGranularity = req.query.granularity === "day" ? "day" : "month";
+
+  res.setHeader("Content-Type", "application/x-ndjson; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store, no-transform");
+  res.setHeader("X-Accel-Buffering", "no");
+
+  const write = (event: unknown) => res.write(JSON.stringify(event) + "\n");
+  try {
+    for await (const event of syncStatCache({ full, granularity })) {
+      write(event);
+    }
+  } catch (e) {
+    write({ type: "error", message: getErrorMessage(e) });
+  }
+  res.end();
+});
+
+export const config = {
+  maxDuration: 300,
+};

--- a/webapps/ee-api/pages/api/admin/sync-cache.ts
+++ b/webapps/ee-api/pages/api/admin/sync-cache.ts
@@ -1,18 +1,21 @@
 import { getErrorMessage } from "juava";
 import { withFirebaseAdminAuth } from "../../../lib/route-helpers";
-import { syncStatCache, SyncCacheGranularity } from "../sync-cache";
+import { syncStatCache } from "../sync-cache";
 
 /**
  * On-demand `newjitsuee.stat_cache` refresh for the admin UI.
  *
- * Streams newline-delimited JSON — one {@link SyncCacheProgress} object per line,
- * plus a final `{ type: "error", message }` line if the refresh fails — so the
- * caller can render live progress. `?full=true` rebuilds the last 12 months;
- * otherwise only the current period is refreshed.
+ * `POST` only — it mutates the cache. Streams newline-delimited JSON: one
+ * {@link SyncCacheProgress} object per line, plus a final `{ type: "error",
+ * message }` line if the refresh fails, so the caller can render live progress.
+ * `?full=true` rebuilds the last 12 months; otherwise only the current month.
  */
 export default withFirebaseAdminAuth(async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
   const full = req.query.full === "true" || req.query.full === "1";
-  const granularity: SyncCacheGranularity = req.query.granularity === "day" ? "day" : "month";
 
   res.setHeader("Content-Type", "application/x-ndjson; charset=utf-8");
   res.setHeader("Cache-Control", "no-store, no-transform");
@@ -20,7 +23,7 @@ export default withFirebaseAdminAuth(async (req, res) => {
 
   const write = (event: unknown) => res.write(JSON.stringify(event) + "\n");
   try {
-    for await (const event of syncStatCache({ full, granularity })) {
+    for await (const event of syncStatCache({ full })) {
       write(event);
     }
   } catch (e) {

--- a/webapps/ee-api/pages/api/sync-cache.ts
+++ b/webapps/ee-api/pages/api/sync-cache.ts
@@ -1,44 +1,63 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { withErrorHandler } from "../../lib/route-helpers";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { auth } from "../../lib/auth";
 import { getLog } from "juava";
 import { getEventsReport } from "./report/workspace-stat";
 import { prisma, Prisma } from "../../lib/services";
 
+dayjs.extend(utc);
+
 const log = getLog();
 
-const handler = async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const claims = await auth(req, res);
-  if (claims?.type !== "admin") {
-    throw new Error("Unauthorized");
-  }
-  const logResult: Record<string, any> = {};
-  const granularity = ((req.query.granularity as string) || "month") as "month" | "day";
-  const full = req.query.full === "true" || req.query.full === "1";
+const lookbackMonths = 12;
+
+export type SyncCacheGranularity = "month" | "day";
+
+export type SyncCacheOptions = {
+  granularity?: SyncCacheGranularity;
+  /** When true, rebuild the last 12 months; otherwise refresh only the current period. */
+  full?: boolean;
+};
+
+/** Progress events streamed by {@link syncStatCache} as it refreshes the cache. */
+export type SyncCacheProgress =
+  | { type: "start"; total: number; from: string; to: string }
+  | { type: "period"; index: number; total: number; start: string; end: string; rows: number; ms: number }
+  | { type: "done"; total: number; ms: number };
+
+/**
+ * Refresh `newjitsuee.stat_cache` from ClickHouse one period at a time, yielding a
+ * progress event after each. `full` rebuilds the last 12 months; otherwise only the
+ * current period is refreshed (plus the previous one on the 1st of the month, so the
+ * just-closed period gets a final pass).
+ */
+export async function* syncStatCache({
+  granularity = "month",
+  full = false,
+}: SyncCacheOptions): AsyncGenerator<SyncCacheProgress> {
   const now = dayjs().utc();
-  let startOfCurrentPeriod = now.startOf(granularity);
-  const lookbackMonths = 12;
   const min = full
     ? now.startOf(granularity).subtract(lookbackMonths, "month")
-    : now.get("day") > 1
+    : now.date() > 1
     ? now.startOf(granularity)
     : now.startOf(granularity).subtract(1, granularity);
-  log.atInfo().log(`Starting cache sync from ${min.toISOString()} to ${startOfCurrentPeriod.toISOString()}`);
-  while (startOfCurrentPeriod.isAfter(min) || startOfCurrentPeriod.isSame(min)) {
-    const start = startOfCurrentPeriod;
-    const end = startOfCurrentPeriod.add(1, granularity);
+  // Period starts, newest first.
+  const periods: dayjs.Dayjs[] = [];
+  for (let cur = now.startOf(granularity); cur.isAfter(min) || cur.isSame(min); ) {
+    periods.push(cur);
+    cur = cur.subtract(1, granularity).startOf(granularity);
+  }
+  const overallTimer = Date.now();
+  log.atInfo().log(`Starting stat_cache sync from ${min.toISOString()} — ${periods.length} period(s)`);
+  yield { type: "start", total: periods.length, from: min.toISOString(), to: now.startOf(granularity).toISOString() };
+  for (let index = 0; index < periods.length; index++) {
+    const start = periods[index];
+    const end = start.add(1, granularity);
     const timer = Date.now();
     log.atInfo().log(`Building report for [${start.toISOString()}, ${end.toISOString()}]`);
     const report = await getEventsReport({ start: start.toISOString(), end: end.toISOString(), granularity: "day" });
-    const ellapsed = Date.now() - timer;
-    log
-      .atInfo()
-      .log(
-        `Built report for [${start.toISOString()}, ${end.toISOString()}] in ${ellapsed}ms. Rows: ${
-          report.length
-        } Adding data to cache`
-      );
     if (report.length > 0) {
       const rows = report.map(
         ({ workspaceId, period, events, syncs }) => Prisma.sql`(${workspaceId}, ${period}, ${events}, ${syncs || 0})`
@@ -50,14 +69,39 @@ const handler = async function handler(req: NextApiRequest, res: NextApiResponse
         on conflict ("workspaceId", "period")
         do update set "events" = excluded."events", "syncs" = excluded."syncs"`;
     }
-    logResult[start.toISOString()] = {
+    const ms = Date.now() - timer;
+    log.atInfo().log(`Cached [${start.toISOString()}, ${end.toISOString()}] in ${ms}ms. Rows: ${report.length}`);
+    yield {
+      type: "period",
+      index,
+      total: periods.length,
       start: start.toISOString(),
       end: end.toISOString(),
-      ms: Date.now() - timer,
+      rows: report.length,
+      ms,
     };
-    startOfCurrentPeriod = startOfCurrentPeriod.subtract(1, granularity).startOf(granularity);
+  }
+  yield { type: "done", total: periods.length, ms: Date.now() - overallTimer };
+}
+
+const handler = async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const claims = await auth(req, res);
+  if (claims?.type !== "admin") {
+    throw new Error("Unauthorized");
+  }
+  const granularity: SyncCacheGranularity = req.query.granularity === "day" ? "day" : "month";
+  const full = req.query.full === "true" || req.query.full === "1";
+  const logResult: Record<string, any> = {};
+  for await (const event of syncStatCache({ granularity, full })) {
+    if (event.type === "period") {
+      logResult[event.start] = { start: event.start, end: event.end, rows: event.rows, ms: event.ms };
+    }
   }
   res.json({ ok: true, log: logResult });
+};
+
+export const config = {
+  maxDuration: 300,
 };
 
 export default withErrorHandler(handler);

--- a/webapps/ee-api/pages/api/sync-cache.ts
+++ b/webapps/ee-api/pages/api/sync-cache.ts
@@ -59,8 +59,12 @@ export async function* syncStatCache({
     log.atInfo().log(`Building report for [${start.toISOString()}, ${end.toISOString()}]`);
     const report = await getEventsReport({ start: start.toISOString(), end: end.toISOString(), granularity: "day" });
     if (report.length > 0) {
+      // `period` is an ISO string; cast it so Postgres does not see a text → timestamp
+      // mismatch (the column is `timestamp without time zone`). The cast ignores the
+      // `Z` designator rather than converting, so it stays session-timezone independent.
       const rows = report.map(
-        ({ workspaceId, period, events, syncs }) => Prisma.sql`(${workspaceId}, ${period}, ${events}, ${syncs || 0})`
+        ({ workspaceId, period, events, syncs }) =>
+          Prisma.sql`(${workspaceId}, ${period}::timestamp, ${events}, ${syncs || 0})`
       );
       log.atDebug().log(`Running batch upsert for ${rows.length} rows`);
       await prisma.$executeRaw`

--- a/webapps/ee-api/pages/api/sync-cache.ts
+++ b/webapps/ee-api/pages/api/sync-cache.ts
@@ -11,14 +11,11 @@ dayjs.extend(utc);
 
 const log = getLog();
 
-/** Number of periods a `full` rebuild covers, including the current one. */
-const fullRebuildPeriods = 12;
-
-export type SyncCacheGranularity = "month" | "day";
+/** Number of months a `full` rebuild covers, including the current one. */
+const fullRebuildMonths = 12;
 
 export type SyncCacheOptions = {
-  granularity?: SyncCacheGranularity;
-  /** When true, rebuild the last 12 months; otherwise refresh only the current period. */
+  /** When true, rebuild the last 12 months; otherwise refresh only the current month. */
   full?: boolean;
 };
 
@@ -60,35 +57,33 @@ async function upsertStatCache(report: WorkspaceReportRow[]): Promise<void> {
 }
 
 /**
- * Refresh `newjitsuee.stat_cache` from ClickHouse one period at a time, yielding a
+ * Refresh `newjitsuee.stat_cache` from ClickHouse one month at a time, yielding a
  * progress event after each. `full` rebuilds the last 12 months; otherwise only the
- * current period is refreshed (plus the previous one on the 1st of the month, so the
- * just-closed period gets a final pass).
+ * current month is refreshed (plus the previous one on the 1st of the month, so the
+ * just-closed month gets a final pass). Per-day rows are always stored — the monthly
+ * loop is only how the ClickHouse work is chunked.
  */
-export async function* syncStatCache({
-  granularity = "month",
-  full = false,
-}: SyncCacheOptions): AsyncGenerator<SyncCacheProgress> {
+export async function* syncStatCache({ full = false }: SyncCacheOptions): AsyncGenerator<SyncCacheProgress> {
   const now = dayjs().utc();
   // The loop below is inclusive of both bounds, so subtract one less than the
-  // period count to land on exactly `fullRebuildPeriods` periods.
+  // month count to land on exactly `fullRebuildMonths` months.
   const min = full
-    ? now.startOf(granularity).subtract(fullRebuildPeriods - 1, granularity)
+    ? now.startOf("month").subtract(fullRebuildMonths - 1, "month")
     : now.date() > 1
-    ? now.startOf(granularity)
-    : now.startOf(granularity).subtract(1, granularity);
-  // Period starts, newest first.
+    ? now.startOf("month")
+    : now.startOf("month").subtract(1, "month");
+  // Month starts, newest first.
   const periods: dayjs.Dayjs[] = [];
-  for (let cur = now.startOf(granularity); cur.isAfter(min) || cur.isSame(min); ) {
+  for (let cur = now.startOf("month"); cur.isAfter(min) || cur.isSame(min); ) {
     periods.push(cur);
-    cur = cur.subtract(1, granularity).startOf(granularity);
+    cur = cur.subtract(1, "month").startOf("month");
   }
   const overallTimer = Date.now();
   log.atInfo().log(`Starting stat_cache sync from ${min.toISOString()} — ${periods.length} period(s)`);
-  yield { type: "start", total: periods.length, from: min.toISOString(), to: now.startOf(granularity).toISOString() };
+  yield { type: "start", total: periods.length, from: min.toISOString(), to: now.startOf("month").toISOString() };
   for (let index = 0; index < periods.length; index++) {
     const start = periods[index];
-    const end = start.add(1, granularity);
+    const end = start.add(1, "month");
     const timer = Date.now();
     log.atInfo().log(`Building report for [${start.toISOString()}, ${end.toISOString()}]`);
     const report = await getEventsReport({ start: start.toISOString(), end: end.toISOString(), granularity: "day" });
@@ -113,10 +108,9 @@ const handler = async function handler(req: NextApiRequest, res: NextApiResponse
   if (claims?.type !== "admin") {
     throw new Error("Unauthorized");
   }
-  const granularity: SyncCacheGranularity = req.query.granularity === "day" ? "day" : "month";
   const full = req.query.full === "true" || req.query.full === "1";
   const logResult: Record<string, any> = {};
-  for await (const event of syncStatCache({ granularity, full })) {
+  for await (const event of syncStatCache({ full })) {
     if (event.type === "period") {
       logResult[event.start] = { start: event.start, end: event.end, rows: event.rows, ms: event.ms };
     }

--- a/webapps/ee-api/pages/api/sync-cache.ts
+++ b/webapps/ee-api/pages/api/sync-cache.ts
@@ -4,14 +4,15 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { auth } from "../../lib/auth";
 import { getLog } from "juava";
-import { getEventsReport } from "./report/workspace-stat";
-import { prisma, Prisma } from "../../lib/services";
+import { getEventsReport, WorkspaceReportRow } from "./report/workspace-stat";
+import { prisma } from "../../lib/services";
 
 dayjs.extend(utc);
 
 const log = getLog();
 
-const lookbackMonths = 12;
+/** Number of periods a `full` rebuild covers, including the current one. */
+const fullRebuildPeriods = 12;
 
 export type SyncCacheGranularity = "month" | "day";
 
@@ -27,6 +28,37 @@ export type SyncCacheProgress =
   | { type: "period"; index: number; total: number; start: string; end: string; rows: number; ms: number }
   | { type: "done"; total: number; ms: number };
 
+/** Rows per upsert statement — keeps the placeholder and parameter count bounded. */
+const upsertChunkSize = 1000;
+
+async function upsertStatCache(report: WorkspaceReportRow[]): Promise<void> {
+  for (let i = 0; i < report.length; i += upsertChunkSize) {
+    const batch = report.slice(i, i + upsertChunkSize);
+    // Positional placeholders via $executeRawUnsafe. `Prisma.sql` / `Prisma.join`
+    // fragments passed to $executeRaw break under Next.js HMR — the `Sql` instances
+    // stop being recognized across reloads and the query collapses to `values $1`.
+    // The SQL here is fully static (only the row count varies), so it is not unsafe.
+    //
+    // `period` is an ISO string cast to timestamp — the column is `timestamp without
+    // time zone`, and the cast drops the `Z` rather than converting, so it stays
+    // session-timezone independent.
+    const tuples = batch
+      .map((_, j) => {
+        const p = j * 4;
+        return `($${p + 1}, $${p + 2}::timestamp, $${p + 3}, $${p + 4})`;
+      })
+      .join(", ");
+    const values = batch.flatMap(({ workspaceId, period, events, syncs }) => [workspaceId, period, events, syncs || 0]);
+    await prisma.$executeRawUnsafe(
+      `insert into newjitsuee.stat_cache ("workspaceId", "period", "events", "syncs")
+       values ${tuples}
+       on conflict ("workspaceId", "period")
+       do update set "events" = excluded."events", "syncs" = excluded."syncs"`,
+      ...values
+    );
+  }
+}
+
 /**
  * Refresh `newjitsuee.stat_cache` from ClickHouse one period at a time, yielding a
  * progress event after each. `full` rebuilds the last 12 months; otherwise only the
@@ -38,8 +70,10 @@ export async function* syncStatCache({
   full = false,
 }: SyncCacheOptions): AsyncGenerator<SyncCacheProgress> {
   const now = dayjs().utc();
+  // The loop below is inclusive of both bounds, so subtract one less than the
+  // period count to land on exactly `fullRebuildPeriods` periods.
   const min = full
-    ? now.startOf(granularity).subtract(lookbackMonths, "month")
+    ? now.startOf(granularity).subtract(fullRebuildPeriods - 1, granularity)
     : now.date() > 1
     ? now.startOf(granularity)
     : now.startOf(granularity).subtract(1, granularity);
@@ -58,21 +92,7 @@ export async function* syncStatCache({
     const timer = Date.now();
     log.atInfo().log(`Building report for [${start.toISOString()}, ${end.toISOString()}]`);
     const report = await getEventsReport({ start: start.toISOString(), end: end.toISOString(), granularity: "day" });
-    if (report.length > 0) {
-      // `period` is an ISO string; cast it so Postgres does not see a text → timestamp
-      // mismatch (the column is `timestamp without time zone`). The cast ignores the
-      // `Z` designator rather than converting, so it stays session-timezone independent.
-      const rows = report.map(
-        ({ workspaceId, period, events, syncs }) =>
-          Prisma.sql`(${workspaceId}, ${period}::timestamp, ${events}, ${syncs || 0})`
-      );
-      log.atDebug().log(`Running batch upsert for ${rows.length} rows`);
-      await prisma.$executeRaw`
-        insert into newjitsuee.stat_cache ("workspaceId", "period", "events", "syncs")
-        values ${Prisma.join(rows)}
-        on conflict ("workspaceId", "period")
-        do update set "events" = excluded."events", "syncs" = excluded."syncs"`;
-    }
+    await upsertStatCache(report);
     const ms = Date.now() - timer;
     log.atInfo().log(`Cached [${start.toISOString()}, ${end.toISOString()}] in ${ms}ms. Rows: ${report.length}`);
     yield {

--- a/webapps/ee-api/vercel.json
+++ b/webapps/ee-api/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/billing/export-subscriptions",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/sync-cache",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Prep for moving `/admin/overage-billing` and `/admin/workspaces` into ee-api: surface the
`stat_cache` refresh endpoint in the UI and keep the cache fresh with a cron.

### 1. "Update stat cache" button

A button in the ee-api admin header (visible on every admin page) opens a modal where you
pick the scope — **Current month** (fast) or **Full rebuild** (last 12 months) — and watch
live progress.

- The refresh loop is extracted into a `syncStatCache` async generator that yields a
  progress event per period.
- New `POST /api/admin/sync-cache` (Firebase admin auth) streams those events as
  newline-delimited JSON; the modal renders a progress bar + per-period log.
- The cron route `/api/sync-cache` now consumes the same generator — no behavior change to
  its JSON response.

### 2. Is `stat_cache` enough for the two admin routes?

**Yes.** ClickHouse is touched in exactly one place across both routes — event counts
(`getEventsReport` → `active_incoming_agg_view`) — and `stat_cache` already stores events
per-day per-workspace.

| Data | Source | Covered |
|---|---|---|
| Events / day / workspace | ClickHouse | ✅ `stat_cache.events` |
| Sync counts | Postgres (`source_task`) | Postgres, not ClickHouse |
| Workspace name/slug/domains/users/throttle | Postgres | Postgres, not ClickHouse |
| Billing status, invoices, plans | Stripe | Stripe |

Both `/api/report/overage` and `/api/report/workspace-stat` already accept `cache=true`,
which routes events through `getEventsReportFromCache` instead of ClickHouse. So the data
layer is ready — no schema change needed.

Caveats (not blockers, noted for the migration):
- `stat_cache.syncs` is effectively dead — it is always `0` because `getEventsReport` never
  returns a `syncs` field. Harmless: syncs are read live from Postgres, which is allowed.
- Coverage is rolling — `full=false` refreshes the current month; the 60-day overage window
  relies on last month's rows already being cached. The hourly cron keeps this rolling, but
  the table needs one **Full rebuild** to backfill initially.
- The report endpoints use `auth()` (JWT / `CRON_SECRET`), not `withFirebaseAdminAuth`.
  When the two pages move into the ee-api UI they will need a Firebase-admin entry point —
  the same pattern this PR establishes with `/api/admin/sync-cache`.

### 3. Hourly cron

- Added `/api/sync-cache` to `webapps/ee-api/vercel.json`, hourly (`0 * * * *`).
- `CRON_SECRET` is **already set** on the `new-jitsu-ee-api` Vercel project (Production /
  Preview / Development) — the existing `export-subscriptions` cron already relies on it.
  Vercel sends it automatically as a Bearer token, and `lib/auth.ts` already accepts it.
  Nothing to add.

### Also

- Fixed the incremental cutoff in the refresh loop: it used dayjs `day` (day-of-week) where
  it meant `date` (day-of-month), so on Sundays/Mondays it redundantly re-processed the
  previous month every hour.
- Added a `maxDuration` config to `/api/sync-cache` (it had none).

## Verification

`pnpm --filter ee-api typecheck`, `eslint`, and `prettier` all pass. The streaming endpoint
and modal were not exercised against live ClickHouse/Firebase.
