### PR TITLE
GTM destination: add "Load GTM" option to skip script injection

### DIFF
--- a/libs/jitsu-js/src/destination-plugins/gtm.ts
+++ b/libs/jitsu-js/src/destination-plugins/gtm.ts
@@ -5,6 +5,9 @@ import { applyFilters, CommonDestinationCredentials, InternalPlugin } from "./in
 export type GtmDestinationCredentials = {
   containerId?: string;
   dataLayerName?: string;
+  // When false, Jitsu does not inject the GTM script — the client is expected to load
+  // GTM itself (e.g. on page load). Jitsu still pushes events to the data layer.
+  loadGtm?: boolean;
 } & CommonDestinationCredentials;
 
 function omit(obj: any, ...keys: string[]) {
@@ -111,12 +114,20 @@ function setGtmState(s: GtmState) {
 }
 
 async function initGtmIfNeeded(config: GtmDestinationCredentials, payload: AnalyticsClientEvent) {
+  const dlName = config.dataLayerName || "dataLayer";
+
+  // The client loads GTM itself: don't inject the GTM script. We only make sure the data
+  // layer exists so events can be pushed; the client-loaded GTM container will process them.
+  if (config.loadGtm === false) {
+    window[dlName] = window[dlName] || [];
+    return;
+  }
+
   if (getGtmState() !== "fresh") {
     return;
   }
   setGtmState("loading");
 
-  const dlName = config.dataLayerName || "dataLayer";
   const tagId = config.containerId;
 
   (function (w, l, i) {

--- a/webapps/console/lib/schema/destinations.tsx
+++ b/webapps/console/lib/schema/destinations.tsx
@@ -380,6 +380,12 @@ const gtmDeviceDestination = {
   credentials: z.object({
     containerId: z.string().describe("The Container ID uniquely identifies the GTM Container."),
     dataLayerName: z.string().default("dataLayer").describe("The name of the data layer variable."),
+    loadGtm: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Load GTM::Whether Jitsu should load the Google Tag Manager script. Disable this if you load GTM yourself (e.g. on page load) so tags are ready before navigation — Jitsu will only push events to the data layer."
+      ),
   }),
   deviceOptions: {
     type: "internal-plugin",


### PR DESCRIPTION
## Summary

Adds a `loadGtm` option to the **Google Tag Manager** device destination so customers can take over loading GTM themselves while still using the official destination.

The GTM destination currently injects the GTM script **lazily** — only on the first event sent to it. For events fired right before a navigation (e.g. link clicks), this loses a race: the script hasn't loaded its tags/pixels by the time the browser navigates away, so the pixel never fires.

With this change, customers can load GTM on page load themselves (so tags are ready early) and set **Load GTM = off**. Jitsu then skips injecting the GTM script but still pushes `page_view` / track / identify events to the data layer, which the client-loaded container processes. This avoids having to reimplement the GTM destination as a generic Tag destination.

## Changes

- **`libs/jitsu-js/src/destination-plugins/gtm.ts`** — add `loadGtm?: boolean` to `GtmDestinationCredentials`. In `initGtmIfNeeded`, when `loadGtm === false`, ensure the data layer exists and return early (skip script injection). Event-pushing logic is unchanged.
- **`webapps/console/lib/schema/destinations.tsx`** — expose a **"Load GTM"** toggle in the GTM destination config (`z.boolean().default(true)`).

## Compatibility

`default(true)` keeps this fully backward-compatible — existing destinations behave exactly as before. Only customers who load GTM themselves flip it off.

## Context

Requested by a customer in Slack (private channel C08UVQMET16). Tracked in the [Notion task](https://app.notion.com/p/383737892e47819fb6f2f73eea77151e).

## Testing notes

- Not yet run: typecheck/tests (authored in a fresh worktree without workspace deps installed). Change is small and matches existing schema/indexing idioms. CI should cover it.

## Follow-ups

- Update the jitsu.com GTM destination docs (external docs repo).
- Reply to the customer once shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)