### PR TITLE
chore(ai-review): bump shared workflow to 1.26.20260527

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,7 +21,7 @@ jobs:
     # causing the review to fail. security-fix.yml dispatches the review manually
     # for bot-opened PRs instead.
     if: github.event_name != 'pull_request' || github.actor != 'jitsu-code-review[bot]'
-    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.25.20260522
+    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.26.20260527
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       AI_CODE_REVIEW_APP_ID: ${{ secrets.AI_CODE_REVIEW_APP_ID }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,11 @@ The default development branch is `newjitsu`.
 
 **Branch naming:** Use a type prefix — `feat/`, `fix/`, `chore/`. Example: `feat/workspace-oidc`.
 
-**Merging policy:** We avoid merge commits. Always rebase onto the default branch —
-never merge the default branch into a branch. For PRs, merge with full history preserved
-— no squash merge. It's fine to squash overly granular commits within a branch locally
-before opening a PR.
+**Merging policy:** When working on a feature branch, never merge the default branch into
+it — always rebase your branch onto the latest default branch. When merging a PR into the
+default branch, either "Create a merge commit" (the default) or "Rebase and merge" is fine.
+Squash merge stays off; if you want to squash overly granular commits, do it locally before
+opening the PR.
 
 **Commit style:** [Conventional commits](https://www.conventionalcommits.org/) —
 `type(scope): description`. Common types: `fix`, `feat`, `chore`, `refactor`, `ci`.
@@ -130,9 +131,3 @@ Builds are triggered automatically by [lint.yml](.github/workflows/lint.yml) aft
 pass on `newjitsu` or the stable branches. On a successful beta or stable release, a
 GitHub release is created and the infra repo is notified via webhook to update deployment
 configs.
-
-
-
-
-
-  


### PR DESCRIPTION
Picks up [`jitsucom/github-workflows@1.26.20260527`](https://github.com/jitsucom/github-workflows/releases/tag/1.26.20260527).

The shared `ai-review.yml` no longer posts `REQUEST_CHANGES` — the AI reviewer now only posts `COMMENT` (with inline findings) or `APPROVE`. Merge gating moves to GitHub's "require conversation resolution before merging" branch protection.