### PR TITLE
Bulker: support multi-partition retry topics

### DIFF
--- a/bulker/bulkerapp/app/abstract_batch_consumer.go
+++ b/bulker/bulkerapp/app/abstract_batch_consumer.go
@@ -273,10 +273,18 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 		var err error
 		for i := 0; i < 10; i++ {
 			ass, err = consumer.Assignment()
-			if err != nil || len(ass) != 1 {
-				time.Sleep(time.Second * time.Duration(i+1))
-			} else {
+			if err == nil && len(ass) == 1 {
 				break
+			}
+			// rebalance events are served only during poll calls:
+			// poll the consumer so it can join the group and obtain its assignment
+			message, _ := consumer.ReadMessage(time.Second * time.Duration(i+1))
+			if message != nil {
+				// a message slipped through before batch processing started - rollback the position
+				_, seekErr := consumer.SeekPartitions([]kafka.TopicPartition{message.TopicPartition})
+				if seekErr != nil {
+					bc.SystemErrorf("Failed to seek back a message received while waiting for assignment: %v", seekErr)
+				}
 			}
 		}
 		if err != nil || len(ass) != 1 {

--- a/bulker/bulkerapp/app/abstract_batch_consumer.go
+++ b/bulker/bulkerapp/app/abstract_batch_consumer.go
@@ -273,20 +273,13 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 		var err error
 		for i := 0; i < 10; i++ {
 			ass, err = consumer.Assignment()
-			if err == nil && len(ass) > 0 {
-				break
+			if err != nil || len(ass) != 1 {
+				time.Sleep(time.Second * time.Duration(i+1))
 			}
-			time.Sleep(time.Second * time.Duration(i+1))
 		}
-		if err != nil || len(ass) == 0 {
+		if err != nil || len(ass) != 1 {
 			bc.errorMetric("assignment_error")
 			return BatchCounters{}, bc.NewError("Failed to get consumer assignment (%d): %v", len(ass), err)
-		}
-		if len(ass) > 1 {
-			// topic may have more partitions than shards count or rebalancing may be in progress.
-			// report error and continue: it is safe because batch commits offsets of a single partition only - see RetryConsumer.processBatchImpl
-			bc.errorMetric("assignment_error")
-			bc.SystemErrorf("Consumer assignment has %d partitions. Expected exactly 1. Continuing with partition: %d", len(ass), ass[0].Partition)
 		}
 		partition = ass[0].Partition
 		bc.Infof("Assigned partition: %d", partition)

--- a/bulker/bulkerapp/app/abstract_batch_consumer.go
+++ b/bulker/bulkerapp/app/abstract_batch_consumer.go
@@ -275,6 +275,8 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 			ass, err = consumer.Assignment()
 			if err != nil || len(ass) != 1 {
 				time.Sleep(time.Second * time.Duration(i+1))
+			} else {
+				break
 			}
 		}
 		if err != nil || len(ass) != 1 {

--- a/bulker/bulkerapp/app/abstract_batch_consumer.go
+++ b/bulker/bulkerapp/app/abstract_batch_consumer.go
@@ -37,6 +37,7 @@ type BatchConsumer interface {
 	BatchPeriodSec() int
 	UpdateBatchPeriod(batchPeriodSec int)
 	Options() *bulker.StreamOptions
+	Mode() string
 }
 
 type AbstractBatchConsumer struct {
@@ -272,13 +273,20 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 		var err error
 		for i := 0; i < 10; i++ {
 			ass, err = consumer.Assignment()
-			if err != nil || len(ass) != 1 {
-				time.Sleep(time.Second * time.Duration(i+1))
+			if err == nil && len(ass) > 0 {
+				break
 			}
+			time.Sleep(time.Second * time.Duration(i+1))
 		}
-		if err != nil || len(ass) != 1 {
+		if err != nil || len(ass) == 0 {
 			bc.errorMetric("assignment_error")
 			return BatchCounters{}, bc.NewError("Failed to get consumer assignment (%d): %v", len(ass), err)
+		}
+		if len(ass) > 1 {
+			// topic may have more partitions than shards count or rebalancing may be in progress.
+			// report error and continue: it is safe because batch commits offsets of a single partition only - see RetryConsumer.processBatchImpl
+			bc.errorMetric("assignment_error")
+			bc.SystemErrorf("Consumer assignment has %d partitions. Expected exactly 1. Continuing with partition: %d", len(ass), ass[0].Partition)
 		}
 		partition = ass[0].Partition
 		bc.Infof("Assigned partition: %d", partition)
@@ -610,6 +618,10 @@ func (bc *AbstractBatchConsumer) Retire() {
 }
 func (bc *AbstractBatchConsumer) errorMetric(errorType string) {
 	metrics.ConsumerErrors(bc.topicId, bc.mode, bc.destinationId, bc.tableName, errorType).Inc()
+}
+
+func (bc *AbstractBatchConsumer) Mode() string {
+	return bc.mode
 }
 
 func (bc *AbstractBatchConsumer) Options() *bulker.StreamOptions {

--- a/bulker/bulkerapp/app/abstract_batch_consumer.go
+++ b/bulker/bulkerapp/app/abstract_batch_consumer.go
@@ -267,7 +267,7 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 		return BatchCounters{}, bc.NewError("Failed to resume kafka consumer: %v", err)
 	}
 	var partition int32 = 0
-	if bc.mode == "retry" && bc.topicId == bc.config.KafkaDestinationsRetryTopicName {
+	if bc.mode == "retry" {
 		var ass []kafka.TopicPartition
 		var err error
 		for i := 0; i < 10; i++ {
@@ -485,9 +485,9 @@ func (bc *AbstractBatchConsumer) initConsumer(force bool) (consumer *kafka.Consu
 			bc.Errorf("Failed to subscribe to topic: %v", err)
 			return nil, err
 		}
-		if bc.mode == "retry" && bc.topicId == bc.config.KafkaDestinationsRetryTopicName {
-			consumer.Assign([]kafka.TopicPartition{kafka.TopicPartition{Topic: &bc.topicId, Offset: kafka.OffsetStored, Partition: int32(bc.config.InstanceIndex)}})
-		}
+		//if bc.mode == "retry" && bc.topicId == bc.config.KafkaDestinationsRetryTopicName {
+		//	consumer.Assign([]kafka.TopicPartition{kafka.TopicPartition{Topic: &bc.topicId, Offset: kafka.OffsetStored, Partition: int32(bc.config.InstanceIndex)}})
+		//}
 		bc.Infof("Consumer created: %s", consumer.String())
 		bc.consumer.Store(consumer)
 	}

--- a/bulker/bulkerapp/app/cron.go
+++ b/bulker/bulkerapp/app/cron.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"math/rand/v2"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -29,7 +30,10 @@ func (c *Cron) AddBatchConsumer(destinationId string, batchConsumer BatchConsume
 		var delay uint32
 		spreadTablesSchedule := bulker.SpreadTablesSchedule.Get(batchConsumer.Options())
 		// spread start time to avoid all batch run at the same time
-		if spreadTablesSchedule {
+		if batchConsumer.Mode() == "retry" {
+			// random delay
+			delay = rand.Uint32N(uint32(batchPeriodSec))
+		} else if spreadTablesSchedule {
 			// all topics(topics) for the same destination will spread across the batch period
 			delay = utils.HashStringInt(batchConsumer.TopicId()) % uint32(batchPeriodSec)
 		} else {

--- a/bulker/bulkerapp/app/retry_consumer.go
+++ b/bulker/bulkerapp/app/retry_consumer.go
@@ -3,13 +3,14 @@ package app
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	bulker "github.com/jitsucom/bulker/bulkerlib"
 	"github.com/jitsucom/bulker/jitsubase/utils"
 	"github.com/jitsucom/bulker/kafkabase"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type RetryConsumer struct {

--- a/bulker/bulkerapp/app/retry_consumer.go
+++ b/bulker/bulkerapp/app/retry_consumer.go
@@ -140,6 +140,19 @@ func (rc *RetryConsumer) processBatchImpl(_ *Destination, _, _, _, retryBatchSiz
 			}
 			return counters, state, false, rc.NewError("Failed to consume event from topic. Retryable: %t: %v", kafkaErr.IsRetriable(), kafkaErr)
 		}
+		if firstPosition != nil && message.TopicPartition.Partition != firstPosition.Partition {
+			// partition assignment may change in the middle of consumption (rebalance)
+			// all messages in the batch must belong to a single partition to commit their offsets atomically.
+			// seek the foreign message back so it is re-read later and commit what was already consumed
+			rc.Infof("Got message from partition %d while consuming partition %d. Stopping batch", message.TopicPartition.Partition, firstPosition.Partition)
+			_, seekErr := rc.consumer.Load().SeekPartitions([]kafka.TopicPartition{message.TopicPartition})
+			if seekErr != nil {
+				rc.SystemErrorf("Failed to seek back message from partition %d: %v", message.TopicPartition.Partition, seekErr)
+			}
+			// end the run: highOffset of the current run belongs to another partition. next run will query correct offsets
+			nextBatch = false
+			break
+		}
 		counters.consumed++
 		lastPosition = &message.TopicPartition
 		if counters.consumed == 1 {

--- a/bulker/bulkerapp/app/topic_manager.go
+++ b/bulker/bulkerapp/app/topic_manager.go
@@ -215,27 +215,9 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 			tm.destinationTopics[destinationId] = dstTopics
 		}
 		if !dstTopics.Contains(topic) {
-			hash := utils.HashStringInt(topic)
-			shardsCount := uint64(tm.config.ShardsCount)
-			consumersCount := uint64(1)
-			if mode == retryTopicMode {
-				partitionsCount := uint64(max(len(topicMetadata.Partitions), 1))
-				if partitionsCount > shardsCount {
-					metrics.ConsumerErrors(topic, mode, destinationId, tableName, "invalid_partitions_count").Inc()
-					tm.SystemErrorf("Topic %s has %d partitions - more than shards count: %d. Some partitions may not be consumed", topic, partitionsCount, shardsCount)
-					continue
-				}
-				// retry consumers support multi-partition topics: start a consumer on a separate shard for each partition
-				consumersCount = min(partitionsCount, shardsCount)
-			}
-			startConsumer := false
-			if tm.enableConsumers {
-				for i := uint64(0); i < consumersCount; i++ {
-					if (uint64(hash)+i)%shardsCount == uint64(tm.shardNumber) {
-						startConsumer = true
-						break
-					}
-				}
+			startConsumer, invalidPartitionsCount := tm.startConsumerOnThisShard(topic, mode, destinationId, tableName, len(topicMetadata.Partitions))
+			if invalidPartitionsCount {
+				continue
 			}
 			if startConsumer {
 				tm.Debugf("Found topic %s for destination %s and table %s", topic, destinationId, tableName)
@@ -393,7 +375,8 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 		tm.SystemErrorf("Failed to create destination retry topic [%s]: %v", destinationsRetryTopicName, err)
 	}
 	if tm.enableConsumers {
-		if _, dstRetryCnsmrStarted := tm.retryConsumers[destinationsRetryTopicName]; !dstRetryCnsmrStarted {
+		startRetryConsumer, _ := tm.startConsumerOnThisShard(destinationsRetryTopicName, retryTopicMode, "", "", len(metadata.Topics[destinationsRetryTopicName].Partitions))
+		if _, dstRetryCnsmrStarted := tm.retryConsumers[destinationsRetryTopicName]; !dstRetryCnsmrStarted && startRetryConsumer {
 			retryPeriodSec := tm.config.BatchRunnerRetryPeriodSec
 			retryConsumer, err := NewRetryConsumer(nil, "", retryPeriodSec, destinationsRetryTopicName, tm.config, tm.kafkaConfig, tm.batchProducer, tm)
 			if err != nil {
@@ -423,6 +406,33 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 	tm.Debugf("[topic-manager] Refreshed metadata in %v", time.Since(start))
 	tm.ready = true
 	tm.updatedAt = time.Now()
+}
+
+// startConsumerOnThisShard checks that the topic partitions count is compatible with the shards count
+// and returns true when a consumer for the topic must be started on the current instance's shard.
+// retry consumers support multi-partition topics: a consumer is started on a separate shard for each partition.
+// for other modes a single consumer is started on the shard selected by the topic name hash
+func (tm *TopicManager) startConsumerOnThisShard(topic, mode, destinationId, tableName string, partitions int) (startConsumer, invalidPartitionsCount bool) {
+	partitionsCount := uint64(1)
+	shardsCount := uint64(tm.config.ShardsCount)
+	if mode == retryTopicMode {
+		partitionsCount = uint64(max(partitions, 1))
+		if partitionsCount > shardsCount {
+			metrics.ConsumerErrors(topic, mode, destinationId, tableName, "invalid_partitions_count").Inc()
+			tm.SystemErrorf("Topic %s has %d partitions - more than shards count: %d. Some partitions may not be consumed", topic, partitionsCount, shardsCount)
+			return false, true
+		}
+	}
+	if !tm.enableConsumers {
+		return false, false
+	}
+	hash := uint64(utils.HashStringInt(topic))
+	for i := uint64(0); i < partitionsCount; i++ {
+		if (hash+i)%shardsCount == uint64(tm.shardNumber) {
+			return true, false
+		}
+	}
+	return false, false
 }
 
 func ExcludeConsumerForTopic[T Consumer](consumers []T, topicId string, cron *Cron) []T {

--- a/bulker/bulkerapp/app/topic_manager.go
+++ b/bulker/bulkerapp/app/topic_manager.go
@@ -216,8 +216,21 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 		}
 		if !dstTopics.Contains(topic) {
 			hash := utils.HashStringInt(topic)
-			topicShardNum := hash % uint32(tm.config.ShardsCount)
-			startConsumer := tm.enableConsumers && int(topicShardNum) == tm.shardNumber
+			shardsCount := uint64(tm.config.ShardsCount)
+			consumersCount := uint64(1)
+			if mode == retryTopicMode {
+				// retry consumers support multi-partition topics: start a consumer on a separate shard for each partition
+				consumersCount = min(uint64(max(len(topicMetadata.Partitions), 1)), shardsCount)
+			}
+			startConsumer := false
+			if tm.enableConsumers {
+				for i := uint64(0); i < consumersCount; i++ {
+					if (uint64(hash)+i)%shardsCount == uint64(tm.shardNumber) {
+						startConsumer = true
+						break
+					}
+				}
+			}
 			if startConsumer {
 				tm.Debugf("Found topic %s for destination %s and table %s", topic, destinationId, tableName)
 				destination := tm.repository.GetDestination(destinationId)
@@ -266,15 +279,7 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 					}
 				case retryTopicMode:
 					retryPeriodSec := utils.Nvl(int(bulker.RetryFrequencyOption.Get(destination.streamOptions)*60), tm.config.BatchRunnerRetryPeriodSec)
-					var err error
-					if len(topicMetadata.Partitions) > 1 {
-						metrics.ConsumerErrors(topic, mode, destinationId, tableName, "invalid_partitions_count").Inc()
-						err = fmt.Errorf("Topic has more than 1 partition. Retry Consumer supports only topics with a single partition")
-					}
-					var retryConsumer *RetryConsumer
-					if err == nil {
-						retryConsumer, err = NewRetryConsumer(tm.repository, destinationId, retryPeriodSec, topic, tm.config, tm.kafkaConfig, tm.batchProducer, tm)
-					}
+					retryConsumer, err := NewRetryConsumer(tm.repository, destinationId, retryPeriodSec, topic, tm.config, tm.kafkaConfig, tm.batchProducer, tm)
 					if err != nil {
 						topicsErrorsByMode[mode]++
 						tm.Errorf("Failed to create retry consumer for destination topic: %s: %v", topic, err)

--- a/bulker/bulkerapp/app/topic_manager.go
+++ b/bulker/bulkerapp/app/topic_manager.go
@@ -223,6 +223,7 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 				if partitionsCount > shardsCount {
 					metrics.ConsumerErrors(topic, mode, destinationId, tableName, "invalid_partitions_count").Inc()
 					tm.SystemErrorf("Topic %s has %d partitions - more than shards count: %d. Some partitions may not be consumed", topic, partitionsCount, shardsCount)
+					continue
 				}
 				// retry consumers support multi-partition topics: start a consumer on a separate shard for each partition
 				consumersCount = min(partitionsCount, shardsCount)

--- a/bulker/bulkerapp/app/topic_manager.go
+++ b/bulker/bulkerapp/app/topic_manager.go
@@ -219,8 +219,13 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 			shardsCount := uint64(tm.config.ShardsCount)
 			consumersCount := uint64(1)
 			if mode == retryTopicMode {
+				partitionsCount := uint64(max(len(topicMetadata.Partitions), 1))
+				if partitionsCount > shardsCount {
+					metrics.ConsumerErrors(topic, mode, destinationId, tableName, "invalid_partitions_count").Inc()
+					tm.SystemErrorf("Topic %s has %d partitions - more than shards count: %d. Some partitions may not be consumed", topic, partitionsCount, shardsCount)
+				}
 				// retry consumers support multi-partition topics: start a consumer on a separate shard for each partition
-				consumersCount = min(uint64(max(len(topicMetadata.Partitions), 1)), shardsCount)
+				consumersCount = min(partitionsCount, shardsCount)
 			}
 			startConsumer := false
 			if tm.enableConsumers {


### PR DESCRIPTION
## Summary

Allows retry topics (both per-destination and the shared `destination-messages-retry`) to have multiple partitions, consumed in parallel by multiple bulker instances.

- **topic_manager**: for a retry topic with N partitions, a retry consumer is started on N consecutive shards: `(hash+i) % shardsCount` for `i in 0..N-1` (capped at `shardsCount`). Single-partition topics map to exactly the same shard as before, so existing topic→shard placement is unchanged. The arithmetic is done in uint64 to avoid a uint32 overflow corner case that could map two partitions to the same shard for non-power-of-2 shard counts. The "retry topic must have a single partition" restriction is removed (batch topics keep it).
- **abstract_batch_consumer**: every retry consumer now discovers its partition from the consumer group assignment. The manual `Assign(partition = INSTANCE_INDEX)` previously used for the shared retry topic is removed — partition distribution is handled by group rebalancing for all retry topics uniformly.
- **retry_consumer**: handle a rebalance happening mid-batch. A batch must contain messages of a single partition (defined by the batch's first message) for its offsets to be committed atomically, so when a message from a different partition arrives, it is seeked back for later re-reading, the already-consumed messages are committed, and the run ends — the next run queries watermark/committed offsets for whatever partition the consumer owns by then.

## Notes / known degraded modes

- A consumer must own exactly 1 partition to consume (`len(assignment) != 1` → `assignment_error`). Transient multi-assignment (peer instance down/suspended past session timeout) or zero-assignment (more group members than partitions) skips the run with an error until the group stabilizes; offsets are committed transactionally, so no loss — retries are just delayed.
- Partition count of a retry topic should not exceed `SHARDS_COUNT`.

## Test plan

- [x] `go build ./app/` passes
- [x] Shard fan-out simulated for shards∈{1,2,3,12,16} × partitions∈{0,1,3,5,16,20} incl. wraparound and uint32-overflow hashes: every partition gets exactly one shard, single-partition placement identical to current behavior
- [ ] Deploy to staging: create a 3-partition per-destination retry topic, verify 3 instances each consume one partition and messages drain after rebalances

🤖 Generated with [Claude Code](https://claude.com/claude-code)