### PR TITLE
fix: missing docker compose up command in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ git clone --depth 1 https://github.com/jitsucom/jitsu
 cd jitsu/docker
 # Optionally, edit .env.local file and set env variables, see README.md in `docker` folder
 touch .env.local
-#
-
+docker compose up --force-recreate
 ```
 
 ### Deploy at scale


### PR DESCRIPTION
## Summary
The Docker Compose quick start in README.md was missing the actual `docker compose up` command. After cloning the repo, cd-ing into the docker folder, and touching `.env.local`, the code block ended with a stray `#` comment and a blank line — leaving users with no command to actually start Jitsu.

## How to reproduce
1. Open README.md and find the "Docker Compose" section under "Install Jitsu"
2. Follow the commands in the bash block — the last line is `#` with nothing after it
3. No command is given to start the services

## Test plan
- Confirm the code block now ends with `docker compose up --force-recreate`
- Matches the command documented in `docker/README.md`