### PR TITLE
feat(ee-api): track overage invoices on admin workspaces page

### DIFF
--- a/webapps/ee-api/lib/admin-workspaces.ts
+++ b/webapps/ee-api/lib/admin-workspaces.ts
@@ -14,6 +14,13 @@ import {
   stripeDataTable,
   stripeLink,
 } from "./stripe";
+import {
+  fetchOverageInvoiceInfos,
+  loadOverageInvoiceRows,
+  matchOverageInvoice,
+  OverageInvoiceInfo,
+  periodKey,
+} from "./overage-invoices";
 
 dayjs.extend(utc);
 
@@ -144,6 +151,10 @@ export type AdminWorkspaceRow = {
   overage: OverageInfo | null;
   /** Combined overage for the previous period — null for non-paid workspaces. */
   previousOverage: PreviousOverageInfo | null;
+  /** Canonical period key for the previous billing period — `YYYY-MM-DD_YYYY-MM-DD`. */
+  previousPeriodKey: string;
+  /** Overage invoice recorded for the previous period; null when none exists (or it was voided). */
+  overageInvoice: OverageInvoiceInfo | null;
   syncs: SyncsInfo;
   stripeCustomerId: string | null;
   stripeSubscriptionId: string | null;
@@ -419,8 +430,14 @@ async function activeSyncsInWindows(
  * Build the admin workspace overview: billing status, usage, overage and sync
  * stats for every active workspace. All event stats come from the `stat_cache`
  * table — ClickHouse is never queried.
+ *
+ * When `withOverageInvoices` is left on (default), each paid row is also
+ * annotated with the overage invoice recorded for its previous billing period —
+ * this fans out to Stripe to read invoice statuses. Pass `false` to skip it.
  */
-export async function buildAdminWorkspaces(): Promise<AdminWorkspacesResponse> {
+export async function buildAdminWorkspaces(
+  opts: { withOverageInvoices?: boolean } = {}
+): Promise<AdminWorkspacesResponse> {
   const now = dayjs().utc();
   const todayStart = now.startOf("day");
   const yesterdayStart = todayStart.subtract(1, "day");
@@ -728,6 +745,8 @@ export async function buildAdminWorkspaces(): Promise<AdminWorkspacesResponse> {
       plan: billing.plan,
       overage,
       previousOverage: null,
+      previousPeriodKey: periodKey(billing.previousPeriodStart.toISOString(), billing.previousPeriodEnd.toISOString()),
+      overageInvoice: null,
       syncs,
       stripeCustomerId: billing.customerId,
       stripeSubscriptionId: subscriptionId,
@@ -800,6 +819,36 @@ export async function buildAdminWorkspaces(): Promise<AdminWorkspacesResponse> {
       syncsLimit != null ? Math.max(0, (previousActiveSyncs.get(row.workspaceId) || 0) - syncsLimit) : 0;
     const syncsFee = syncsOver * (syncOveragePrice || 0) * discountFactor;
     row.previousOverage = { eventsOver, eventsFee, syncsOver, syncsFee, totalFee: eventsFee + syncsFee };
+  }
+
+  // Attach the overage invoice recorded for each paid workspace's previous
+  // period. The stored row holds only the invoice id — its current status is
+  // read live from Stripe so voided invoices drop out of the view.
+  //
+  // Wrapped so the whole page survives any failure here — a missing
+  // `overage_invoices` table (schema not yet pushed) or a Stripe error just
+  // leaves every row's `overageInvoice` null and the Create button showing.
+  if (opts.withOverageInvoices !== false) {
+    try {
+      const overageRowsByWorkspace = await loadOverageInvoiceRows();
+      const matched: { row: AdminWorkspaceRow; stored: ReturnType<typeof matchOverageInvoice> }[] = [];
+      for (const row of rows) {
+        if (!row.paid) {
+          continue;
+        }
+        const stored = matchOverageInvoice(overageRowsByWorkspace.get(row.workspaceId), row.previousPeriodStart);
+        if (stored) {
+          matched.push({ row, stored });
+        }
+      }
+      const infos = await fetchOverageInvoiceInfos(matched.map(m => m.stored!));
+      for (const { row, stored } of matched) {
+        row.overageInvoice = infos.get(stored!.invoiceId) || null;
+      }
+      log.atInfo().log(`Resolved ${infos.size} overage invoices for ${matched.length} matched workspaces`);
+    } catch (e) {
+      log.atWarn().withCause(e).log("Failed to resolve overage invoices — continuing without them");
+    }
   }
 
   log.atInfo().log(`Built admin overview for ${rows.length} workspaces`);

--- a/webapps/ee-api/lib/admin-workspaces.ts
+++ b/webapps/ee-api/lib/admin-workspaces.ts
@@ -836,7 +836,11 @@ export async function buildAdminWorkspaces(
         if (!row.paid) {
           continue;
         }
-        const stored = matchOverageInvoice(overageRowsByWorkspace.get(row.workspaceId), row.previousPeriodStart);
+        const stored = matchOverageInvoice(
+          overageRowsByWorkspace.get(row.workspaceId),
+          row.previousPeriodStart,
+          row.previousPeriodEnd
+        );
         if (stored) {
           matched.push({ row, stored });
         }

--- a/webapps/ee-api/lib/overage-invoices.ts
+++ b/webapps/ee-api/lib/overage-invoices.ts
@@ -115,7 +115,18 @@ export function matchOverageInvoice(
   return best?.row ?? null;
 }
 
-/** Retrieve invoices by id, tolerating ones deleted in Stripe. Bounded concurrency. */
+/** True for a Stripe "object does not exist" error — a deleted (or never-existing) invoice. */
+function isMissingInvoiceError(e: unknown): boolean {
+  return e instanceof Stripe.errors.StripeError && (e.statusCode === 404 || e.code === "resource_missing");
+}
+
+/**
+ * Retrieve invoices by id. An invoice that no longer exists in Stripe (404) is
+ * omitted from the result. Any other failure (network, rate limit, 5xx) is
+ * rethrown, never swallowed — a transient lookup failure must not be mistaken
+ * for "invoice deleted", which would drop a valid `overage_invoices` row and
+ * spawn a duplicate draft. Bounded concurrency.
+ */
 async function retrieveInvoices(ids: string[]): Promise<Map<string, Stripe.Invoice>> {
   const result = new Map<string, Stripe.Invoice>();
   const concurrency = 10;
@@ -124,8 +135,11 @@ async function retrieveInvoices(ids: string[]): Promise<Map<string, Stripe.Invoi
     const invoices = await Promise.all(
       chunk.map(id =>
         stripe.invoices.retrieve(id).catch(e => {
-          log.atWarn().withCause(e).log(`Failed to retrieve overage invoice ${id}`);
-          return null;
+          if (isMissingInvoiceError(e)) {
+            log.atWarn().log(`Overage invoice ${id} no longer exists in Stripe`);
+            return null;
+          }
+          throw e;
         })
       )
     );
@@ -140,8 +154,10 @@ async function retrieveInvoices(ids: string[]): Promise<Map<string, Stripe.Invoi
 
 /**
  * Resolve the current Stripe state of stored overage invoices, keyed by invoice
- * id. Invoices that were deleted or voided in Stripe are omitted — the admin
- * page treats them as "no invoice" and offers a Create button again.
+ * id. Invoices that were deleted (404) or voided in Stripe are omitted — the
+ * admin page treats them as "no invoice" and offers a Create button again. A
+ * transient Stripe failure is rethrown, not swallowed, so callers never mistake
+ * it for a deleted invoice.
  */
 export async function fetchOverageInvoiceInfos(rows: OverageInvoiceRow[]): Promise<Map<string, OverageInvoiceInfo>> {
   const result = new Map<string, OverageInvoiceInfo>();

--- a/webapps/ee-api/lib/overage-invoices.ts
+++ b/webapps/ee-api/lib/overage-invoices.ts
@@ -1,0 +1,367 @@
+import dayjs, { Dayjs } from "dayjs";
+import utc from "dayjs/plugin/utc";
+import Stripe from "stripe";
+import { getServerLog } from "./log";
+import { prisma, store } from "./services";
+import { stripe, stripeDataTable, stripeLink, StripeDataTableEntry } from "./stripe";
+
+dayjs.extend(utc);
+
+const log = getServerLog("overage-invoices");
+
+/** Line description for the event-overage line — matches the manually-created overage invoices in Stripe. */
+const EVENTS_LINE_DESCRIPTION = "Overage fee - events over plan limit, per event";
+const DAY_FMT = "YYYY-MM-DD";
+
+/**
+ * A backfilled overage invoice carries the billing period entered by hand on
+ * its Stripe line, which can drift a day or two from the Stripe-derived billing
+ * cycle. A stored period whose start is within this many days of the cycle
+ * start is treated as the same period.
+ */
+const PERIOD_MATCH_TOLERANCE_DAYS = 7;
+
+/** Stripe invoice statuses we surface. Voided invoices are filtered out upstream. */
+export type OverageInvoiceStatus = "draft" | "open" | "paid" | "uncollectible" | "void";
+
+/** Overage invoice info attached to an admin workspace row. */
+export type OverageInvoiceInfo = {
+  invoiceId: string;
+  /** Period key the invoice is stored under (`YYYY-MM-DD_YYYY-MM-DD`). */
+  period: string;
+  status: OverageInvoiceStatus;
+  /** Stripe dashboard link to the invoice. */
+  link: string;
+  /** Invoice total in dollars. */
+  total: number;
+};
+
+/** A row of the `overage_invoices` table. */
+type OverageInvoiceRow = { workspaceId: string; period: string; invoiceId: string };
+
+/**
+ * Canonical period key for a billing period: `YYYY-MM-DD_YYYY-MM-DD`, start
+ * inclusive and end exclusive, both in UTC.
+ */
+export function periodKey(startIso: string, endIso: string): string {
+  return `${dayjs.utc(startIso).format(DAY_FMT)}_${dayjs.utc(endIso).format(DAY_FMT)}`;
+}
+
+/** Parse a period key back into UTC day boundaries; null when malformed. */
+export function parsePeriodKey(key: string): { start: Dayjs; end: Dayjs } | null {
+  const m = /^(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})$/.exec(key);
+  return m ? { start: dayjs.utc(m[1]), end: dayjs.utc(m[2]) } : null;
+}
+
+/** All `overage_invoices` rows grouped by workspace id. */
+export async function loadOverageInvoiceRows(): Promise<Map<string, OverageInvoiceRow[]>> {
+  const rows = await prisma.overageInvoice.findMany({
+    select: { workspaceId: true, period: true, invoiceId: true },
+  });
+  const byWorkspace = new Map<string, OverageInvoiceRow[]>();
+  for (const row of rows) {
+    const list = byWorkspace.get(row.workspaceId);
+    if (list) {
+      list.push(row);
+    } else {
+      byWorkspace.set(row.workspaceId, [row]);
+    }
+  }
+  return byWorkspace;
+}
+
+/**
+ * Find the stored overage invoice for a workspace's billing period. The match
+ * is tolerant (see PERIOD_MATCH_TOLERANCE_DAYS) so backfilled invoices line up
+ * with the Stripe-derived billing cycle even when the dates are slightly off.
+ */
+export function matchOverageInvoice(
+  rows: OverageInvoiceRow[] | undefined,
+  periodStartIso: string
+): OverageInvoiceRow | null {
+  if (!rows || rows.length === 0) {
+    return null;
+  }
+  const target = dayjs.utc(periodStartIso);
+  let best: { row: OverageInvoiceRow; diff: number } | null = null;
+  for (const row of rows) {
+    const parsed = parsePeriodKey(row.period);
+    if (!parsed) {
+      continue;
+    }
+    const diff = Math.abs(parsed.start.diff(target, "day"));
+    if (diff <= PERIOD_MATCH_TOLERANCE_DAYS && (!best || diff < best.diff)) {
+      best = { row, diff };
+    }
+  }
+  return best?.row ?? null;
+}
+
+/** Retrieve invoices by id, tolerating ones deleted in Stripe. Bounded concurrency. */
+async function retrieveInvoices(ids: string[]): Promise<Map<string, Stripe.Invoice>> {
+  const result = new Map<string, Stripe.Invoice>();
+  const concurrency = 10;
+  for (let i = 0; i < ids.length; i += concurrency) {
+    const chunk = ids.slice(i, i + concurrency);
+    const invoices = await Promise.all(
+      chunk.map(id =>
+        stripe.invoices.retrieve(id).catch(e => {
+          log.atWarn().withCause(e).log(`Failed to retrieve overage invoice ${id}`);
+          return null;
+        })
+      )
+    );
+    for (const inv of invoices) {
+      if (inv) {
+        result.set(inv.id, inv);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolve the current Stripe state of stored overage invoices, keyed by invoice
+ * id. Invoices that were deleted or voided in Stripe are omitted — the admin
+ * page treats them as "no invoice" and offers a Create button again.
+ */
+export async function fetchOverageInvoiceInfos(rows: OverageInvoiceRow[]): Promise<Map<string, OverageInvoiceInfo>> {
+  const result = new Map<string, OverageInvoiceInfo>();
+  if (rows.length === 0) {
+    return result;
+  }
+  const invoices = await retrieveInvoices(rows.map(r => r.invoiceId));
+  for (const row of rows) {
+    const inv = invoices.get(row.invoiceId);
+    if (!inv) {
+      continue;
+    }
+    const status = (inv.status || "draft") as OverageInvoiceStatus;
+    if (status === "void") {
+      continue;
+    }
+    result.set(row.invoiceId, {
+      invoiceId: inv.id,
+      period: row.period,
+      status,
+      link: stripeLink("invoices", inv.id),
+      total: (inv.total || 0) / 100,
+    });
+  }
+  return result;
+}
+
+export type CreateOverageInvoiceInput = {
+  workspaceId: string;
+  workspaceName: string;
+  stripeCustomerId: string;
+  /** Billing period start, inclusive (ISO). */
+  periodStartIso: string;
+  /** Billing period end, exclusive (ISO). */
+  periodEndIso: string;
+  /** Overage events beyond the included quota. */
+  eventsOver: number;
+  /** Event overage fee, dollars (discount already applied). */
+  eventsFee: number;
+  /** Active syncs over the included limit. */
+  syncsOver: number;
+  /** Sync overage fee, dollars (discount already applied). */
+  syncsFee: number;
+};
+
+export type CreateOverageInvoiceResult = {
+  invoiceId: string;
+  period: string;
+  link: string;
+  total: number;
+  /** True when an existing invoice was returned instead of creating a new one. */
+  reused: boolean;
+};
+
+/**
+ * Create a draft Stripe overage invoice for a workspace's completed billing
+ * period and record it in `overage_invoices`. Idempotent: a non-voided invoice
+ * already stored for the period is returned unchanged.
+ *
+ * The invoice is left as a draft (`auto_advance: false`) — an admin reviews it
+ * in Stripe and finalizes it there, which is what charges the customer.
+ */
+export async function createOverageInvoice(input: CreateOverageInvoiceInput): Promise<CreateOverageInvoiceResult> {
+  const period = periodKey(input.periodStartIso, input.periodEndIso);
+
+  // Idempotency — reuse any non-voided invoice already stored for this period.
+  const existingRows = await prisma.overageInvoice.findMany({
+    where: { workspaceId: input.workspaceId },
+    select: { workspaceId: true, period: true, invoiceId: true },
+  });
+  const existing = matchOverageInvoice(existingRows, input.periodStartIso);
+  if (existing) {
+    const info = (await fetchOverageInvoiceInfos([existing])).get(existing.invoiceId);
+    if (info) {
+      return { invoiceId: info.invoiceId, period: existing.period, link: info.link, total: info.total, reused: true };
+    }
+    // Stored invoice was deleted/voided in Stripe — drop the stale row, create fresh.
+    await prisma.overageInvoice
+      .delete({ where: { workspaceId_period: { workspaceId: existing.workspaceId, period: existing.period } } })
+      .catch(() => undefined);
+  }
+
+  if (input.eventsOver <= 0 && input.syncsOver <= 0) {
+    throw new Error(`Workspace ${input.workspaceId} has no overage for period ${period}`);
+  }
+
+  const linePeriod = {
+    start: Math.floor(dayjs.utc(input.periodStartIso).valueOf() / 1000),
+    end: Math.floor(dayjs.utc(input.periodEndIso).valueOf() / 1000),
+  };
+
+  // Draft invoice. `pending_invoice_items_behavior: "exclude"` keeps unrelated
+  // pending invoice items off it; `auto_advance: false` leaves it for review.
+  const invoice = await stripe.invoices.create({
+    customer: input.stripeCustomerId,
+    auto_advance: false,
+    collection_method: "charge_automatically",
+    pending_invoice_items_behavior: "exclude",
+    description: `Usage overage — ${input.workspaceName} (${period})`,
+    metadata: { jitsu_overage: "true", jitsu_workspace_id: input.workspaceId, jitsu_period: period },
+  });
+
+  try {
+    if (input.eventsOver > 0 && input.eventsFee > 0) {
+      // `quantity` must be an integer; the per-event price is then derived from
+      // the final (discounted) fee so the invoice total equals the figure shown
+      // in the admin table.
+      const quantity = Math.round(input.eventsOver);
+      const unitAmountDecimal = ((input.eventsFee * 100) / quantity).toFixed(12);
+      await stripe.invoiceItems.create({
+        customer: input.stripeCustomerId,
+        invoice: invoice.id,
+        currency: "usd",
+        description: EVENTS_LINE_DESCRIPTION,
+        quantity,
+        unit_amount_decimal: unitAmountDecimal,
+        period: linePeriod,
+      });
+    }
+    if (input.syncsOver > 0 && input.syncsFee > 0) {
+      await stripe.invoiceItems.create({
+        customer: input.stripeCustomerId,
+        invoice: invoice.id,
+        currency: "usd",
+        description: `Overage fee - active syncs over plan limit (${input.syncsOver})`,
+        amount: Math.round(input.syncsFee * 100),
+        period: linePeriod,
+      });
+    }
+  } catch (e) {
+    // Roll back the empty draft so a failed run leaves nothing behind.
+    await stripe.invoices.del(invoice.id).catch(() => undefined);
+    throw e;
+  }
+
+  await prisma.overageInvoice.upsert({
+    where: { workspaceId_period: { workspaceId: input.workspaceId, period } },
+    create: { workspaceId: input.workspaceId, period, invoiceId: invoice.id },
+    update: { invoiceId: invoice.id },
+  });
+  log.atInfo().log(`Created overage invoice ${invoice.id} for workspace ${input.workspaceId}, period ${period}`);
+
+  const finalized = await stripe.invoices.retrieve(invoice.id);
+  return {
+    invoiceId: invoice.id,
+    period,
+    link: stripeLink("invoices", invoice.id),
+    total: (finalized.total || 0) / 100,
+    reused: false,
+  };
+}
+
+export type BackfillResult = {
+  /** Invoices examined. */
+  scanned: number;
+  /** Invoices identified as overage invoices. */
+  matched: number;
+  /** Rows written to `overage_invoices`. */
+  upserted: number;
+  /** Overage invoices that could not be recorded, with the reason. */
+  skipped: { invoiceId: string; reason: string }[];
+};
+
+/** Whether an invoice looks like a manually-created (or jitsu-created) overage invoice. */
+function isOverageInvoice(invoice: Stripe.Invoice): boolean {
+  if (invoice.metadata?.jitsu_overage === "true") {
+    return true;
+  }
+  if (invoice.billing_reason !== "manual") {
+    return false;
+  }
+  return invoice.lines.data.some(l => /overage/i.test(l.description || ""));
+}
+
+/** Period key for a backfilled invoice — from its metadata, else from the overage line's period. */
+function backfillPeriod(invoice: Stripe.Invoice): string | null {
+  if (invoice.metadata?.jitsu_period) {
+    return invoice.metadata.jitsu_period;
+  }
+  const line = invoice.lines.data.find(l => /overage/i.test(l.description || "")) || invoice.lines.data[0];
+  if (!line?.period?.start || !line?.period?.end) {
+    return null;
+  }
+  return periodKey(dayjs.unix(line.period.start).utc().toISOString(), dayjs.unix(line.period.end).utc().toISOString());
+}
+
+/**
+ * Scan Stripe invoices from the last `months` and record every overage invoice
+ * in `overage_invoices`. Voided invoices are skipped. Existing rows are updated.
+ */
+export async function backfillOverageInvoices(months: number): Promise<BackfillResult> {
+  const gte = Math.floor(dayjs().utc().subtract(months, "month").valueOf() / 1000);
+
+  // Customer id -> workspace id, from the stripe-settings table.
+  const stripeEntries = (await store.getTable(stripeDataTable).list()) as { id: string; obj: StripeDataTableEntry }[];
+  const workspaceByCustomer = new Map<string, string>();
+  for (const entry of stripeEntries) {
+    if (entry.obj?.stripeCustomerId) {
+      workspaceByCustomer.set(entry.obj.stripeCustomerId, entry.id);
+    }
+  }
+
+  const result: BackfillResult = { scanned: 0, matched: 0, upserted: 0, skipped: [] };
+  let startingAfter: string | undefined = undefined;
+  do {
+    const page = await stripe.invoices.list({ limit: 100, starting_after: startingAfter, created: { gte } });
+    for (const invoice of page.data) {
+      result.scanned++;
+      if (invoice.status === "void") {
+        continue;
+      }
+      if (!isOverageInvoice(invoice)) {
+        continue;
+      }
+      result.matched++;
+      const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id;
+      const workspaceId = customerId ? workspaceByCustomer.get(customerId) : undefined;
+      if (!workspaceId) {
+        result.skipped.push({ invoiceId: invoice.id, reason: `no workspace for customer ${customerId}` });
+        continue;
+      }
+      const period = backfillPeriod(invoice);
+      if (!period) {
+        result.skipped.push({ invoiceId: invoice.id, reason: "no billing period on invoice lines" });
+        continue;
+      }
+      await prisma.overageInvoice.upsert({
+        where: { workspaceId_period: { workspaceId, period } },
+        create: { workspaceId, period, invoiceId: invoice.id },
+        update: { invoiceId: invoice.id },
+      });
+      result.upserted++;
+    }
+    startingAfter = page.has_more ? page.data[page.data.length - 1]?.id : undefined;
+  } while (startingAfter);
+
+  log
+    .atInfo()
+    .log(`Overage backfill: scanned ${result.scanned}, matched ${result.matched}, upserted ${result.upserted}`);
+  return result;
+}

--- a/webapps/ee-api/lib/overage-invoices.ts
+++ b/webapps/ee-api/lib/overage-invoices.ts
@@ -2,7 +2,7 @@ import dayjs, { Dayjs } from "dayjs";
 import utc from "dayjs/plugin/utc";
 import Stripe from "stripe";
 import { getServerLog } from "./log";
-import { prisma, store } from "./services";
+import { Prisma, prisma, store } from "./services";
 import { stripe, stripeDataTable, stripeLink, StripeDataTableEntry } from "./stripe";
 
 dayjs.extend(utc);
@@ -71,18 +71,36 @@ export async function loadOverageInvoiceRows(): Promise<Map<string, OverageInvoi
 }
 
 /**
- * Find the stored overage invoice for a workspace's billing period. The match
- * is tolerant (see PERIOD_MATCH_TOLERANCE_DAYS) so backfilled invoices line up
- * with the Stripe-derived billing cycle even when the dates are slightly off.
+ * Find the stored overage invoice for a workspace's billing period.
+ *
+ * An exact period-key match always wins. Failing that, the match falls back to
+ * a tolerant comparison — a backfilled invoice carries the line period entered
+ * by hand on Stripe, which can drift a day or two from the Stripe-derived
+ * cycle. The tolerance is capped strictly below half the period length, so it
+ * can never reach an adjacent period: weekly periods sit only 7 days apart, and
+ * a flat ±7-day window would otherwise let the previous week's invoice match.
  */
 export function matchOverageInvoice(
   rows: OverageInvoiceRow[] | undefined,
-  periodStartIso: string
+  periodStartIso: string,
+  periodEndIso: string
 ): OverageInvoiceRow | null {
   if (!rows || rows.length === 0) {
     return null;
   }
+  const exactKey = periodKey(periodStartIso, periodEndIso);
+  const exact = rows.find(r => r.period === exactKey);
+  if (exact) {
+    return exact;
+  }
   const target = dayjs.utc(periodStartIso);
+  // Cap tolerance below half the period length so adjacent periods cannot
+  // collide (their starts are a full period length apart).
+  const periodDays = Math.max(1, dayjs.utc(periodEndIso).diff(target, "day"));
+  const tolerance = Math.min(PERIOD_MATCH_TOLERANCE_DAYS, Math.floor(periodDays / 2) - 1);
+  if (tolerance < 1) {
+    return null;
+  }
   let best: { row: OverageInvoiceRow; diff: number } | null = null;
   for (const row of rows) {
     const parsed = parsePeriodKey(row.period);
@@ -90,7 +108,7 @@ export function matchOverageInvoice(
       continue;
     }
     const diff = Math.abs(parsed.start.diff(target, "day"));
-    if (diff <= PERIOD_MATCH_TOLERANCE_DAYS && (!best || diff < best.diff)) {
+    if (diff <= tolerance && (!best || diff < best.diff)) {
       best = { row, diff };
     }
   }
@@ -178,32 +196,44 @@ export type CreateOverageInvoiceResult = {
   reused: boolean;
 };
 
+/** Build a "reused" result for an already-stored invoice; null if it is gone or voided in Stripe. */
+async function reuseStoredInvoice(row: OverageInvoiceRow): Promise<CreateOverageInvoiceResult | null> {
+  const info = (await fetchOverageInvoiceInfos([row])).get(row.invoiceId);
+  return info
+    ? { invoiceId: info.invoiceId, period: row.period, link: info.link, total: info.total, reused: true }
+    : null;
+}
+
 /**
  * Create a draft Stripe overage invoice for a workspace's completed billing
- * period and record it in `overage_invoices`. Idempotent: a non-voided invoice
- * already stored for the period is returned unchanged.
+ * period and record it in `overage_invoices`.
+ *
+ * Idempotent and concurrency-safe:
+ *  - A non-voided invoice already stored for the exact period is returned as-is.
+ *  - The `(workspaceId, period)` primary key is the atomic guard. The row is
+ *    written with a plain `create`, so two concurrent requests cannot both
+ *    persist: the loser hits `P2002`, deletes its now-duplicate draft and
+ *    returns the winner's invoice.
+ *  - Any other persistence failure also deletes the draft, so a failed run
+ *    never leaves an orphan invoice that a retry would then duplicate.
  *
  * The invoice is left as a draft (`auto_advance: false`) — an admin reviews it
  * in Stripe and finalizes it there, which is what charges the customer.
  */
 export async function createOverageInvoice(input: CreateOverageInvoiceInput): Promise<CreateOverageInvoiceResult> {
   const period = periodKey(input.periodStartIso, input.periodEndIso);
+  const key = { workspaceId_period: { workspaceId: input.workspaceId, period } };
+  const rowSelect = { workspaceId: true, period: true, invoiceId: true } as const;
 
-  // Idempotency — reuse any non-voided invoice already stored for this period.
-  const existingRows = await prisma.overageInvoice.findMany({
-    where: { workspaceId: input.workspaceId },
-    select: { workspaceId: true, period: true, invoiceId: true },
-  });
-  const existing = matchOverageInvoice(existingRows, input.periodStartIso);
+  // Fast path — reuse a non-voided invoice already stored for this exact period.
+  const existing = await prisma.overageInvoice.findUnique({ where: key, select: rowSelect });
   if (existing) {
-    const info = (await fetchOverageInvoiceInfos([existing])).get(existing.invoiceId);
-    if (info) {
-      return { invoiceId: info.invoiceId, period: existing.period, link: info.link, total: info.total, reused: true };
+    const reused = await reuseStoredInvoice(existing);
+    if (reused) {
+      return reused;
     }
-    // Stored invoice was deleted/voided in Stripe — drop the stale row, create fresh.
-    await prisma.overageInvoice
-      .delete({ where: { workspaceId_period: { workspaceId: existing.workspaceId, period: existing.period } } })
-      .catch(() => undefined);
+    // Stored invoice was deleted/voided in Stripe — drop the stale row, recreate.
+    await prisma.overageInvoice.delete({ where: key }).catch(() => undefined);
   }
 
   if (input.eventsOver <= 0 && input.syncsOver <= 0) {
@@ -253,17 +283,25 @@ export async function createOverageInvoice(input: CreateOverageInvoiceInput): Pr
         period: linePeriod,
       });
     }
+    // Persist. A plain `create` makes the (workspaceId, period) primary key the
+    // atomic guard against concurrent duplicate creation — see the catch below.
+    await prisma.overageInvoice.create({ data: { workspaceId: input.workspaceId, period, invoiceId: invoice.id } });
   } catch (e) {
-    // Roll back the empty draft so a failed run leaves nothing behind.
+    // Roll back our draft so a failed (or lost-the-race) run leaves nothing
+    // behind for a retry to duplicate.
     await stripe.invoices.del(invoice.id).catch(() => undefined);
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      // A concurrent request persisted first — return its invoice, not ours.
+      const winner = await prisma.overageInvoice.findUnique({ where: key, select: rowSelect });
+      if (winner) {
+        const reused = await reuseStoredInvoice(winner);
+        if (reused) {
+          return reused;
+        }
+      }
+    }
     throw e;
   }
-
-  await prisma.overageInvoice.upsert({
-    where: { workspaceId_period: { workspaceId: input.workspaceId, period } },
-    create: { workspaceId: input.workspaceId, period, invoiceId: invoice.id },
-    update: { invoiceId: invoice.id },
-  });
   log.atInfo().log(`Created overage invoice ${invoice.id} for workspace ${input.workspaceId}, period ${period}`);
 
   const finalized = await stripe.invoices.retrieve(invoice.id);

--- a/webapps/ee-api/pages/admin-workspaces.tsx
+++ b/webapps/ee-api/pages/admin-workspaces.tsx
@@ -64,17 +64,22 @@ async function readError(resp: Response): Promise<string> {
   return `HTTP ${resp.status}`;
 }
 
-/** Period start/end and events for the selected variant. */
+/**
+ * Period start/end and events for the selected variant.
+ *
+ * DATE SEMANTICS — intentional, do not "fix": `start`/`end` are a half-open
+ * interval `[start, end)`. `end` is the *exclusive* upper bound — for the
+ * previous period it equals the current period's start (e.g. a period is
+ * `Apr 22 → May 22`, and `May 22` is the first day of the next period). The UI
+ * renders `start` and `end` verbatim and labels them as a `[start, end)` range,
+ * so showing `May 22` as the end is correct. Earlier code subtracted a day here
+ * to display an "inclusive last day" (`May 21`); that was reverted on purpose —
+ * do not re-introduce it.
+ */
 function periodOf(row: AdminWorkspaceRow, variant: PeriodVariant) {
   return variant === "active"
     ? { start: row.periodStart, end: row.periodEnd, events: row.events.period }
-    : {
-        start: row.previousPeriodStart,
-        // previousPeriodEnd is an exclusive bound (= current period start); show
-        // the last day actually included so the range matches the summed totals.
-        end: dayjs.utc(row.previousPeriodEnd).subtract(1, "day").toISOString(),
-        events: row.events.previousPeriod,
-      };
+    : { start: row.previousPeriodStart, end: row.previousPeriodEnd, events: row.events.previousPeriod };
 }
 
 /** Full plan breakdown shown on status hover/click — rendered as a white table. */
@@ -367,10 +372,17 @@ function buildColumns(
       defaultSortOrder: variant === "previous" ? "descend" : undefined,
       render: (_, row) => {
         const period = periodOf(row, variant);
+        // Headline: the month the period starts in (a billing period spans two
+        // calendar months, e.g. Apr 22 → May 22 → "April 2026"). Sub-line: the
+        // explicit `[start, end)` range — `end` is exclusive, see periodOf.
         return (
           <div className="tabular-nums">
-            <div className="text-[15px] font-semibold leading-tight text-neutral-900">{fmtDate(period.end)}</div>
-            <div className="text-xs text-neutral-400">from {fmtDateShort(period.start)}</div>
+            <div className="text-[15px] font-semibold leading-tight text-neutral-900">
+              {dayjs.utc(period.start).format("MMMM YYYY")}
+            </div>
+            <div className="text-xs text-neutral-400">
+              {fmtDateShort(period.start)} → {fmtDate(period.end)}
+            </div>
           </div>
         );
       },

--- a/webapps/ee-api/pages/admin-workspaces.tsx
+++ b/webapps/ee-api/pages/admin-workspaces.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Dropdown, Input, Progress, Segmented, Select, Spin, Table, Tag, Tooltip } from "antd";
+import { Button, Dropdown, Input, Modal, Progress, Segmented, Select, Spin, Table, Tag, Tooltip } from "antd";
 import type { TableColumnsType } from "antd";
-import { MoreOutlined, ReloadOutlined, ThunderboltFilled } from "@ant-design/icons";
+import { CloudDownloadOutlined, MoreOutlined, ReloadOutlined, ThunderboltFilled } from "@ant-design/icons";
 import { useRouter } from "next/router";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -11,6 +11,10 @@ import { AdminLayout } from "../components/AdminLayout";
 import { RequireAdmin } from "../components/RequireAdmin";
 import { useAuth } from "../components/AuthProvider";
 import type { AdminWorkspaceRow, AdminWorkspacesResponse, ChartPoint, WorkspaceStatus } from "../lib/admin-workspaces";
+import type { OverageInvoiceStatus } from "../lib/overage-invoices";
+
+/** `fetch` with the caller's Firebase ID token attached. */
+type AuthFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 /** Which billing period the table is showing. */
 type PeriodVariant = "active" | "previous";
@@ -37,6 +41,15 @@ const STATUS_META: Record<WorkspaceStatus, { label: string; color: string }> = {
   QUOTA_ABOUT_TO_EXCEED: { label: "Quota Warning", color: "orange" },
 };
 const STATUS_ORDER = Object.keys(STATUS_META) as WorkspaceStatus[];
+
+/** Pill styling for an overage invoice's Stripe status. */
+const INVOICE_STATUS_META: Record<OverageInvoiceStatus, { label: string; color: string }> = {
+  draft: { label: "Draft", color: "default" },
+  open: { label: "Open", color: "gold" },
+  paid: { label: "Paid", color: "green" },
+  uncollectible: { label: "Uncollectible", color: "red" },
+  void: { label: "Void", color: "default" },
+};
 
 /** A best-effort error message from a non-OK API response. */
 async function readError(resp: Response): Promise<string> {
@@ -209,7 +222,77 @@ const SummaryStat: React.FC<{ label: string; value: string; accent?: boolean }> 
   </div>
 );
 
-function buildColumns(appBaseUrl: string, variant: PeriodVariant): TableColumnsType<AdminWorkspaceRow> {
+/**
+ * Previous-period overage invoice cell: a status pill linking to the invoice
+ * when one exists, otherwise a Create button that opens a draft Stripe invoice.
+ */
+const OverageInvoiceCell: React.FC<{ row: AdminWorkspaceRow; authFetch: AuthFetch; reload: () => void }> = ({
+  row,
+  authFetch,
+  reload,
+}) => {
+  const [creating, setCreating] = useState(false);
+  const inv = row.overageInvoice;
+  if (inv) {
+    const meta = INVOICE_STATUS_META[inv.status] || { label: inv.status, color: "default" };
+    return (
+      <a href={inv.link} target="_blank" rel="noreferrer" className="inline-flex">
+        <Tooltip title="Open invoice in Stripe">
+          <Tag color={meta.color} bordered={false} className="!m-0 cursor-pointer !rounded-full">
+            <span className="align-middle">{meta.label}</span>
+            <span className="ml-1 align-middle tabular-nums text-neutral-500">{fmtMoney(inv.total)}</span>
+          </Tag>
+        </Tooltip>
+      </a>
+    );
+  }
+  const overage = row.previousOverage;
+  if (!overage || overage.totalFee <= 0 || !row.stripeCustomerId) {
+    return <span className="text-neutral-300">—</span>;
+  }
+  const confirmCreate = () => {
+    Modal.confirm({
+      title: "Create overage invoice?",
+      content: (
+        <span>
+          A draft Stripe invoice for <strong>{fmtMoney(overage.totalFee)}</strong> will be created for{" "}
+          <strong>{row.workspaceName}</strong>, covering {row.previousPeriodKey.replace("_", " → ")}. It is left as a
+          draft — review and finalize it in Stripe to charge the customer.
+        </span>
+      ),
+      okText: "Create draft invoice",
+      onOk: async () => {
+        setCreating(true);
+        try {
+          const resp = await authFetch("/api/admin/create-overage-invoice", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ workspaceId: row.workspaceId, period: row.previousPeriodKey }),
+          });
+          if (!resp.ok) {
+            throw new Error(await readError(resp));
+          }
+          reload();
+        } catch (e: any) {
+          Modal.error({ title: "Failed to create invoice", content: e?.message || "Unknown error" });
+        } finally {
+          setCreating(false);
+        }
+      },
+    });
+  };
+  return (
+    <Button size="small" loading={creating} onClick={confirmCreate}>
+      Create
+    </Button>
+  );
+};
+
+function buildColumns(
+  appBaseUrl: string,
+  variant: PeriodVariant,
+  ctx: { authFetch: AuthFetch; reload: () => void }
+): TableColumnsType<AdminWorkspaceRow> {
   return [
     {
       title: "Workspace",
@@ -391,6 +474,17 @@ function buildColumns(appBaseUrl: string, variant: PeriodVariant): TableColumnsT
             );
           },
         },
+    // Overage invoice for the completed period — status pill or a Create button.
+    ...(variant === "previous"
+      ? ([
+          {
+            title: "Overage Invoice",
+            key: "overageInvoice",
+            width: 160,
+            render: (_, row) => <OverageInvoiceCell row={row} authFetch={ctx.authFetch} reload={ctx.reload} />,
+          },
+        ] as TableColumnsType<AdminWorkspaceRow>)
+      : []),
     {
       title: "Syncs",
       key: "syncs",
@@ -488,6 +582,7 @@ const AdminWorkspaces: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<WorkspaceStatus[]>([]);
+  const [backfilling, setBackfilling] = useState(false);
   // The active/previous toggle is mirrored in the URL so the view survives reloads and can be linked.
   const router = useRouter();
   const variant: PeriodVariant = router.query.period === "previous" ? "previous" : "active";
@@ -520,7 +615,41 @@ const AdminWorkspaces: React.FC = () => {
     load();
   }, [load]);
 
-  const columns = useMemo(() => buildColumns(data?.appBaseUrl || "", variant), [data?.appBaseUrl, variant]);
+  // Backfill `overage_invoices` from Stripe — needed once so existing invoices
+  // show up before any are created from this page.
+  const backfill = useCallback(() => {
+    Modal.confirm({
+      title: "Backfill overage invoices from Stripe?",
+      content:
+        "Scans Stripe invoices from the last 6 months and records every overage invoice in the database. " +
+        "Existing entries are refreshed.",
+      okText: "Backfill",
+      onOk: async () => {
+        setBackfilling(true);
+        try {
+          const resp = await authFetch("/api/admin/backfill-overage-invoices?months=6", { method: "POST" });
+          if (!resp.ok) {
+            throw new Error(await readError(resp));
+          }
+          const result = await resp.json();
+          await load();
+          Modal.success({
+            title: "Backfill complete",
+            content: `Scanned ${result.scanned} invoices, recorded ${result.upserted} overage invoices.`,
+          });
+        } catch (e: any) {
+          Modal.error({ title: "Backfill failed", content: e?.message || "Unknown error" });
+        } finally {
+          setBackfilling(false);
+        }
+      },
+    });
+  }, [authFetch, load]);
+
+  const columns = useMemo(
+    () => buildColumns(data?.appBaseUrl || "", variant, { authFetch, reload: load }),
+    [data?.appBaseUrl, variant, authFetch, load]
+  );
 
   const filtered = useMemo(() => {
     const rows = data?.rows || [];
@@ -604,6 +733,9 @@ const AdminWorkspaces: React.FC = () => {
           {data?.statCacheUpdatedAt && (
             <span className="text-xs text-neutral-400">Event stats through {fmtDateTime(data.statCacheUpdatedAt)}</span>
           )}
+          <Button icon={<CloudDownloadOutlined />} loading={backfilling} onClick={backfill}>
+            Backfill invoices
+          </Button>
           <Button icon={<ReloadOutlined />} onClick={load}>
             Refresh
           </Button>
@@ -651,7 +783,7 @@ const AdminWorkspaces: React.FC = () => {
           size="small"
           columns={columns}
           dataSource={filtered}
-          scroll={{ x: variant === "active" ? 1230 : 1000 }}
+          scroll={{ x: variant === "active" ? 1230 : 1160 }}
           sticky
           pagination={{ pageSize: 500, showSizeChanger: false }}
         />

--- a/webapps/ee-api/pages/api/admin/backfill-overage-invoices.ts
+++ b/webapps/ee-api/pages/api/admin/backfill-overage-invoices.ts
@@ -1,0 +1,21 @@
+import { withFirebaseAdminAuth } from "../../../lib/route-helpers";
+import { backfillOverageInvoices } from "../../../lib/overage-invoices";
+
+/** Paging through several months of Stripe invoices — give it room. */
+export const config = {
+  maxDuration: 180,
+};
+
+/**
+ * Backfill `overage_invoices` from Stripe: scan invoices from the last `months`
+ * (query/body param, default 6, capped at 24) and record every overage invoice.
+ */
+export default withFirebaseAdminAuth(async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+  const raw = req.query.months ?? req.body?.months;
+  const months = Math.min(24, Math.max(1, parseInt(String(raw ?? "6"), 10) || 6));
+  return await backfillOverageInvoices(months);
+});

--- a/webapps/ee-api/pages/api/admin/create-overage-invoice.ts
+++ b/webapps/ee-api/pages/api/admin/create-overage-invoice.ts
@@ -1,0 +1,66 @@
+import { withFirebaseAdminAuth } from "../../../lib/route-helpers";
+import { buildAdminWorkspaces } from "../../../lib/admin-workspaces";
+import { createOverageInvoice, periodKey } from "../../../lib/overage-invoices";
+
+/** Building the overview to recompute overage fans out to Stripe — give it room. */
+export const config = {
+  maxDuration: 180,
+};
+
+/**
+ * Create a draft Stripe overage invoice for a workspace's previous billing
+ * period and record it in `overage_invoices`. The overage is recomputed
+ * server-side from authoritative data — the client only names the workspace and
+ * (optionally) the period it expects, which guards against a stale click.
+ */
+export default withFirebaseAdminAuth(async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+  const workspaceId: unknown = req.body?.workspaceId;
+  if (typeof workspaceId !== "string" || !workspaceId) {
+    res.status(400).json({ error: "workspaceId is required" });
+    return;
+  }
+  const requestedPeriod: unknown = req.body?.period;
+
+  const overview = await buildAdminWorkspaces({ withOverageInvoices: false });
+  const row = overview.rows.find(r => r.workspaceId === workspaceId);
+  if (!row) {
+    res.status(404).json({ error: `Workspace ${workspaceId} not found` });
+    return;
+  }
+  if (!row.paid) {
+    res.status(400).json({ error: "Overage invoices are only created for paid workspaces" });
+    return;
+  }
+  if (!row.stripeCustomerId) {
+    res.status(400).json({ error: "Workspace has no Stripe customer" });
+    return;
+  }
+
+  const expectedPeriod = periodKey(row.previousPeriodStart, row.previousPeriodEnd);
+  if (typeof requestedPeriod === "string" && requestedPeriod && requestedPeriod !== expectedPeriod) {
+    res.status(409).json({ error: `Period ${requestedPeriod} is stale; current previous period is ${expectedPeriod}` });
+    return;
+  }
+
+  const overage = row.previousOverage;
+  if (!overage || overage.totalFee <= 0) {
+    res.status(400).json({ error: "Workspace has no overage for the previous period" });
+    return;
+  }
+
+  return await createOverageInvoice({
+    workspaceId: row.workspaceId,
+    workspaceName: row.workspaceName,
+    stripeCustomerId: row.stripeCustomerId,
+    periodStartIso: row.previousPeriodStart,
+    periodEndIso: row.previousPeriodEnd,
+    eventsOver: overage.eventsOver,
+    eventsFee: overage.eventsFee,
+    syncsOver: overage.syncsOver,
+    syncsFee: overage.syncsFee,
+  });
+});

--- a/webapps/ee-api/prisma/schema.prisma
+++ b/webapps/ee-api/prisma/schema.prisma
@@ -51,6 +51,21 @@ model StatCache {
   @@schema("newjitsuee")
 }
 
+/// Stripe overage invoices created for completed billing periods. One row per
+/// workspace per period; `period` is `YYYY-MM-DD_YYYY-MM-DD` (start inclusive,
+/// end exclusive). Populated from the admin workspaces page (manual create) and
+/// backfilled from Stripe — see lib/overage-invoices.ts.
+model OverageInvoice {
+  workspaceId String   @map("workspace_id")
+  period      String
+  invoiceId   String   @map("invoice_id")
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@id([workspaceId, period], map: "overage_invoices_pk")
+  @@map("overage_invoices")
+  @@schema("newjitsuee")
+}
+
 /// DEAD TABLE — modeled here only so `prisma db push` does not drop it.
 /// It is a hand-managed table that used to feed the `newjitsu.backup_connections`
 /// view. That view has been removed, and S3 backup connections are now built in


### PR DESCRIPTION
Stacked on #1321 — base will retarget to `newjitsu` once that merges.

## Summary

Adds overage-invoice tracking to the **Previous periods** view of
`/admin-workspaces`.

- **New `Overage Invoice` column** (previous-period view only):
  - If an overage invoice exists for the workspace's completed billing
    period, it shows as a **status pill** (`Draft` / `Open` / `Paid` /
    `Uncollectible`) linking to the invoice in Stripe.
  - If not, a **Create** button opens a draft Stripe invoice covering the
    period's event + sync overage.
  - **Voided invoices are ignored** — a voided invoice falls back to the
    Create button.

- **New `overage_invoices` table** (`newjitsuee` schema) — one row per
  workspace per period: `workspace_id`, `period`
  (`YYYY-MM-DD_YYYY-MM-DD`, start inclusive / end exclusive),
  `invoice_id`, `created_at`.

- **Backfill** — a `Backfill invoices` header button (and
  `POST /api/admin/backfill-overage-invoices`) scans the last 6 months of
  Stripe invoices and records every overage invoice it finds.

## Invoice shape

Modelled on the manually-created overage invoices already in Stripe
(`billing_reason: manual`, a one-time per-event line `Overage fee -
events over plan limit, per event`). The created invoice:

- is a **draft** (`auto_advance: false`) — an admin reviews and finalizes
  it in Stripe, which is what charges the customer;
- has a per-event line whose quantity is the overage event count and
  whose unit price is derived from the **final, discounted** fee, so the
  invoice total matches the figure in the Overage column exactly;
- adds a second line for sync overage when a workspace is over its sync
  limit;
- carries `jitsu_overage` / `jitsu_workspace_id` / `jitsu_period`
  metadata.

## Notes

- `period` matching is tolerant (±7 days on the start date) so
  backfilled invoices — whose Stripe line period was entered by hand —
  still line up with the Stripe-derived billing cycle.
- Creating an invoice is idempotent: an existing non-voided invoice for
  the period is returned instead of creating a duplicate.
- The overage-invoice lookup in `buildAdminWorkspaces` is wrapped so any
  failure (Stripe error, or the table not yet existing) just leaves the
  column empty — the page still renders.
- **Deploy step:** `overage_invoices` is a new table — run
  `pnpm --filter ee-api db:update-schema` (`prisma db push`) before/with
  the deploy, then click `Backfill invoices` once.