### PR TITLE
fix(console): forward GET to EE provision-db and s3-init endpoints

### DIFF
--- a/webapps/console/components/ConfigObjectEditor/ConfigEditor.tsx
+++ b/webapps/console/components/ConfigObjectEditor/ConfigEditor.tsx
@@ -629,7 +629,7 @@ const SingleObjectEditor: React.FC<SingleObjectEditorProps> = props => {
       await getConfigApi(workspace.id, type).create(newObject);
       if (type === "stream" && appConfig.ee.available) {
         try {
-          await eeRpc("s3-init", { method: "POST", query: { workspaceId: workspace.id } });
+          await eeRpc("s3-init", { method: "GET", query: { workspaceId: workspace.id } });
         } catch (e: any) {
           console.error("Failed to init S3 bucket", e.message);
         }

--- a/webapps/console/pages/_app.tsx
+++ b/webapps/console/pages/_app.tsx
@@ -423,7 +423,7 @@ export const S3BucketInitializer: React.FC<{}> = () => {
     (async () => {
       if (appConfig.ee.available && workspace?.id && streams.length > 0) {
         try {
-          await eeRpc("s3-init", { method: "POST", query: { workspaceId: workspace.id } });
+          await eeRpc("s3-init", { method: "GET", query: { workspaceId: workspace.id } });
         } catch (e: any) {
           console.error("Failed to init S3 bucket", e.message);
         }

--- a/webapps/console/pages/api/[workspaceId]/ee/provision-db/credentials.ts
+++ b/webapps/console/pages/api/[workspaceId]/ee/provision-db/credentials.ts
@@ -7,7 +7,7 @@ import { eeAuthHeadersOrServiceToken, getEeConnection, isEEAvailable } from "../
 export default createRoute()
   .GET({
     auth: true,
-    // Provisions a ClickHouse DB on the EE side — POSTs to `${ee}/api/provision-db`,
+    // Provisions a ClickHouse DB on the EE side — GETs `${ee}/api/provision-db`,
     // creating real infra. Side-effect outside the Prisma backstop, so opt
     // into the maintenance gate explicitly.
     mutates: true,
@@ -20,7 +20,7 @@ export default createRoute()
     await verifyAccess(user, workspaceId);
     const { host } = getEeConnection();
     const provisionedDbCredentials = await rpc(`${host}api/provision-db`, {
-      method: "POST",
+      method: "GET",
       query: { workspaceId, slug: workspaceId }, //db is created, so the slug won't be really used
       headers: {
         "Content-Type": "application/json",

--- a/webapps/console/pages/api/[workspaceId]/ee/provision-db/index.ts
+++ b/webapps/console/pages/api/[workspaceId]/ee/provision-db/index.ts
@@ -71,7 +71,7 @@ export const api: Api = {
 
       const { host } = getEeConnection();
       const provisionedDbCredentials = await rpc(`${host}api/provision-db`, {
-        method: "POST",
+        method: "GET",
         query: { workspaceId, slug: workspace.slug || workspace.id },
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Problem

Clicking **Create Database** (ProvisionDatabaseButton) failed with:

> Method not allowed. Expected GET, got POST.

The console component correctly POSTs to its own route `/api/[workspaceId]/ee/provision-db` (which has a POST handler). The mismatch is one layer deeper: that handler **forwards** to the EE billing service at `${ee}/api/provision-db`.

The EE endpoints were refactored to the `defineRoute({ method: "GET" })` registry and are now **GET-only**, but the console kept forwarding `method: "POST"`. EE's `lib/api/registry.ts` then returns `Method not allowed. Expected GET, got POST`, which bubbles back through the two `rpc` layers to the toast.

## Fix

Cross-checked **every** console→EE forward against the EE route specs. Two endpoints had the same bug; the rest already matched (`user-created`=POST↔POST, `quotas/sync`=GET↔GET, billing endpoints=GET↔GET).

Switched all four forwards POST → GET:

| Endpoint | EE expects | Console site |
|---|---|---|
| `provision-db` | GET | `pages/api/[workspaceId]/ee/provision-db/index.ts` |
| `provision-db` | GET | `pages/api/[workspaceId]/ee/provision-db/credentials.ts` |
| `s3-init` | GET | `pages/_app.tsx` |
| `s3-init` | GET | `components/ConfigObjectEditor/ConfigEditor.tsx` |

The two `s3-init` calls were failing silently (wrapped in a `try/catch` that only `console.error`s), so S3 bucket init has also been broken since the EE refactor — fixed here too.

All forwards pass only `query` (no body), so GET is the correct verb.

## Verification

With `EE_CONNECTION` set, click **Create Database** on a workspace without a provisioned DB — it now provisions successfully instead of toasting the 405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)