### PR TITLE
docs: add Linear issue referencing conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,3 +141,15 @@ go test ./...
 When you need to create branches, make commits, or open pull requests, read
 [CONTRIBUTING.md](CONTRIBUTING.md) first. No need to read it for code exploration —
 only when interacting with git.
+
+### Referencing Linear issues
+
+When referencing a Linear issue in GitHub (PR descriptions, commit messages,
+comments), use the bare issue id — `` `JITSU-67` `` — not a Linear URL or a
+markdown link to one.
+
+Before opening a PR, try to work out which Linear issue the work relates to —
+check the branch name, search via the Linear MCP if it's available, or ask the
+user with the question tool. If the PR clearly relates to an issue, prefix the
+PR title with the issue id and put the id in the body. It's fine if there's no
+issue — but offer to create one (when the Linear MCP is available).


### PR DESCRIPTION
Adds a "Referencing Linear issues" subsection to the Git Workflow section of
`AGENTS.md` (symlinked as `CLAUDE.md`):

- Use the bare issue id (e.g. `JITSU-67`) in GitHub PRs / commits / comments —
  not a Linear URL or markdown link.
- Before opening a PR, work out which Linear issue the work relates to (branch
  name, Linear MCP search, or ask the user). If it clearly relates, prefix the
  PR title with the issue id and put the id in the body.
- No issue is fine — but offer to create one when the Linear MCP is available.
