### PR TITLE
fix(console): recover billing settings after tab loses focus

### DIFF
--- a/webapps/console/components/Billing/BillingProvider.tsx
+++ b/webapps/console/components/Billing/BillingProvider.tsx
@@ -41,20 +41,22 @@ export const BillingProvider: React.FC<PropsWithChildren<{ enabled: boolean; sen
   sendAnalytics,
   children,
 }) => {
-  const [billingSettings, setBillingSettings] = useState<BillingSettings | null>(null);
-  const [error, setError] = useState();
+  //the fetched result is keyed by the workspace it was requested for, and validity is
+  //derived at render time — settings from workspace A are never visible in workspace B,
+  //not even for the render frame before an effect could reset state
+  const [fetchResult, setFetchResult] = useState<{
+    workspaceId: string;
+    settings?: BillingSettings;
+    error?: unknown;
+  } | null>(null);
   const workspace = useWorkspace();
   const user = useUser();
   const { analytics } = useJitsu();
   const { eeRpc } = useEeApi();
   const [refreshDate, setRefreshDate] = useState(new Date());
 
-  //settings belong to a workspace — drop them on switch so the previous
-  //workspace's entitlements can't leak into the new one while (or if) its fetch fails
-  useEffect(() => {
-    setBillingSettings(null);
-    setError(undefined);
-  }, [workspace.id]);
+  const billingSettings = fetchResult?.workspaceId === workspace.id ? fetchResult.settings : undefined;
+  const error = fetchResult?.workspaceId === workspace.id ? fetchResult.error : undefined;
 
   useEffect(() => {
     if (!enabled) {
@@ -63,20 +65,22 @@ export const BillingProvider: React.FC<PropsWithChildren<{ enabled: boolean; sen
     //if the workspace changes while this request is in flight, its late result must not
     //be committed against the new workspace
     let stale = false;
-    eeRpc("billing/settings", { query: { workspaceId: workspace.id, email: user.email } })
+    const workspaceId = workspace.id;
+    eeRpc("billing/settings", { query: { workspaceId, email: user.email } })
       .then(parseBillingSettings)
       .then(settings => {
-        if (stale) {
-          return;
+        if (!stale) {
+          //a successful fetch also clears any stale error from a failed refresh
+          //(e.g. while the tab was asleep) that would otherwise keep masking it
+          setFetchResult({ workspaceId, settings });
         }
-        setBillingSettings(settings);
-        //a stale error from a failed refresh (e.g. while the tab was asleep) must not
-        //keep masking a successful one
-        setError(undefined);
       })
       .catch(e => {
         if (!stale) {
-          setError(e);
+          //last known good settings of the same workspace win over a transient refresh error
+          setFetchResult(prev =>
+            prev?.workspaceId === workspaceId && prev.settings ? prev : { workspaceId, error: e }
+          );
         }
       });
     return () => {

--- a/webapps/console/components/Billing/BillingProvider.tsx
+++ b/webapps/console/components/Billing/BillingProvider.tsx
@@ -55,7 +55,12 @@ export const BillingProvider: React.FC<PropsWithChildren<{ enabled: boolean; sen
     }
     eeRpc("billing/settings", { query: { workspaceId: workspace.id, email: user.email } })
       .then(parseBillingSettings)
-      .then(setBillingSettings)
+      .then(settings => {
+        setBillingSettings(settings);
+        //a stale error from a failed refresh (e.g. while the tab was asleep) must not
+        //keep masking a successful one
+        setError(undefined);
+      })
       .catch(setError)
       .finally();
   }, [enabled, workspace.id, user.email, refreshDate, eeRpc]);
@@ -69,6 +74,24 @@ export const BillingProvider: React.FC<PropsWithChildren<{ enabled: boolean; sen
       setRefreshDate(new Date());
     }, 1000 * 60 * 5);
     return () => clearInterval(interval);
+  }, [enabled]);
+
+  //interval timers are throttled in background tabs — refresh as soon as the tab is back in focus
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const refresh = () => {
+      if (document.visibilityState === "visible") {
+        setRefreshDate(new Date());
+      }
+    };
+    document.addEventListener("visibilitychange", refresh);
+    window.addEventListener("focus", refresh);
+    return () => {
+      document.removeEventListener("visibilitychange", refresh);
+      window.removeEventListener("focus", refresh);
+    };
   }, [enabled]);
 
   /* eslint-disable react-hooks/exhaustive-deps  */
@@ -90,14 +113,15 @@ export const BillingProvider: React.FC<PropsWithChildren<{ enabled: boolean; sen
 
   if (!enabled) {
     return <BillingContext.Provider value={"disabled"}>{children}</BillingContext.Provider>;
+  } else if (billingSettings) {
+    //last known good settings win over a transient refresh error
+    return <BillingContext.Provider value={billingSettings}>{children}</BillingContext.Provider>;
   } else if (error) {
     // The UI falls back to "Billing is disabled" because that's what the user
     // can act on, but log loudly so an operator can tell a real outage apart
     // from an intentionally-disabled workspace.
     log.atError().withCause(error).log(`Can't reach ee-api billing/settings — falling back to disabled UI`);
     return <BillingContext.Provider value={"disabled"}>{children}</BillingContext.Provider>;
-  } else if (billingSettings) {
-    return <BillingContext.Provider value={billingSettings}>{children}</BillingContext.Provider>;
   } else {
     return <BillingContext.Provider value={"loading"}>{children}</BillingContext.Provider>;
   }

--- a/webapps/console/components/Billing/BillingProvider.tsx
+++ b/webapps/console/components/Billing/BillingProvider.tsx
@@ -49,6 +49,13 @@ export const BillingProvider: React.FC<PropsWithChildren<{ enabled: boolean; sen
   const { eeRpc } = useEeApi();
   const [refreshDate, setRefreshDate] = useState(new Date());
 
+  //settings belong to a workspace — drop them on switch so the previous
+  //workspace's entitlements can't leak into the new one while (or if) its fetch fails
+  useEffect(() => {
+    setBillingSettings(null);
+    setError(undefined);
+  }, [workspace.id]);
+
   useEffect(() => {
     if (!enabled) {
       return;

--- a/webapps/console/components/Billing/BillingProvider.tsx
+++ b/webapps/console/components/Billing/BillingProvider.tsx
@@ -60,16 +60,28 @@ export const BillingProvider: React.FC<PropsWithChildren<{ enabled: boolean; sen
     if (!enabled) {
       return;
     }
+    //if the workspace changes while this request is in flight, its late result must not
+    //be committed against the new workspace
+    let stale = false;
     eeRpc("billing/settings", { query: { workspaceId: workspace.id, email: user.email } })
       .then(parseBillingSettings)
       .then(settings => {
+        if (stale) {
+          return;
+        }
         setBillingSettings(settings);
         //a stale error from a failed refresh (e.g. while the tab was asleep) must not
         //keep masking a successful one
         setError(undefined);
       })
-      .catch(setError)
-      .finally();
+      .catch(e => {
+        if (!stale) {
+          setError(e);
+        }
+      });
+    return () => {
+      stale = true;
+    };
   }, [enabled, workspace.id, user.email, refreshDate, eeRpc]);
 
   //refresh billing settings every 5 minutes


### PR DESCRIPTION
## Problem

After a tab sat in the background for a long time, the `settings/billing` page kept showing the stale **"Billing is disabled for this workspace"** message — even though `billing.jitsu.com/api/billing/settings` was returning a correct, successful response (visible in the network tab).

## Root cause

Two compounding issues in `BillingProvider.tsx`:

1. **A failed refresh poisoned the provider permanently.** While the tab was backgrounded, the throttled 5-minute interval eventually fired a request that failed (suspended network, expired session, etc.) and set `error`. The render path checked `error` *before* `billingSettings`, so even after a later fetch succeeded, the component kept rendering the "disabled" fallback. `error` was never cleared.
2. **No refetch on focus** — recovery had to wait for the next interval tick at best.

## Fix

- Refetch billing settings immediately on `visibilitychange`/`focus` instead of waiting for the throttled interval.
- Clear `error` on a successful fetch so the provider recovers from transient failures.
- Prefer last-known-good `billingSettings` over a transient refresh error in render, so a failed background refresh no longer downgrades a working page to "disabled".

## Verification

- `tsc --noEmit` — no errors in any Billing file (remaining failures are pre-existing and unrelated).
- Prettier clean (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)