### PR TITLE
chore(ci): bump ai-review workflow to 1.25.20260522

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,7 +21,7 @@ jobs:
     # causing the review to fail. security-fix.yml dispatches the review manually
     # for bot-opened PRs instead.
     if: github.event_name != 'pull_request' || github.actor != 'jitsu-code-review[bot]'
-    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.10.20260420
+    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.25.20260522
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       AI_CODE_REVIEW_APP_ID: ${{ secrets.AI_CODE_REVIEW_APP_ID }}


### PR DESCRIPTION
Bumps the shared AI review workflow pin from `1.10.20260420` to `1.25.20260522`.

The new version ([jitsucom/github-workflows#9](https://github.com/jitsucom/github-workflows/pull/9)) severity-gates the review verdict:

- `REQUEST_CHANGES` fires **only** for a new, critical issue — a real bug, security hole, data loss, or user-visible regression.
- Non-critical and uncertain findings post as non-blocking `COMMENT` inline comments.

This stops the reviewer from blocking PRs on false positives / low-confidence findings.