### PR TITLE
fix(juava): use CSPRNG for randomId() to prevent token prediction (#1…

### DIFF
--- a/libs/juava/__tests__/id.test.ts
+++ b/libs/juava/__tests__/id.test.ts
@@ -1,4 +1,11 @@
+import { afterEach, expect, test, vi } from "vitest";
 import { randomId } from "../src";
+
+const ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 test("id test", () => {
   const id1 = randomId();
@@ -14,4 +21,63 @@ test("id test", () => {
   expect(id3.length).toBe(10);
   expect(id4.length).toBe("test_".length + 10);
   expect(id4.startsWith("test_")).toBe(true);
+});
+
+test("only emits characters from the expected alphabet", () => {
+  for (let i = 0; i < 200; i++) {
+    const id = randomId(32);
+    for (const ch of id) {
+      expect(ALPHABET).toContain(ch);
+    }
+  }
+});
+
+test("first character is never a digit (so ids are valid identifiers)", () => {
+  for (let i = 0; i < 500; i++) {
+    const id = randomId(16);
+    expect(/^[0-9]/.test(id)).toBe(false);
+  }
+});
+
+// --- Security regression tests (CWE-338: weak randomness for secrets) ---
+//
+// randomId() mints bearer credentials (API key secrets, CLI keys, invitation
+// tokens). It MUST draw from a CSPRNG, never Math.random(), whose state is
+// recoverable from observed output, which would let an attacker predict tokens.
+
+test("does not use Math.random()", () => {
+  const spy = vi.spyOn(Math, "random");
+  randomId(32);
+  randomId({ digits: 16, prefix: "key" });
+  expect(spy).not.toHaveBeenCalled();
+});
+
+test("output is independent of Math.random() (stays random when it is pinned)", () => {
+  // Pin Math.random to a constant. A weak implementation would now emit a
+  // constant character; a CSPRNG-backed one keeps producing varied output.
+  vi.spyOn(Math, "random").mockReturnValue(0);
+  const id = randomId(64);
+  const distinct = new Set(id.split(""));
+  expect(distinct.size).toBeGreaterThan(1);
+});
+
+test("generates unique ids with no collisions across many draws", () => {
+  const seen = new Set<string>();
+  const n = 5000;
+  for (let i = 0; i < n; i++) {
+    seen.add(randomId(24));
+  }
+  expect(seen.size).toBe(n);
+});
+
+test("character distribution is broad (no modulo collapse / bias smoke test)", () => {
+  // Concatenate many ids and confirm the generator covers most of the
+  // 62-character alphabet — a buggy CSPRNG mapping (e.g. broken rejection
+  // sampling) would collapse onto a narrow subset.
+  let blob = "";
+  for (let i = 0; i < 200; i++) {
+    blob += randomId(32);
+  }
+  const distinct = new Set(blob.split(""));
+  expect(distinct.size).toBeGreaterThanOrEqual(50);
 });

--- a/libs/juava/__tests__/id.test.ts
+++ b/libs/juava/__tests__/id.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, expect, test, vi } from "vitest";
 import { randomId } from "../src";
 
-const ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -23,61 +21,17 @@ test("id test", () => {
   expect(id4.startsWith("test_")).toBe(true);
 });
 
-test("only emits characters from the expected alphabet", () => {
-  for (let i = 0; i < 200; i++) {
-    const id = randomId(32);
-    for (const ch of id) {
-      expect(ALPHABET).toContain(ch);
-    }
-  }
-});
-
-test("first character is never a digit (so ids are valid identifiers)", () => {
-  for (let i = 0; i < 500; i++) {
-    const id = randomId(16);
-    expect(/^[0-9]/.test(id)).toBe(false);
-  }
-});
-
-// --- Security regression tests (CWE-338: weak randomness for secrets) ---
-//
-// randomId() mints bearer credentials (API key secrets, CLI keys, invitation
-// tokens). It MUST draw from a CSPRNG, never Math.random(), whose state is
-// recoverable from observed output, which would let an attacker predict tokens.
-
-test("does not use Math.random()", () => {
+// strongRandom ids must come from the CSPRNG, never Math.random() (CWE-338).
+test("strongRandom does not use Math.random()", () => {
   const spy = vi.spyOn(Math, "random");
-  randomId(32);
-  randomId({ digits: 16, prefix: "key" });
+  const id = randomId({ digits: 32, strongRandom: true, prefix: "key" });
   expect(spy).not.toHaveBeenCalled();
+  expect(id).toBe("key_" + id.slice(4));
+  expect(id.length).toBe("key_".length + 32);
 });
 
-test("output is independent of Math.random() (stays random when it is pinned)", () => {
-  // Pin Math.random to a constant. A weak implementation would now emit a
-  // constant character; a CSPRNG-backed one keeps producing varied output.
+test("strongRandom stays random even when Math.random() is pinned", () => {
   vi.spyOn(Math, "random").mockReturnValue(0);
-  const id = randomId(64);
-  const distinct = new Set(id.split(""));
-  expect(distinct.size).toBeGreaterThan(1);
-});
-
-test("generates unique ids with no collisions across many draws", () => {
-  const seen = new Set<string>();
-  const n = 5000;
-  for (let i = 0; i < n; i++) {
-    seen.add(randomId(24));
-  }
-  expect(seen.size).toBe(n);
-});
-
-test("character distribution is broad (no modulo collapse / bias smoke test)", () => {
-  // Concatenate many ids and confirm the generator covers most of the
-  // 62-character alphabet — a buggy CSPRNG mapping (e.g. broken rejection
-  // sampling) would collapse onto a narrow subset.
-  let blob = "";
-  for (let i = 0; i < 200; i++) {
-    blob += randomId(32);
-  }
-  const distinct = new Set(blob.split(""));
-  expect(distinct.size).toBeGreaterThanOrEqual(50);
+  const id = randomId({ digits: 64, strongRandom: true });
+  expect(new Set(id).size).toBeGreaterThan(1);
 });

--- a/libs/juava/src/id.ts
+++ b/libs/juava/src/id.ts
@@ -16,10 +16,45 @@ export function randomId(_opts: RandomOptsCompat = {}): string {
   return `${prefix ? prefix + "_" : ""}${id}`;
 }
 
+/**
+ * Fills `size` bytes from a cryptographically secure source.
+ *
+ * `Math.random()` is deliberately NOT used here: `randomId()` mints bearer
+ * credentials (API key secrets, CLI keys, workspace invitation tokens), and
+ * V8's `Math.random()` is a PRNG whose internal state is recoverable from a
+ * few observed outputs — letting an attacker predict subsequent tokens.
+ *
+ * Prefers the Web Crypto API (available in browsers and Node >= 19, and this
+ * module is bundled into the browser console) and falls back to Node's
+ * `crypto.randomBytes` for older/edge runtimes.
+ */
+function secureRandomBytes(size: number): Uint8Array {
+  const webcrypto = typeof globalThis !== "undefined" ? (globalThis as any).crypto : undefined;
+  if (webcrypto && typeof webcrypto.getRandomValues === "function") {
+    return webcrypto.getRandomValues(new Uint8Array(size));
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require("crypto").randomBytes(size);
+}
+
+/**
+ * Uniform integer in [0, max) using rejection sampling to avoid the modulo
+ * bias that `byte % max` would introduce when `max` does not divide 256.
+ */
+function secureRandomInt(max: number): number {
+  const limit = 256 - (256 % max); // largest multiple of `max` that is <= 256
+  while (true) {
+    const byte = secureRandomBytes(1)[0];
+    if (byte < limit) {
+      return byte % max;
+    }
+  }
+}
+
 function randomChar(noDigits?: boolean) {
   const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   while (true) {
-    const index = Math.floor(Math.random() * chars.length);
+    const index = secureRandomInt(chars.length);
     if (!noDigits || index > 9) {
       return chars[index];
     }

--- a/libs/juava/src/id.ts
+++ b/libs/juava/src/id.ts
@@ -1,62 +1,54 @@
-export type RandomOpts = { digits?: number; prefix?: string };
+export type RandomOpts = {
+  digits?: number;
+  prefix?: string;
+  // Draw from a CSPRNG instead of Math.random(). Set it for bearer credentials
+  // (API key secrets, CLI keys, invitation tokens): Math.random()'s internal
+  // state is recoverable from its output, so plain ids are predictable (CWE-338).
+  strongRandom?: boolean;
+};
 
 /**
  * Compatibility wrapper for old args
  */
 export type RandomOptsCompat = RandomOpts | number;
 
+const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
 export function randomId(_opts: RandomOptsCompat = {}): string {
   const opts: RandomOpts = typeof _opts === "number" ? { digits: _opts } : _opts;
   const digits = opts.digits ?? 24;
   const prefix = opts.prefix ?? "";
+  const randomInt = opts.strongRandom ? secureRandomInt : insecureRandomInt;
   let id = "";
   for (let i = 0; i < digits; i++) {
-    id += randomChar(i === 0);
+    id += randomChar(randomInt, i === 0);
   }
   return `${prefix ? prefix + "_" : ""}${id}`;
 }
 
-/**
- * Fills `size` bytes from a cryptographically secure source.
- *
- * `Math.random()` is deliberately NOT used here: `randomId()` mints bearer
- * credentials (API key secrets, CLI keys, workspace invitation tokens), and
- * V8's `Math.random()` is a PRNG whose internal state is recoverable from a
- * few observed outputs — letting an attacker predict subsequent tokens.
- *
- * Prefers the Web Crypto API (available in browsers and Node >= 19, and this
- * module is bundled into the browser console) and falls back to Node's
- * `crypto.randomBytes` for older/edge runtimes.
- */
-function secureRandomBytes(size: number): Uint8Array {
-  const webcrypto = typeof globalThis !== "undefined" ? (globalThis as any).crypto : undefined;
-  if (webcrypto && typeof webcrypto.getRandomValues === "function") {
-    return webcrypto.getRandomValues(new Uint8Array(size));
-  }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  return require("crypto").randomBytes(size);
-}
-
-/**
- * Uniform integer in [0, max) using rejection sampling to avoid the modulo
- * bias that `byte % max` would introduce when `max` does not divide 256.
- */
-function secureRandomInt(max: number): number {
-  const limit = 256 - (256 % max); // largest multiple of `max` that is <= 256
+function randomChar(randomInt: (max: number) => number, noDigits?: boolean) {
   while (true) {
-    const byte = secureRandomBytes(1)[0];
-    if (byte < limit) {
-      return byte % max;
+    const index = randomInt(chars.length);
+    if (!noDigits || index > 9) {
+      return chars[index];
     }
   }
 }
 
-function randomChar(noDigits?: boolean) {
-  const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+function insecureRandomInt(max: number): number {
+  return Math.floor(Math.random() * max);
+}
+
+// Uniform int in [0, max) from the platform CSPRNG (Web Crypto — present in
+// browsers, Node >= 19, and edge runtimes). Rejection sampling avoids the modulo
+// bias of `byte % max` when max does not divide 256.
+function secureRandomInt(max: number): number {
+  const limit = 256 - (256 % max);
+  const buf = new Uint8Array(1);
   while (true) {
-    const index = secureRandomInt(chars.length);
-    if (!noDigits || index > 9) {
-      return chars[index];
+    globalThis.crypto.getRandomValues(buf);
+    if (buf[0] < limit) {
+      return buf[0] % max;
     }
   }
 }

--- a/webapps/console/components/ApiKeyEditor/ApiKeyEditor.tsx
+++ b/webapps/console/components/ApiKeyEditor/ApiKeyEditor.tsx
@@ -152,7 +152,7 @@ export const ApiKeysEditor: React.FC<CustomWidgetProps<ApiKey[]> & { compact?: b
         <Button
           type="text"
           onClick={() => {
-            const newKey = randomId(32);
+            const newKey = randomId({ digits: 32, strongRandom: true });
             const newVal = [...keys, { id: randomId(32), plaintext: newKey, hint: hint(newKey) }];
             setKeys(newVal);
             props.onChange(newVal);
@@ -273,7 +273,7 @@ export const StreamKeysEditor: React.FC<WidgetProps<ApiKey[]>> = props => {
           type="text"
           onClick={async () => {
             try {
-              const newKey = randomId(32);
+              const newKey = randomId({ digits: 32, strongRandom: true });
               const newVal = [...keys, { id: randomId(32), plaintext: newKey, hint: hint(newKey) }];
               if (type === "stream" && !context.isNew) {
                 setLoading(true);

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -101,7 +101,7 @@ async function getCustomClaim(user: auth.User, claimName: string): Promise<strin
 }
 
 function getCSRFToken(cookieName: string) {
-  const token = randomId(100);
+  const token = randomId({ digits: 100, strongRandom: true });
   document.cookie = `${cookieName}=${token}; expires=0; path=/`;
   return token;
 }

--- a/webapps/console/pages/api/user/cli-key.ts
+++ b/webapps/console/pages/api/user/cli-key.ts
@@ -14,7 +14,7 @@ const api: Api = {
       result: ApiKey,
     },
     handle: async ({ user }) => {
-      const newKey = randomId(32);
+      const newKey = randomId({ digits: 32, strongRandom: true });
       const id = `jitsu-cli-${randomId(22)}`;
       const expiresAt = new Date();
       expiresAt.setDate(expiresAt.getDate() + CLI_KEY_EXPIRATION_DAYS);

--- a/webapps/console/pages/api/user/keys.ts
+++ b/webapps/console/pages/api/user/keys.ts
@@ -43,7 +43,7 @@ const api: Api = {
       result: ApiKey,
     },
     handle: async ({ user, body }) => {
-      const plaintext = randomId(32);
+      const plaintext = randomId({ digits: 32, strongRandom: true });
       const id = randomId(32);
       const created = await db.prisma().userApiToken.create({
         data: {

--- a/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/users/index.ts
+++ b/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/users/index.ts
@@ -115,7 +115,7 @@ const api: Api = {
           data: {
             email: body.email,
             workspaceId: workspace.id,
-            token: randomId(12),
+            token: randomId({ digits: 12, strongRandom: true }),
             role: body.role || "owner",
           },
         });

--- a/webapps/console/scripts/manage.ts
+++ b/webapps/console/scripts/manage.ts
@@ -44,7 +44,7 @@ const commands: Record<string, Command> = {
     usage: "pnpm manage password-hash [secret]",
     handler: async args => {
       // Get the secret from remaining positional args (after the command name)
-      const secret = args._.length > 1 ? args._[1] : randomId(32);
+      const secret = args._.length > 1 ? args._[1] : randomId({ digits: 32, strongRandom: true });
 
       if (args._.length <= 1) {
         log.atInfo().log("No secret provided, generating a random one");


### PR DESCRIPTION
Fixes #1356.