### PR TITLE
fix: Braze expecting currency in the wrong place

### DIFF
--- a/libs/destination-functions/src/functions/braze-destination.ts
+++ b/libs/destination-functions/src/functions/braze-destination.ts
@@ -108,7 +108,7 @@ function trackPurchase(event: AnalyticsServerEvent, ctx: FullContext<BrazeCreden
     purchases: products.map(product => ({
       ...base,
       product_id: product.product_id,
-      currency: product.currency ?? "USD",
+      currency: event.properties.currency ?? product.currency ?? "USD",
       price: product.price,
       quantity: product.quantity,
       properties: {


### PR DESCRIPTION
Problem: Braze destination file failover always to USD

Why: It expects currency coming in `event.properties.products[].currency` while it should be `event.properties.currency` as per the specs and other destination files

Solution: Prioritize `event.properties.currency` with failover to old behavior to maintain backward compatibility.