### PR TITLE
fix(firebase): emit TRACE STREAM_STATUS for every stream

### DIFF
--- a/bulker/connectors/airbytecdk/protocol.go
+++ b/bulker/connectors/airbytecdk/protocol.go
@@ -24,10 +24,34 @@ const (
 	msgTypeRecord         msgType = "RECORD"
 	msgTypeState          msgType = "STATE"
 	msgTypeLog            msgType = "LOG"
+	msgTypeTrace          msgType = "TRACE"
 	msgTypeConnectionStat msgType = "CONNECTION_STATUS"
 	msgTypeCatalog        msgType = "CATALOG"
 	msgTypeSpec           msgType = "SPEC"
 )
+
+type StreamStatusType string
+
+const (
+	StreamStatusStarted    StreamStatusType = "STARTED"
+	StreamStatusComplete   StreamStatusType = "COMPLETE"
+	StreamStatusIncomplete StreamStatusType = "INCOMPLETE"
+)
+
+type streamDescriptor struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type streamStatus struct {
+	StreamDescriptor streamDescriptor `json:"stream_descriptor"`
+	Status           StreamStatusType `json:"status"`
+}
+
+type traceMessage struct {
+	Type         string        `json:"type"`
+	StreamStatus *streamStatus `json:"stream_status,omitempty"`
+}
 
 var errInvalidTypePayload = errors.New("message type and payload are invalid")
 
@@ -36,6 +60,7 @@ type message struct {
 	*record                 `json:"record,omitempty"`
 	*state                  `json:"state,omitempty"`
 	*logMessage             `json:"log,omitempty"`
+	*traceMessage           `json:"trace,omitempty"`
 	*ConnectorSpecification `json:"spec,omitempty"`
 	*connectionStatus       `json:"connectionStatus,omitempty"`
 	*Catalog                `json:"catalog,omitempty"`
@@ -255,6 +280,9 @@ type StateWriter func(v interface{}) error
 // RecordWriter is exported for documentation purposes - only use this through MessageTracker
 type RecordWriter func(v interface{}, streamName string, namespace string) error
 
+// StreamStatusWriter emits a TRACE message with STREAM_STATUS type
+type StreamStatusWriter func(streamName string, namespace string, status StreamStatusType) error
+
 func newLogWriter(w io.Writer) LogWriter {
 	return func(lvl LogLevel, s string) error {
 		return write(w, &message{
@@ -287,6 +315,24 @@ func newRecordWriter(w io.Writer) RecordWriter {
 				Data:      s,
 				Namespace: namespace,
 				Stream:    stream,
+			},
+		})
+	}
+}
+
+func newStreamStatusWriter(w io.Writer) StreamStatusWriter {
+	return func(streamName string, namespace string, status StreamStatusType) error {
+		return write(w, &message{
+			Type: msgTypeTrace,
+			traceMessage: &traceMessage{
+				Type: "STREAM_STATUS",
+				StreamStatus: &streamStatus{
+					StreamDescriptor: streamDescriptor{
+						Name:      streamName,
+						Namespace: namespace,
+					},
+					Status: status,
+				},
 			},
 		})
 	}

--- a/bulker/connectors/airbytecdk/sourceRunner.go
+++ b/bulker/connectors/airbytecdk/sourceRunner.go
@@ -17,9 +17,10 @@ type SourceRunner struct {
 func NewSourceRunner(src Source, w io.Writer) SourceRunner {
 	w = newSafeWriter(w)
 	msgTracker := MessageTracker{
-		Record: newRecordWriter(w),
-		State:  newStateWriter(w),
-		Log:    newLogWriter(w),
+		Record:       newRecordWriter(w),
+		State:        newStateWriter(w),
+		Log:          newLogWriter(w),
+		StreamStatus: newStreamStatusWriter(w),
 	}
 
 	return SourceRunner{

--- a/bulker/connectors/airbytecdk/trackers.go
+++ b/bulker/connectors/airbytecdk/trackers.go
@@ -9,6 +9,8 @@ type MessageTracker struct {
 	Record RecordWriter
 	// Log logs out to airbyte
 	Log LogWriter
+	// StreamStatus emits TRACE STREAM_STATUS messages (STARTED, COMPLETE, INCOMPLETE)
+	StreamStatus StreamStatusWriter
 }
 
 // LogTracker is a single struct which holds a tracker which can be used for logs

--- a/bulker/connectors/firebase/firebase.go
+++ b/bulker/connectors/firebase/firebase.go
@@ -224,16 +224,20 @@ func (f FirebaseSource) Read(sourceCfgPath string, prevStatePath string, configu
 	}
 
 	for _, stream := range configuredCat.Streams {
+		if err := tracker.StreamStatus(stream.Stream.Name, stream.Stream.Namespace, airbyte.StreamStatusStarted); err != nil {
+			return err
+		}
 		if stream.Stream.Namespace == "auth" && stream.Stream.Name == "users" {
 			err = loadUsers(ctx, stream.Stream, authClient, tracker)
-			if err != nil {
-				return err
-			}
 		} else {
 			err = loadCollection(ctx, stream.Stream, firestoreClient, tracker)
-			if err != nil {
-				return err
-			}
+		}
+		if err != nil {
+			_ = tracker.StreamStatus(stream.Stream.Name, stream.Stream.Namespace, airbyte.StreamStatusIncomplete)
+			return err
+		}
+		if err := tracker.StreamStatus(stream.Stream.Name, stream.Stream.Namespace, airbyte.StreamStatusComplete); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add TRACE `STREAM_STATUS` message support to the airbyte CDK (`STARTED`, `COMPLETE`, `INCOMPLETE`)
- Firebase connector now emits stream status around each stream in the `Read` loop
- Empty collections now properly report `STARTED` → `COMPLETE` instead of producing no output at all, so the sidecar can track stream lifecycle

## Test plan
- [ ] Run firebase source sync against a project with an empty Firestore collection — verify sidecar sees STARTED + COMPLETE for that stream
- [ ] Run firebase source sync against a project with data — verify records still flow and streams report STARTED + COMPLETE
- [ ] Verify a stream that errors mid-read emits STARTED + INCOMPLETE

🤖 Generated with [Claude Code](https://claude.com/claude-code)