### PR TITLE
fix(console): allow unknown fields on StreamConfig

### DIFF
--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -166,15 +166,20 @@ export function inferTokenTypeFromId(id: string): string {
 }
 
 export const StreamConfig = ConfigEntityBase.merge(
-  z.object({
-    domains: z.array(z.string()).optional(),
-    authorizedJavaScriptDomains: z.string().optional(),
-    publicKeys: z.array(ApiKey).optional(),
-    privateKeys: z.array(ApiKey).optional(),
-    strict: z.boolean().optional(),
-    shard: z.number().optional(),
-    deduplicateWindowMs: z.number().optional(),
-  })
+  z
+    .object({
+      domains: z.array(z.string()).optional(),
+      authorizedJavaScriptDomains: z.string().optional(),
+      publicKeys: z.array(ApiKey).optional(),
+      privateKeys: z.array(ApiKey).optional(),
+      strict: z.boolean().optional(),
+      shard: z.number().optional(),
+      deduplicateWindowMs: z.number().optional(),
+    })
+    // Tolerate legacy/unknown fields on older stream records (matches DestinationConfig).
+    // Without this, zodToJsonSchema emits `additionalProperties: false` and the editor's
+    // live validation rejects old streams with "must NOT have additional properties".
+    .passthrough()
 );
 export type StreamConfig = z.infer<typeof StreamConfig>;
 


### PR DESCRIPTION
## Problem

Editing an older stream in the console shows a red **"must NOT have additional properties"** error with `Save` disabled — even without touching anything.

The stream editor live-validates the loaded object against a JSON schema derived from the `StreamConfig` zod schema. Because `StreamConfig` is a plain merged zod object (default "strip" mode), `zodToJsonSchema` emits `additionalProperties: false`, and RJSF/AJV rejects any legacy field that older stream records still carry.

`DestinationConfig` right below already uses `.passthrough()`, which is why destinations don't hit this.

## Fix

Add `.passthrough()` to `StreamConfig`, matching `DestinationConfig`. This makes the generated JSON schema allow unknown properties, so old streams load and save cleanly. Fixes every affected stream at once rather than cleaning records one by one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)