### PR TITLE
fix(ci): auto-review bot-opened PRs, drop manual review dispatch

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,12 +16,11 @@ on:
 
 jobs:
   ai-review:
-    # Skip auto-trigger for PRs opened by the bot. codex-action's write-access
-    # check calls the collaborators API which returns 'none' for app-bot actors,
-    # causing the review to fail. security-fix.yml dispatches the review manually
-    # for bot-opened PRs instead.
-    if: github.event_name != 'pull_request' || github.actor != 'jitsu-code-review[bot]'
-    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.28.20260529
+    # Bot-opened PRs (e.g. the automated security-fix PRs from github-actions[bot])
+    # are reviewed too: the reusable workflow passes allow-bots: true to codex-action,
+    # so its write-access check no longer aborts on the bot actor. Draft PRs are
+    # skipped inside the reusable workflow.
+    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.29.20260622
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       AI_CODE_REVIEW_APP_ID: ${{ secrets.AI_CODE_REVIEW_APP_ID }}

--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -342,29 +342,9 @@ jobs:
           sandbox: danger-full-access
           codex-home: .github/codex/home
 
-  # Separate job so actions: write is not available to the Codex step above.
-  # ai-review.yml skips PRs opened by jitsu-code-review[bot] (codex-action's
-  # write-access check fails for app-bot actors), so we dispatch it manually.
-  # Running over all open security/* PRs is intentional — this workflow is
-  # manual, so a re-review on an older PR is harmless.
-  trigger-review:
-    name: 🔍 Trigger AI Review
-    needs: scan-and-fix
-    if: ${{ inputs.dry_run != true }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      pull-requests: read
-    steps:
-      - name: Dispatch AI review for open security PRs
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr list --repo ${{ github.repository }} --base newjitsu --state open \
-            --json number,headRefName \
-            --jq '[.[] | select(.headRefName | startswith("security/")) | .number | tostring] | .[]' \
-          | while IFS= read -r num; do
-              echo "Dispatching AI review for PR #$num"
-              gh workflow run ai-review.yml --repo ${{ github.repository }} --ref newjitsu -f pr_number="$num"
-            done
+  # Note: AI review for the security PRs opened by this workflow is no longer
+  # dispatched manually. The PRs are opened by github-actions[bot], and
+  # ai-review.yml now auto-reviews bot-opened PRs (the reusable workflow passes
+  # allow-bots: true to codex-action, so its write-access check no longer aborts
+  # on the bot actor). A manual dispatch here would produce a duplicate review.
 


### PR DESCRIPTION
## Problem

AI Review fails on the automated security-fix PRs (e.g. `security/fix-npm-2026-06-22`). The `🤖 Run Codex analysis` step aborts with:

```
Error: Actor 'github-actions[bot]' is not permitted to run this action:
Actor 'github-actions[bot]' must have write access to jitsucom/jitsu.
Detected permission: 'none'.
```

`openai/codex-action`'s write-access pre-check queries the collaborators API, which returns `none` for the `github-actions[bot]` actor, so the action exits 1. The previous skip-guard in `ai-review.yml` checked for `jitsu-code-review[bot]` — but these PRs are opened under the repo's own `GITHUB_TOKEN`, i.e. actor `github-actions[bot]`, so the guard never matched and the auto-trigger ran and failed.

## Fix

The reusable workflow now passes `allow-bots: true` to codex-action (jitsucom/github-workflows@`1.29.20260622`), which whitelists the GitHub-owned `github-actions[bot]` specifically. The review still posts via the `AI_CODE_REVIEW` app token (PR write) — the actor check was the only gate.

This PR adopts that on the jitsu side:

- **`ai-review.yml`**: bump the reusable workflow ref `1.28.20260529` → `1.29.20260622`, and drop the dead skip-guard so bot-opened PRs are reviewed. Draft PRs are still skipped inside the reusable workflow.
- **`security-fix.yml`**: remove the `trigger-review` job. It manually dispatched the review as a workaround for the failing auto-trigger; now that the auto-trigger works, it would only produce a **duplicate** review per security PR.

## Upstream change

jitsucom/github-workflows@`1.29.20260622` — adds `allow-bots: true` to the codex-action step. `allow-bots` only trusts `github-actions[bot]` (repo-internal automation running under the repo's own token), not arbitrary external actors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)