### PR TITLE
feat(console): proxy ee-api calls through the console server

### DIFF
--- a/webapps/console/lib/eeApi.ts
+++ b/webapps/console/lib/eeApi.ts
@@ -1,9 +1,6 @@
 import { useCallback } from "react";
-import { getLog, rpc } from "juava";
+import { rpc } from "juava";
 import { useAppConfig } from "./context";
-import { getFirebaseIdToken } from "./firebase-client";
-
-const log = getLog("eeApi");
 
 export type EeApiOptions = {
   method?: string;
@@ -12,17 +9,14 @@ export type EeApiOptions = {
 };
 
 /**
- * Thrown when a browser-side call to ee-api can't be authenticated because the
- * user has no Firebase session. Distinct from a network/HTTP error so callers
- * can render an actionable message (sign in / contact admin) instead of a
- * generic 500.
+ * Kept for backward compatibility — the proxy handles authentication
+ * server-side via the console session, so this is no longer thrown from
+ * the request path. It remains exported in case any caller still does
+ * `instanceof EeApiNotAuthenticatedError`.
  */
 export class EeApiNotAuthenticatedError extends Error {
   constructor() {
-    super(
-      "Not authenticated against ee-api: no Firebase ID token. " +
-        "Browser→ee-api calls (billing pages, S3 init, etc.) require a Firebase session."
-    );
+    super("Not authenticated against ee-api.");
     this.name = "EeApiNotAuthenticatedError";
   }
 }
@@ -31,70 +25,47 @@ export type EeApi = {
   /** True when an ee-api host is configured (i.e. this is an EE deployment). */
   available: boolean;
   /**
-   * Call an ee-api endpoint directly from the browser. The request carries the
-   * signed-in user's Firebase ID token in the `x-fb-auth` header; ee-api
-   * verifies it and decides admin status and workspace access on its own —
-   * there is no console-side proxy or minted token. `path` is relative to
-   * ee-api's `/api/`, e.g. `eeRpc("billing/settings", { query: { workspaceId } })`.
-   *
-   * Throws `EeApiNotAuthenticatedError` if no Firebase ID token is available —
-   * see the module-level note about the Cloud-only scope.
+   * Call an ee-api endpoint via the console's own server-side proxy at
+   * `/api/ee/<path>`. The console authenticates the user from the session
+   * cookie and forwards the Firebase credential to billing-server; the
+   * browser does NOT carry the billing-server URL or a billing token.
+   * `path` is relative to ee-api's `/api/`, e.g. `eeRpc("billing/settings", { query: { workspaceId } })`.
    */
   eeRpc: <T = any>(path: string, opts?: EeApiOptions) => Promise<T>;
 };
 
 /**
- * Browser client for ee-api.
+ * Browser client for ee-api, routed through the console's server-side proxy
+ * (`pages/api/ee/[...path].ts`). The browser issues a same-origin request to
+ * `/api/ee/<path>`; the console authenticates the user from its session,
+ * forwards the request to billing-server, and returns the JSON response.
  *
- * **Scope: Jitsu Cloud only.** ee-api hosts enterprise/billing features that
- * only run in our hosted product, and Cloud authenticates users exclusively
- * through Firebase (Google sign-in / Firebase email-password). The browser
- * sends its Firebase ID token in `x-fb-auth`; ee-api verifies it server-side.
- *
- * Self-hosted deployments that use NextAuth/OIDC/credentials login are kept
- * out of this path at the source: `pages/api/app-config.ts` returns
- * `ee.available = false` whenever Firebase isn't enabled, even if
- * `EE_CONNECTION` is set. Callers that check `appConfig.ee.available` (S3
- * init, billing UI, EE-flavored UI hints) therefore skip cleanly in those
- * deployments. Reaching `eeRpc()` without a Firebase session on a Cloud
- * deployment is a programming error (e.g. forgot to render a Firebase login
- * gate) and throws `EeApiNotAuthenticatedError` so the failure surfaces in
- * logs instead of as a generic 500 from a stripped-token request.
- *
- * If a future use case needs ee-api access from a non-Firebase deployment,
- * the right move is a server-side proxy on console that authenticates with
- * `EE_API_SERVICE_TOKEN` — never client-side direct calls.
+ * **Scope: Jitsu Cloud only.** Billing-server's user routes verify identity
+ * from the forwarded Firebase token. Deployments without Firebase login set
+ * `appConfig.ee.available = false`, so callers (S3 init, billing UI, EE-flavored
+ * UI hints) skip cleanly. The proxy itself also refuses non-Firebase callers
+ * with 401.
  */
 export function useEeApi(): EeApi {
   const appConfig = useAppConfig();
-  const host = appConfig.ee?.host;
+  const available = !!appConfig.ee?.available;
   const eeRpc = useCallback(
     async <T = any>(path: string, opts?: EeApiOptions): Promise<T> => {
-      if (!host) {
+      if (!available) {
         // Self-hosted / non-EE deployment. Callers should check `available`
         // first; reaching here means they didn't.
         throw new Error(`ee-api is not configured (EE_CONNECTION unset). Path: ${path}`);
       }
-      const idToken = await getFirebaseIdToken();
-      if (!idToken) {
-        log
-          .atWarn()
-          .log(
-            `eeRpc(${path}) called without a Firebase session — this only works on Jitsu Cloud ` +
-              `where Firebase login is mandatory. See lib/eeApi.ts.`
-          );
-        throw new EeApiNotAuthenticatedError();
-      }
-      return rpc(`${host}api/${path.replace(/^\/+/, "")}`, {
+      const cleanPath = path.replace(/^\/+/, "");
+      return rpc(`/api/ee/${cleanPath}`, {
         method: opts?.method,
         query: opts?.query,
         body: opts?.body,
-        headers: { "x-fb-auth": idToken },
       });
     },
-    [host]
+    [available]
   );
-  return { available: !!host, eeRpc };
+  return { available, eeRpc };
 }
 
 /**

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -86,7 +86,6 @@ export const AppConfig = z.object({
   customDomainsEnabled: z.boolean().optional(),
   ee: z.object({
     available: z.boolean(),
-    host: z.string().optional(),
   }),
   billingEnabled: z.boolean(),
   publicEndpoints: z.object({

--- a/webapps/console/pages/api/app-config.ts
+++ b/webapps/console/pages/api/app-config.ts
@@ -1,7 +1,7 @@
 import { createRoute } from "../../lib/api";
 import { AppConfig } from "../../lib/schema";
 import { getAppEndpoint } from "../../lib/domains";
-import { getEeConnection, isEEAvailable } from "../../lib/server/ee";
+import { isEEAvailable } from "../../lib/server/ee";
 import { isFirebaseEnabled, requireFirebaseOptions } from "../../lib/server/firebase-server";
 import { nangoConfig } from "../../lib/server/oauth/nango-config";
 import { readOnlyUntil } from "../../lib/server/read-only-mode";
@@ -45,20 +45,22 @@ export default createRoute()
       dynamicOidc: serverEnv.DYNAMIC_OIDC_ENABLED,
     };
     // `appConfig.ee.available` advertises ee-api to the browser. Browser→ee-api
-    // calls authenticate with a Firebase ID token (`x-fb-auth`) — see
-    // `lib/eeApi.ts`. A deployment that has `EE_CONNECTION` set but Firebase
-    // disabled (self-hosted EE with NextAuth/OIDC) cannot serve those calls,
-    // so we advertise `available = false` there. Callers that check this flag
-    // (S3 init, billing UI, EE-flavored UI hints) skip cleanly. Server-side
-    // code keeps using `isEEAvailable()` directly + the service token for
-    // its own console→ee-api calls; that path doesn't go through app-config.
+    // calls now go through the console-side proxy at `/api/ee/<path>` (see
+    // `lib/eeApi.ts` and `pages/api/ee/[...path].ts`) — the browser never talks
+    // to billing-server directly and no billing-server URL is exposed in
+    // app-config. The proxy authenticates by forwarding the user's Firebase
+    // session, so a deployment that has `EE_CONNECTION` set but Firebase
+    // disabled (self-hosted EE with NextAuth/OIDC) still gets `available = false`
+    // — callers (S3 init, billing UI, EE-flavored UI hints) skip cleanly.
+    // Server-side code keeps using `isEEAvailable()` directly + the service
+    // token for its own console→ee-api calls; that path doesn't go through
+    // this app-config.
     const eeBrowserAvailable = isEEAvailable() && isFirebaseEnabled();
     return {
       docsUrl: serverEnv.JITSU_DOCUMENTATION_URL || "https://docs.jitsu.com/",
       readOnlyUntil: readOnlyUntil?.toISOString(),
       ee: {
         available: eeBrowserAvailable,
-        host: eeBrowserAvailable ? getEeConnection().host : undefined,
       },
       disableSignup: isSignupDisabled(),
       auth,

--- a/webapps/console/pages/api/ee/[...path].ts
+++ b/webapps/console/pages/api/ee/[...path].ts
@@ -1,12 +1,13 @@
+import type { NextApiRequest } from "next";
 import { createRoute } from "../../../lib/api";
 import { z } from "zod";
-import { rpc } from "juava";
-import { eeAuthHeaders, getEeConnection, isEEAvailable } from "../../../lib/server/ee";
+import { firebaseAuthCookieName } from "../../../lib/server/firebase-server";
+import { getEeConnection, isEEAvailable } from "../../../lib/server/ee";
 import { ApiError } from "../../../lib/shared/errors";
 
 // Catch-all server-side proxy: browser → /api/ee/<path> → billing-server.
-// Forwards the request method, query, and body, and forwards the user's
-// Firebase session as `x-fb-auth` so billing-server authenticates the call.
+// Forwards the request method, query, and body; attaches the user's Firebase
+// credential as `x-fb-auth` so billing-server authenticates the call.
 // The browser no longer needs to know the billing-server URL or carry a
 // billing-server token.
 
@@ -16,6 +17,22 @@ const querySchema = z
   })
   .passthrough();
 
+// getFirebaseUser accepts the credential from either the `jitsu-auth` cookie or
+// an `Authorization: Bearer <idToken>` header (lib/server/firebase-server.ts);
+// both yield `authType === "firebase"`. Look in both places so the proxy works
+// for browser-cookie callers AND programmatic Bearer callers.
+function extractFirebaseToken(req: NextApiRequest): string | undefined {
+  const cookieToken = req.cookies[firebaseAuthCookieName];
+  if (cookieToken) {
+    return cookieToken;
+  }
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.toLowerCase().startsWith("bearer ")) {
+    return authHeader.substring("bearer ".length);
+  }
+  return undefined;
+}
+
 async function forward({ user, req, body, query }: any) {
   if (!isEEAvailable()) {
     throw new ApiError("EE is not available", {}, { status: 503 });
@@ -23,23 +40,69 @@ async function forward({ user, req, body, query }: any) {
   if (user.authType !== "firebase") {
     // ee-api user routes verify identity from the forwarded Firebase token.
     // The proxy intentionally refuses other auth types so we never reach
-    // billing-server with the admin service token in place of a real user —
-    // see lib/server/ee.ts for the same reasoning in eeAuthHeadersOrServiceToken.
+    // billing-server with the admin service token in place of a real user.
     throw new ApiError("ee-api proxy is only available for Firebase-authenticated users", {}, { status: 401 });
   }
+  const firebaseToken = extractFirebaseToken(req);
+  if (!firebaseToken) {
+    // 401 (not 500) when the Firebase user was authenticated via a header that
+    // isn't reachable here — keeps clients honest about retrying with credentials.
+    throw new ApiError("Missing Firebase credentials for ee-api proxy", {}, { status: 401 });
+  }
+
   const { host } = getEeConnection();
-  const target = (query.path as string[]).join("/");
-  // Strip the catch-all segments out of the forwarded query string.
   const { path: _drop, ...forwardQuery } = query as Record<string, unknown>;
-  return await rpc(`${host}api/${target}`, {
-    method: req.method,
-    query: forwardQuery,
-    body,
+  const targetUrl = new URL(`${host}api/${(query.path as string[]).join("/")}`);
+  for (const [k, v] of Object.entries(forwardQuery)) {
+    if (v === undefined || v === null) {
+      continue;
+    }
+    if (Array.isArray(v)) {
+      v.forEach(item => targetUrl.searchParams.append(k, String(item)));
+    } else {
+      targetUrl.searchParams.set(k, String(v));
+    }
+  }
+
+  const method = (req.method || "GET").toUpperCase();
+  const init: RequestInit = {
+    method,
     headers: {
       "Content-Type": "application/json",
-      ...eeAuthHeaders(req),
+      "x-fb-auth": firebaseToken,
     },
-  });
+  };
+  if (method !== "GET" && method !== "HEAD" && body !== undefined) {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+
+  // Use `fetch` directly (instead of `juava.rpc`) so we can map billing-server's
+  // status code into the response. `rpc` raises `ApiResponseError` whose shape
+  // doesn't match the framework's `isApiError` check, which would surface every
+  // upstream 4xx as a generic 500 with a stack trace.
+  const response = await fetch(targetUrl, init);
+  const text = await response.text();
+  const isJson = (response.headers.get("content-type") ?? "").includes("application/json");
+  let parsed: any;
+  if (isJson && text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  } else {
+    parsed = text;
+  }
+
+  if (!response.ok) {
+    const message =
+      (isJson && parsed && typeof parsed === "object" && (parsed.message || parsed.error)) ||
+      `ee-api returned ${response.status}`;
+    const responseObject = isJson && parsed && typeof parsed === "object" ? parsed : { upstreamBody: parsed };
+    throw new ApiError(message, responseObject, { status: response.status });
+  }
+
+  return parsed;
 }
 
 export default createRoute()

--- a/webapps/console/pages/api/ee/[...path].ts
+++ b/webapps/console/pages/api/ee/[...path].ts
@@ -1,0 +1,50 @@
+import { createRoute } from "../../../lib/api";
+import { z } from "zod";
+import { rpc } from "juava";
+import { eeAuthHeaders, getEeConnection, isEEAvailable } from "../../../lib/server/ee";
+import { ApiError } from "../../../lib/shared/errors";
+
+// Catch-all server-side proxy: browser → /api/ee/<path> → billing-server.
+// Forwards the request method, query, and body, and forwards the user's
+// Firebase session as `x-fb-auth` so billing-server authenticates the call.
+// The browser no longer needs to know the billing-server URL or carry a
+// billing-server token.
+
+const querySchema = z
+  .object({
+    path: z.array(z.string()),
+  })
+  .passthrough();
+
+async function forward({ user, req, body, query }: any) {
+  if (!isEEAvailable()) {
+    throw new ApiError("EE is not available", {}, { status: 503 });
+  }
+  if (user.authType !== "firebase") {
+    // ee-api user routes verify identity from the forwarded Firebase token.
+    // The proxy intentionally refuses other auth types so we never reach
+    // billing-server with the admin service token in place of a real user —
+    // see lib/server/ee.ts for the same reasoning in eeAuthHeadersOrServiceToken.
+    throw new ApiError("ee-api proxy is only available for Firebase-authenticated users", {}, { status: 401 });
+  }
+  const { host } = getEeConnection();
+  const target = (query.path as string[]).join("/");
+  // Strip the catch-all segments out of the forwarded query string.
+  const { path: _drop, ...forwardQuery } = query as Record<string, unknown>;
+  return await rpc(`${host}api/${target}`, {
+    method: req.method,
+    query: forwardQuery,
+    body,
+    headers: {
+      "Content-Type": "application/json",
+      ...eeAuthHeaders(req),
+    },
+  });
+}
+
+export default createRoute()
+  .GET({ auth: true, query: querySchema })
+  .handler(forward)
+  .POST({ auth: true, query: querySchema, body: z.any() })
+  .handler(forward)
+  .toNextApiHandler();

--- a/webapps/console/pages/api/ee/[...path].ts
+++ b/webapps/console/pages/api/ee/[...path].ts
@@ -1,8 +1,6 @@
-import type { NextApiRequest } from "next";
 import { createRoute } from "../../../lib/api";
 import { z } from "zod";
-import { firebaseAuthCookieName } from "../../../lib/server/firebase-server";
-import { getEeConnection, isEEAvailable } from "../../../lib/server/ee";
+import { eeAuthHeaders, getEeConnection, isEEAvailable } from "../../../lib/server/ee";
 import { ApiError } from "../../../lib/shared/errors";
 
 // Catch-all server-side proxy: browser → /api/ee/<path> → billing-server.
@@ -10,28 +8,20 @@ import { ApiError } from "../../../lib/shared/errors";
 // credential as `x-fb-auth` so billing-server authenticates the call.
 // The browser no longer needs to know the billing-server URL or carry a
 // billing-server token.
+//
+// Auth note: `getUser()` (lib/api.ts) routes `Authorization: Bearer …` to the
+// API-key path (`keyId:secret`) and would reject a raw Firebase ID token before
+// it ever reaches this handler. So in the current console, `authType === "firebase"`
+// implies the `jitsu-auth` cookie is set. The try/catch around `eeAuthHeaders`
+// is defensive — if the cookie ever ends up missing we want a clean 401 instead
+// of a 500 from `requireDefined`. Supporting Bearer Firebase ID tokens is a
+// separate change to `getUser` and is out of scope here.
 
 const querySchema = z
   .object({
     path: z.array(z.string()),
   })
   .passthrough();
-
-// getFirebaseUser accepts the credential from either the `jitsu-auth` cookie or
-// an `Authorization: Bearer <idToken>` header (lib/server/firebase-server.ts);
-// both yield `authType === "firebase"`. Look in both places so the proxy works
-// for browser-cookie callers AND programmatic Bearer callers.
-function extractFirebaseToken(req: NextApiRequest): string | undefined {
-  const cookieToken = req.cookies[firebaseAuthCookieName];
-  if (cookieToken) {
-    return cookieToken;
-  }
-  const authHeader = req.headers.authorization;
-  if (authHeader && authHeader.toLowerCase().startsWith("bearer ")) {
-    return authHeader.substring("bearer ".length);
-  }
-  return undefined;
-}
 
 async function forward({ user, req, body, query }: any) {
   if (!isEEAvailable()) {
@@ -43,10 +33,10 @@ async function forward({ user, req, body, query }: any) {
     // billing-server with the admin service token in place of a real user.
     throw new ApiError("ee-api proxy is only available for Firebase-authenticated users", {}, { status: 401 });
   }
-  const firebaseToken = extractFirebaseToken(req);
-  if (!firebaseToken) {
-    // 401 (not 500) when the Firebase user was authenticated via a header that
-    // isn't reachable here — keeps clients honest about retrying with credentials.
+  let fbHeaders: Record<string, string>;
+  try {
+    fbHeaders = eeAuthHeaders(req);
+  } catch {
     throw new ApiError("Missing Firebase credentials for ee-api proxy", {}, { status: 401 });
   }
 
@@ -69,7 +59,7 @@ async function forward({ user, req, body, query }: any) {
     method,
     headers: {
       "Content-Type": "application/json",
-      "x-fb-auth": firebaseToken,
+      ...fbHeaders,
     },
   };
   if (method !== "GET" && method !== "HEAD" && body !== undefined) {

--- a/webapps/console/pages/api/ee/[...path].ts
+++ b/webapps/console/pages/api/ee/[...path].ts
@@ -42,7 +42,17 @@ async function forward({ user, req, body, query }: any) {
 
   const { host } = getEeConnection();
   const { path: _drop, ...forwardQuery } = query as Record<string, unknown>;
-  const targetUrl = new URL(`${host}api/${(query.path as string[]).join("/")}`);
+  // Reject dot-segments and embedded slashes before constructing the URL —
+  // otherwise `..` (or its URL-encoded form `%2e%2e`, which Next.js has already
+  // decoded into the catch-all segments) could let the request escape the
+  // `/api/` prefix and hit unrelated billing-server paths.
+  const segments = query.path as string[];
+  for (const seg of segments) {
+    if (!seg || seg === "." || seg === ".." || seg.includes("/") || seg.includes("\\")) {
+      throw new ApiError("Invalid path segment", { segment: seg }, { status: 400 });
+    }
+  }
+  const targetUrl = new URL(`${host}api/${segments.join("/")}`);
   for (const [k, v] of Object.entries(forwardQuery)) {
     if (v === undefined || v === null) {
       continue;


### PR DESCRIPTION
## Summary
The browser previously called billing-server (`EE_CONNECTION`) directly with a Firebase ID token in `x-fb-auth`. This PR routes those calls through a same-origin proxy on the console:

```
browser  →  GET/POST /api/ee/<path>  →  console server  →  ${EE_CONNECTION}api/<path>
```

## Changes
- **`pages/api/ee/[...path].ts`** (new) — catch-all proxy. Forwards method / query / body to billing-server; attaches the user's Firebase session as `x-fb-auth` via the existing `eeAuthHeaders(req)`. Refuses non-Firebase callers with 401 so we never substitute the admin service token for a real user on billing-server's user routes (cf. the same reasoning in `eeAuthHeadersOrServiceToken`).
- **`lib/eeApi.ts`** — `eeRpc()` now calls `/api/ee/<path>`. The browser no longer fetches a Firebase ID token to attach (`getFirebaseIdToken`), and doesn't carry the billing-server URL.
- **`pages/api/app-config.ts`** + **`lib/schema/index.ts`** — drop `ee.host` from the public app config; nothing in the client reads it anymore.

## Auth design
- The console session carries the Firebase token in the `jitsu-auth` cookie (set on the console domain). The proxy reads it server-side and forwards as `x-fb-auth` to billing-server, which authenticates and resolves admin/workspace access the same way it does today.
- The proxy is **Firebase-only**: `appConfig.ee.available` already requires Firebase to be enabled, and the proxy enforces `user.authType === "firebase"` defensively. This preserves the prior behavior and avoids the admin-impersonation risk that would come from falling back to the service token (which runs as `system@jitsu.com`) for a user-driven call.
- No changes required in billing-server (`jitsu-cloud-billing`) — its Firebase authenticator already accepts `x-fb-auth`.

## Test plan
- [ ] Open billing pages on a Cloud (Firebase) deployment → `/api/ee/billing/settings`, `/api/ee/billing/plans`, `/api/ee/s3-init` succeed; billing-server logs show the user identity (not admin).
- [ ] `useEeRedirect` flows (billing portal / upgrade) still navigate to the returned Stripe URL.
- [ ] Hitting `/api/ee/billing/settings` while unauthenticated → 401.
- [ ] On a NextAuth/OIDC deployment, `appConfig.ee.available` is `false`, billing UI is hidden, and direct `/api/ee/...` returns 401.
- [ ] `appConfig.ee.host` no longer appears in the browser's `/api/app-config` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)