### PR TITLE
perf(bulker) snowflake: sort dedup CTAS by timestamp

### DIFF
--- a/bulker/bulkerlib/implementations/sql/snowflake.go
+++ b/bulker/bulkerlib/implementations/sql/snowflake.go
@@ -45,7 +45,7 @@ const (
 	// stages 2 and 3 read a much smaller, pre-deduped relation. Each stage
 	// emits its own WarehouseState so timing for dedup/update/insert is
 	// visible in the run report.
-	sfDedupStatement       = `CREATE OR REPLACE TEMPORARY TABLE {{.NamespaceFrom}}{{.DedupTable}} AS SELECT {{.Columns}} FROM (SELECT {{.Columns}}, ROW_NUMBER() OVER (PARTITION BY {{.PrimaryKeyColumns}}{{.Discriminator}}) rn FROM {{.NamespaceFrom}}{{.TableFrom}}) QUALIFY rn = MAX(rn) OVER (PARTITION BY {{.PrimaryKeyColumns}})`
+	sfDedupStatement       = `CREATE OR REPLACE TEMPORARY TABLE {{.NamespaceFrom}}{{.DedupTable}} AS SELECT {{.Columns}} FROM (SELECT {{.Columns}}, ROW_NUMBER() OVER (PARTITION BY {{.PrimaryKeyColumns}}{{.Discriminator}}) rn FROM {{.NamespaceFrom}}{{.TableFrom}}) QUALIFY rn = MAX(rn) OVER (PARTITION BY {{.PrimaryKeyColumns}}){{if .DedupOrderBy}} ORDER BY {{.DedupOrderBy}}{{end}}`
 	sfMergeUpdateStatement = `UPDATE {{.Namespace}}{{.TableTo}} T SET {{.UpdateSet}} FROM {{.NamespaceFrom}}{{.DedupTable}} S WHERE {{.JoinConditions}}`
 	sfMergeInsertStatement = `INSERT INTO {{.Namespace}}{{.TableTo}} ({{.Columns}}) SELECT {{.SourceColumns}} FROM {{.NamespaceFrom}}{{.DedupTable}} S WHERE NOT EXISTS (SELECT 1 FROM {{.Namespace}}{{.TableTo}} T WHERE {{.JoinConditions}})`
 	sfDropDedupStatement   = `DROP TABLE IF EXISTS {{.NamespaceFrom}}{{.DedupTable}}`
@@ -562,12 +562,25 @@ func (s *Snowflake) copyOrMergeSplit(ctx context.Context, targetTable *Table, so
 	})
 	pkColumns := utils.ArrayMap(targetTable.GetPKFields(), s.quotedColumnName)
 
+	// Pre-sort the dedup CTAS by the target's timestamp column so the
+	// later INSERT writes new T micro-partitions whose TO_DATE(ts) min/max
+	// are tight along T's CLUSTER BY (TO_DATE(timestamp)) key. This
+	// minimises the work auto-clustering has to do to re-partition new
+	// data. UPDATE rewrites preserve clustering on their own, so this is
+	// strictly an INSERT-side optimisation; no benefit (and no harm)
+	// when there is no timestamp column.
+	var dedupOrderBy string
+	if targetTable.TimestampColumn != "" {
+		dedupOrderBy = s.quotedColumnName(targetTable.TimestampColumn)
+	}
+
 	payload := QueryPayload{
 		Namespace:         s.namespacePrefix(targetTable.Namespace),
 		NamespaceFrom:     s.namespacePrefix(sourceTable.Namespace),
 		TableTo:           s.quotedTableName(targetTable.Name),
 		TableFrom:         s.quotedTableName(sourceTable.Name),
 		DedupTable:        s.quotedTableName(sourceTable.Name + "_DEDUP"),
+		DedupOrderBy:      dedupOrderBy,
 		Columns:           strings.Join(columnNames, ","),
 		PrimaryKeyName:    targetTable.PrimaryKeyName,
 		PrimaryKeyColumns: strings.Join(pkColumns, ","),

--- a/bulker/bulkerlib/implementations/sql/sql_adapter_base.go
+++ b/bulker/bulkerlib/implementations/sql/sql_adapter_base.go
@@ -428,6 +428,7 @@ type QueryPayload struct {
 	TableTo        string
 	TableFrom      string
 	DedupTable     string
+	DedupOrderBy   string
 	JoinConditions string
 	SourceColumns  string
 }


### PR DESCRIPTION
Follow-up to #1346. Asked whether the dedup TEMPORARY table is already presorted by timestamp — it isn't (QUALIFY emits rows in window-function-output order, roughly PK-grouped) — and whether presorting would help. It does, but only for INSERT's write path.

## Summary

Add an optional \`ORDER BY {timestamp_col}\` clause to the dedup CTAS template (gated on a new \`QueryPayload.DedupOrderBy\` field; set in \`copyOrMergeSplit\` only when \`targetTable.TimestampColumn != \"\"\`).

## Why

Target tables created by bulker use \`CLUSTER BY (TO_DATE(timestamp))\` (\`sfAlterClusteringKeyTemplate\`). When the INSERT stage writes new rows into T, Snowflake creates new micro-partitions whose \`TO_DATE(ts)\` min/max are determined by the input row order:

- **Without sort** (status quo): dedup output is roughly PK-grouped, so within a single new micro-partition rows span the full date range of the batch. Auto-clustering then has to repartition that data to restore the cluster key — billable warehouse work.
- **With sort**: dedup rows hit storage in timestamp order, so new T micro-partitions have tight \`TO_DATE(ts)\` ranges along the cluster key from the start. Auto-clustering has almost nothing to do.

UPDATE is unaffected — rewriting a micro-partition preserves T's existing clustering layout regardless of source row order. The join itself is unaffected — hash-join doesn't care about input order on either side.

Cost: O(N log N) sort on the already-deduped row set during the CTAS. Sub-second for typical batch sizes; trivial compared to even one auto-clustering pass on T.

## Test plan

- [ ] Build green (\`go build ./bulkerlib/...\` in \`bulker/\`) — done locally.
- [ ] Run a Snowflake sync on an INSERT-heavy table and observe the auto-clustering credits used by the target table over the next few hours — should drop vs. the pre-PR baseline.
- [ ] Run a sync where the target has no timestamp column — \`DedupOrderBy\` stays empty, dedup template renders unchanged.
- [ ] Compare \`dedup\` stage time before/after — small bump expected (sort cost), should be sub-second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)