### PR TITLE
feat(console): add AUTH_COOKIE_DOMAIN to scope the Firebase auth cookie

### DIFF
--- a/webapps/console/lib/server/firebase-server.ts
+++ b/webapps/console/lib/server/firebase-server.ts
@@ -6,6 +6,7 @@ import * as JSON5 from "json5";
 import { getErrorMessage, getSingleton, requireDefined, Singleton } from "juava";
 import { getServerLog } from "./log";
 import { getServerEnv } from "./serverEnv";
+import { getRequestHost } from "./origin";
 
 export type FirebaseOptions = {
   admin: any;
@@ -67,6 +68,16 @@ export function firebase(): admin.app.App {
 }
 
 export const firebaseAuthCookieName = "jitsu-auth";
+
+/**
+ * Domain for the Firebase auth cookie. Defaults to the request host (host-only
+ * scope). When AUTH_COOKIE_DOMAIN is set (e.g. "jitsu.com"), the cookie is shared
+ * across that domain's subdomains so sibling apps (e.g. a marketing site) can read
+ * the logged-in session. The set and clear paths must use the same value.
+ */
+export function getAuthCookieDomain(req: NextApiRequest): string {
+  return getServerEnv().AUTH_COOKIE_DOMAIN || getRequestHost(req).split(":")[0];
+}
 
 export type FirebaseToken = { idToken: string; cookieToken?: never } | { idToken?: never; cookieToken: string };
 

--- a/webapps/console/lib/server/firebase-server.ts
+++ b/webapps/console/lib/server/firebase-server.ts
@@ -6,7 +6,6 @@ import * as JSON5 from "json5";
 import { getErrorMessage, getSingleton, requireDefined, Singleton } from "juava";
 import { getServerLog } from "./log";
 import { getServerEnv } from "./serverEnv";
-import { getRequestHost } from "./origin";
 
 export type FirebaseOptions = {
   admin: any;
@@ -70,13 +69,15 @@ export function firebase(): admin.app.App {
 export const firebaseAuthCookieName = "jitsu-auth";
 
 /**
- * Domain for the Firebase auth cookie. Defaults to the request host (host-only
- * scope). When AUTH_COOKIE_DOMAIN is set (e.g. "jitsu.com"), the cookie is shared
- * across that domain's subdomains so sibling apps (e.g. a marketing site) can read
- * the logged-in session. The set and clear paths must use the same value.
+ * Domain for the Firebase auth cookie, or undefined for a host-only cookie.
+ * Host-only is the default — to get it the `Domain` attribute must be omitted
+ * entirely, so callers should only set `domain` when this returns a value. When
+ * AUTH_COOKIE_DOMAIN is set (e.g. "jitsu.com"), the cookie is shared across that
+ * domain's subdomains so sibling apps (e.g. a marketing site) can read the
+ * logged-in session. The set and clear paths must use the same value.
  */
-export function getAuthCookieDomain(req: NextApiRequest): string {
-  return getServerEnv().AUTH_COOKIE_DOMAIN || getRequestHost(req).split(":")[0];
+export function getAuthCookieDomain(): string | undefined {
+  return getServerEnv().AUTH_COOKIE_DOMAIN || undefined;
 }
 
 export type FirebaseToken = { idToken: string; cookieToken?: never } | { idToken?: never; cookieToken: string };

--- a/webapps/console/lib/server/serverEnv.ts
+++ b/webapps/console/lib/server/serverEnv.ts
@@ -350,6 +350,12 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   // CORS allowed origins pattern
   ALLOWED_API_ORIGINS: z.string().optional(),
 
+  // Domain set on the Firebase auth cookie. By default the cookie is scoped to the
+  // request host (e.g. "use.jitsu.com"). Set this to a parent domain (e.g.
+  // "jitsu.com") to share the session across sibling subdomains — for example so a
+  // marketing site can read the logged-in user. Leave unset for host-only scope.
+  AUTH_COOKIE_DOMAIN: z.string().optional(),
+
   // Comma-separated list of data domains
   DATA_DOMAIN: z.string().optional(),
 

--- a/webapps/console/lib/server/serverEnv.ts
+++ b/webapps/console/lib/server/serverEnv.ts
@@ -350,12 +350,6 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   // CORS allowed origins pattern
   ALLOWED_API_ORIGINS: z.string().optional(),
 
-  // Domain set on the Firebase auth cookie. By default the cookie is scoped to the
-  // request host (e.g. "use.jitsu.com"). Set this to a parent domain (e.g.
-  // "jitsu.com") to share the session across sibling subdomains — for example so a
-  // marketing site can read the logged-in user. Leave unset for host-only scope.
-  AUTH_COOKIE_DOMAIN: z.string().optional(),
-
   // Comma-separated list of data domains
   DATA_DOMAIN: z.string().optional(),
 

--- a/webapps/console/pages/api/fb-auth/create-session.ts
+++ b/webapps/console/pages/api/fb-auth/create-session.ts
@@ -4,12 +4,12 @@ import {
   createSessionCookie,
   firebase,
   firebaseAuthCookieName,
+  getAuthCookieDomain,
   isUnverifiedPasswordAccount,
 } from "../../../lib/server/firebase-server";
 import { ApiError } from "../../../lib/shared/errors";
 import { SerializeOptions, serialize } from "cookie";
 import { getAppEndpoint } from "../../../lib/domains";
-import { getRequestHost } from "../../../lib/server/origin";
 import { getServerLog } from "../../../lib/server/log";
 import { getLog } from "juava";
 
@@ -47,8 +47,9 @@ export const api: Api = {
       // calls only at the actual sign-in moment. This endpoint is hit on
       // every cookie mint / refresh — too noisy to audit here.
 
-      //we need to split() since the domain might contain a port, not good for cookies
-      const domain = getRequestHost(req).split(":")[0];
+      // Host-only by default; AUTH_COOKIE_DOMAIN can widen it to a parent domain
+      // so sibling subdomains share the session.
+      const domain = getAuthCookieDomain(req);
       getLog().atDebug().log(`Setting firebase auth cookie for '${domain}': ${cookie}`);
       const options: SerializeOptions = {
         maxAge: expiresIn,

--- a/webapps/console/pages/api/fb-auth/create-session.ts
+++ b/webapps/console/pages/api/fb-auth/create-session.ts
@@ -11,7 +11,6 @@ import { ApiError } from "../../../lib/shared/errors";
 import { SerializeOptions, serialize } from "cookie";
 import { getAppEndpoint } from "../../../lib/domains";
 import { getServerLog } from "../../../lib/server/log";
-import { getLog } from "juava";
 
 const log = getServerLog("firebase");
 
@@ -50,9 +49,8 @@ export const api: Api = {
       // Host-only by default (no Domain attribute); AUTH_COOKIE_DOMAIN widens it to
       // a parent domain so sibling subdomains share the session.
       const domain = getAuthCookieDomain();
-      getLog()
-        .atDebug()
-        .log(`Setting firebase auth cookie (domain: ${domain ?? "host-only"}): ${cookie}`);
+      // Never log the cookie value itself — it's a bearer session credential.
+      log.atDebug().log(`Setting firebase auth cookie (domain: ${domain ?? "host-only"}, maxAge: ${expiresIn}ms)`);
       const options: SerializeOptions = {
         maxAge: expiresIn,
         httpOnly: true,

--- a/webapps/console/pages/api/fb-auth/create-session.ts
+++ b/webapps/console/pages/api/fb-auth/create-session.ts
@@ -47,17 +47,20 @@ export const api: Api = {
       // calls only at the actual sign-in moment. This endpoint is hit on
       // every cookie mint / refresh — too noisy to audit here.
 
-      // Host-only by default; AUTH_COOKIE_DOMAIN can widen it to a parent domain
-      // so sibling subdomains share the session.
-      const domain = getAuthCookieDomain(req);
-      getLog().atDebug().log(`Setting firebase auth cookie for '${domain}': ${cookie}`);
+      // Host-only by default (no Domain attribute); AUTH_COOKIE_DOMAIN widens it to
+      // a parent domain so sibling subdomains share the session.
+      const domain = getAuthCookieDomain();
+      getLog()
+        .atDebug()
+        .log(`Setting firebase auth cookie (domain: ${domain ?? "host-only"}): ${cookie}`);
       const options: SerializeOptions = {
         maxAge: expiresIn,
         httpOnly: true,
         secure,
         path: "/",
         sameSite: "lax",
-        domain,
+        // Omit Domain entirely for a true host-only cookie; only set it when configured.
+        ...(domain ? { domain } : {}),
       };
       res.setHeader("Set-Cookie", serialize(firebaseAuthCookieName, cookie, options));
 

--- a/webapps/console/pages/api/fb-auth/revoke-session.ts
+++ b/webapps/console/pages/api/fb-auth/revoke-session.ts
@@ -1,5 +1,5 @@
 import { createRoute } from "../../../lib/api";
-import { firebaseAuthCookieName, signOut } from "../../../lib/server/firebase-server";
+import { firebaseAuthCookieName, getAuthCookieDomain, signOut } from "../../../lib/server/firebase-server";
 import { serialize } from "cookie";
 import { getAppEndpoint } from "../../../lib/domains";
 import { getServerLog } from "../../../lib/server/log";
@@ -26,6 +26,8 @@ export default createRoute()
         maxAge: 0,
         httpOnly: true,
         secure,
+        // Must match the domain used when the cookie was set, or it won't clear.
+        domain: getAuthCookieDomain(req),
       })
     );
   })

--- a/webapps/console/pages/api/fb-auth/revoke-session.ts
+++ b/webapps/console/pages/api/fb-auth/revoke-session.ts
@@ -20,14 +20,17 @@ export default createRoute()
         .log("Failed to record firebase logout audit event");
     }
     const secure = getAppEndpoint(req).protocol === "https";
+    // Name, path and domain must all match create-session, or the real cookie
+    // won't be cleared.
+    const domain = getAuthCookieDomain();
     res.setHeader(
       "Set-Cookie",
       serialize(firebaseAuthCookieName, "", {
         maxAge: 0,
         httpOnly: true,
         secure,
-        // Must match the domain used when the cookie was set, or it won't clear.
-        domain: getAuthCookieDomain(req),
+        path: "/",
+        ...(domain ? { domain } : {}),
       })
     );
   })


### PR DESCRIPTION
## What

The `jitsu-auth` Firebase **session cookie** is set with `domain = getRequestHost(req)` — i.e. host-only (`use.jitsu.com`). Sibling subdomains on the same apex (e.g. a marketing site at `jitsu.com`) therefore never receive it and can't read the logged-in session server-side.

This adds an optional **`AUTH_COOKIE_DOMAIN`** env var. When set (e.g. `jitsu.com`), the auth cookie is scoped to that parent domain and is shared across its subdomains. Unset preserves the current host-only behaviour.

## Why

So a separate app on a sibling subdomain can resolve the logged-in user from the cookie (verify the session-cookie JWT) and, for example, attach identity to analytics — without a cross-origin `/api/me` round-trip.

## Changes

- **serverEnv.ts** — add optional `AUTH_COOKIE_DOMAIN`.
- **firebase-server.ts** — `getAuthCookieDomain(req)` helper: `AUTH_COOKIE_DOMAIN` if set, else the request host.
- **create-session.ts** — set the cookie with that domain.
- **revoke-session.ts** — clear the cookie with the **same** domain (otherwise a domain-scoped cookie won't be cleared on logout).

## Notes

- Default behaviour is unchanged when the var is unset.
- Security: widening to a parent domain shares the session across all its subdomains — only set it on a domain you fully control.