### PR TITLE
fix(ee-api): JITSU_APPLICATION_URL accepts a list with wildcards

### DIFF
--- a/webapps/ee-api/README.md
+++ b/webapps/ee-api/README.md
@@ -35,6 +35,7 @@ Auth is fully client-side — there is no session cookie:
 | `JITSU_EE_ADMINS`                           | Comma-separated email patterns that may access the UI. `*` is a wildcard.                                |
 | `EE_API_SERVICE_TOKENS`                     | Comma-separated allow-list of static bearer tokens for trusted server-to-server callers (console's quota check / exports). Accepted by `lib/auth.ts`. |
 | `CRON_SECRET`                               | Bearer token for Vercel-managed cron jobs only — Vercel injects it automatically. Accepted by `lib/auth.ts`. |
+| `JITSU_APPLICATION_URL`                     | Comma-separated origin allow-list. Source for CORS on browser→ee-api calls, and for the canonical app URL used in emails / admin pages (first non-wildcard entry). Scheme defaults to `https`. Wildcards: `*.host.tld` matches any subdomain. Example: `use.jitsu.com,*.jitsu.localhost`. |
 
 `JITSU_EE_ADMINS` example:
 

--- a/webapps/ee-api/lib/admin-workspaces.ts
+++ b/webapps/ee-api/lib/admin-workspaces.ts
@@ -14,6 +14,7 @@ import {
   stripeDataTable,
   stripeLink,
 } from "./stripe";
+import { getAppBaseUrl } from "./app-urls";
 import {
   fetchOverageInvoiceInfos,
   loadOverageInvoiceRows,
@@ -861,7 +862,7 @@ export async function buildAdminWorkspaces(
     rows,
     statCacheUpdatedAt: statCacheUpdatedAt ? statCacheUpdatedAt.toISOString() : null,
     generatedAt: now.toISOString(),
-    appBaseUrl: (process.env.JITSU_APPLICATION_URL || "https://use.jitsu.com").replace(/\/$/, ""),
+    appBaseUrl: getAppBaseUrl(),
     freePlanEventsQuota: FREE_PLAN_EVENTS_QUOTA,
   };
 }

--- a/webapps/ee-api/lib/app-urls.ts
+++ b/webapps/ee-api/lib/app-urls.ts
@@ -1,0 +1,82 @@
+/**
+ * Parser and matcher for `JITSU_APPLICATION_URL`.
+ *
+ * Value is a comma-separated list of origins ee-api is allowed to serve via
+ * CORS, and from which the canonical app URL (used in emails and admin pages)
+ * is taken. Each entry can be:
+ *
+ *   - a literal origin: `use.jitsu.com`, `https://app.example.com`
+ *   - a host wildcard:  `*.jitsu.localhost` matches any subdomain of
+ *     `jitsu.localhost` (one level or more)
+ *
+ * Scheme is `https` when omitted. Trailing path is ignored.
+ *
+ *   JITSU_APPLICATION_URL=use.jitsu.com,*.jitsu.localhost
+ */
+
+export type AllowedOrigin =
+  | { kind: "exact"; protocol: string; host: string }
+  | { kind: "suffix"; protocol: string; suffix: string };
+
+const HTTPS = "https:";
+const schemeRe = /^([a-z][a-z0-9+.-]*):\/\/(.*)$/i;
+
+function splitScheme(entry: string): { protocol: string; rest: string } {
+  const m = schemeRe.exec(entry);
+  if (m) {
+    return { protocol: `${m[1].toLowerCase()}:`, rest: m[2] };
+  }
+  return { protocol: HTTPS, rest: entry };
+}
+
+export function parseAllowedOrigins(env: string | undefined): AllowedOrigin[] {
+  if (!env) return [];
+  const out: AllowedOrigin[] = [];
+  for (const raw of env.split(",")) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const { protocol, rest } = splitScheme(trimmed);
+    const host = rest.replace(/\/.*$/, "").toLowerCase();
+    if (host.startsWith("*.")) {
+      out.push({ kind: "suffix", protocol, suffix: host.slice(2) });
+    } else {
+      out.push({ kind: "exact", protocol, host });
+    }
+  }
+  return out;
+}
+
+export function isOriginAllowed(origin: string | undefined, allowed: AllowedOrigin[]): boolean {
+  if (!origin) return false;
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  const protocol = url.protocol;
+  const host = url.host.toLowerCase();
+  for (const entry of allowed) {
+    if (entry.protocol !== protocol) continue;
+    if (entry.kind === "exact" && entry.host === host) return true;
+    if (entry.kind === "suffix" && (host === entry.suffix || host.endsWith(`.${entry.suffix}`))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Canonical app URL — the first non-wildcard entry from `JITSU_APPLICATION_URL`.
+ * Used to build links in emails and admin pages. Returns a bare origin (no
+ * trailing slash).
+ */
+export function getAppBaseUrl(): string {
+  const env = process.env.JITSU_APPLICATION_URL;
+  for (const entry of parseAllowedOrigins(env)) {
+    if (entry.kind === "exact") {
+      return `${entry.protocol}//${entry.host}`;
+    }
+  }
+  throw new Error(`JITSU_APPLICATION_URL must contain at least one non-wildcard origin (got: ${JSON.stringify(env)})`);
+}

--- a/webapps/ee-api/lib/email.tsx
+++ b/webapps/ee-api/lib/email.tsx
@@ -16,6 +16,7 @@ import ThrottlingStarted from "../emails/throttling-started";
 import BillingIssueEmail from "../emails/billing-issues";
 import ConnectionStatusFailedEmail from "../emails/connection-status-failed";
 import ConnectionStatusSuccessEmail from "../emails/connection-status-success";
+import { getAppBaseUrl } from "./app-urls";
 
 dayjs.extend(utc);
 export const UnsubscribeCodes = z.object({
@@ -278,7 +279,7 @@ export async function getWorkspaceEmailHistory(workspaceId: string): Promise<Ema
   if (!logsEntry) {
     return [];
   }
-  const appUrl = process.env.JITSU_APPLICATION_URL || "https://use.jitsu.com";
+  const appUrl = getAppBaseUrl();
   return sortBy(logsEntry.logs, "timestamp")
     .reverse()
     .map(({ subject, ...rest }) => {

--- a/webapps/ee-api/lib/route-helpers.ts
+++ b/webapps/ee-api/lib/route-helpers.ts
@@ -4,6 +4,7 @@ import { getServerLog } from "./log";
 import { getFirebaseToken, verifyFirebaseToken } from "./firebase-auth";
 import type admin from "firebase-admin";
 import { isAdminEmail } from "./admins";
+import { isOriginAllowed, parseAllowedOrigins } from "./app-urls";
 
 const log = getServerLog("api-error");
 const authLog = getServerLog("admin-auth");
@@ -32,46 +33,21 @@ export function withErrorHandler(handler: NextApiHandler): NextApiHandler {
 }
 
 /**
- * Allow-list for `withBrowserApi` endpoints: in production, only the configured
- * console origin (`JITSU_APPLICATION_URL`, the same var emails and admin
- * workspaces use to link back to console); in non-production, any
- * `*.jitsu.localhost` host (the portless dev convention — branches vary at
- * runtime so we don't know the exact origin ahead of time).
- *
- * Credentials aren't sent (auth is via `x-fb-auth` header, not cookies), but
- * reflecting any Origin still lets attacker-controlled pages READ responses
- * for someone who holds a Firebase ID token — so the check is real.
- */
-function isAllowedOrigin(origin: string | undefined): boolean {
-  if (!origin) return false;
-  const configured = process.env.JITSU_APPLICATION_URL;
-  if (configured) {
-    try {
-      if (new URL(origin).origin === new URL(configured).origin) return true;
-    } catch {
-      // ignore malformed origin
-    }
-  }
-  if (process.env.NODE_ENV !== "production") {
-    try {
-      const host = new URL(origin).hostname;
-      if (host === "jitsu.localhost" || host.endsWith(".jitsu.localhost")) return true;
-    } catch {
-      // ignore malformed origin
-    }
-  }
-  return false;
-}
-
-/**
  * CORS for ee-api endpoints the console browser app calls directly. The request
  * carries a Firebase ID token in `x-fb-auth` (not cookies). Returns `true` if
  * the request was a preflight that has now been answered — the caller should
  * stop.
+ *
+ * Allowed origins come from `JITSU_APPLICATION_URL` (comma-separated list,
+ * `*.host` wildcards supported). Credentials aren't sent (auth is via header,
+ * not cookies), but reflecting any Origin would still let attacker-controlled
+ * pages READ responses for someone holding a Firebase ID token — so the check
+ * is real.
  */
 export function applyCors(req: NextApiRequest, res: NextApiResponse): boolean {
   const origin = Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin;
-  if (isAllowedOrigin(origin)) {
+  const allowed = parseAllowedOrigins(process.env.JITSU_APPLICATION_URL);
+  if (isOriginAllowed(origin, allowed)) {
     res.setHeader("Access-Control-Allow-Origin", origin as string);
     res.setHeader("Vary", "Origin");
   }


### PR DESCRIPTION
## Summary

Origin allow-list for browser→ee-api CORS now reads a **comma-separated list** from `JITSU_APPLICATION_URL`. Each entry can be:

- a literal origin: `use.jitsu.com`, `https://app.example.com`
- a host wildcard: `*.jitsu.localhost` (matches any subdomain)

Scheme defaults to `https` when omitted. The canonical app URL used in emails and admin pages (`getAppBaseUrl()`) is the **first non-wildcard entry**.

### Why

Two motivating issues:

1. **Single-value limit.** `withBrowserApi` previously matched exactly one origin from `JITSU_APPLICATION_URL`. With this PR you can configure prod + local dev in one env var: `JITSU_APPLICATION_URL=use.jitsu.com,*.jitsu.localhost`.
2. **No more `NODE_ENV` gates, no more hardcoded hosts.** The previous code special-cased `*.jitsu.localhost` *only when* `process.env.NODE_ENV !== "production"` — which is always `production` on Vercel and in our k8s deploys, so the localhost branch never fired anywhere it mattered. Wildcards are now driven by config, the same in every environment.

### Changes

- `webapps/ee-api/lib/app-urls.ts` (new) — `parseAllowedOrigins`, `isOriginAllowed`, `getAppBaseUrl`.
- `webapps/ee-api/lib/route-helpers.ts` — `applyCors` uses the new helpers; removed `isAllowedOrigin` and its NODE_ENV branch.
- `webapps/ee-api/lib/email.tsx`, `lib/admin-workspaces.ts` — drop the `|| "https://use.jitsu.com"` fallback, call `getAppBaseUrl()` (throws loudly if the env is missing).
- `README.md` — document `JITSU_APPLICATION_URL`.

### Follow-up

After merge: update `JITSU_APPLICATION_URL` on the `new-jitsu-ee-api` Vercel project to `https://use.jitsu.com,*.jitsu.localhost` so local dev can hit prod ee-api.

## Test plan

- [ ] `pnpm --filter @jitsu-ee/ee-api typecheck` (passes locally)
- [ ] Preview deploy: curl `OPTIONS https://<preview>/api/billing/settings` with `Origin: https://use.jitsu.com` returns `Access-Control-Allow-Origin: https://use.jitsu.com`
- [ ] Same with `Origin: https://console-foo.jitsu.localhost` returns the matching ACAO header
- [ ] Same with `Origin: https://evil.com` returns NO `Access-Control-Allow-Origin`
- [ ] Billing page loads at `https://use.jitsu.com/<workspace>/settings/billing`