### PR TITLE
feat(ci): auto-deploy console to beta on labeled PR merge

### DIFF
--- a/.github/workflows/deploy-console-on-merge.yml
+++ b/.github/workflows/deploy-console-on-merge.yml
@@ -11,7 +11,7 @@ name: 🚀 Deploy console on merge
 # carefully — do NOT extend this workflow to them without a deliberate decision.
 #
 # How it works:
-#   - Fires on a PR closed against `newjitsu`, but only acts when the PR was
+#   - Fires when a PR against `newjitsu` is closed, but only acts when the PR was
 #     actually merged AND carries the `deploy:console` label.
 #   - Dispatches jitsu-cloud-infra's deploy.yaml with version=beta, which builds
 #     a fresh beta image from newjitsu HEAD (now including the merged change) and
@@ -27,7 +27,13 @@ name: 🚀 Deploy console on merge
 #   new-release-notify.yaml in that repo.
 
 on:
-  pull_request:
+  # pull_request_target, not pull_request: a PR opened from a fork runs the
+  # `pull_request` event WITHOUT repository secrets, which would leave
+  # DEPLOY_GITHUB_TOKEN empty and the dispatch step failing. pull_request_target
+  # runs in the base-repo context with secrets available. It's safe here because
+  # this job never checks out or executes any PR-supplied code — it only reads
+  # event metadata (the merged flag and labels) and dispatches a workflow.
+  pull_request_target:
     types: [closed]
     branches: [newjitsu]
 
@@ -51,6 +57,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
+
+          # Stamp the time just before dispatching so we can later pick out *our*
+          # run rather than whatever happens to be newest repo-wide (another
+          # deploy could be dispatched around the same time).
+          SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
           gh workflow run deploy.yaml \
             --repo jitsucom/jitsu-cloud-infra \
             --ref main \
@@ -61,15 +73,26 @@ jobs:
 
           echo "Dispatched console beta deploy for PR #${PR_NUMBER}"
 
-          # Give GitHub a moment to register the run, then grab its URL so we can
-          # link it from the PR (mirrors services.yaml's notify step).
-          sleep 5
-          RUN_URL=$(gh run list \
-            --repo jitsucom/jitsu-cloud-infra \
-            --workflow deploy.yaml \
-            --limit 1 \
-            --json url \
-            --jq '.[0].url' || true)
+          # workflow_dispatch doesn't return a run id, so resolve it best-effort:
+          # poll for the newest workflow_dispatch run of deploy.yaml created at or
+          # after SINCE. If indexing lags and we can't find it, fall back to the
+          # workflow's runs page — never emit an empty or literal `null` URL.
+          WORKFLOW_PAGE="${GITHUB_SERVER_URL}/jitsucom/jitsu-cloud-infra/actions/workflows/deploy.yaml"
+          RUN_URL=""
+          for _ in 1 2 3 4 5 6; do
+            sleep 5
+            RUN_URL=$(gh run list \
+              --repo jitsucom/jitsu-cloud-infra \
+              --workflow deploy.yaml \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json url,createdAt \
+              --jq "[.[] | select(.createdAt >= \"$SINCE\")] | sort_by(.createdAt) | last | .url // empty" 2>/dev/null || echo "")
+            if [ -n "$RUN_URL" ]; then
+              break
+            fi
+          done
+          [ -n "$RUN_URL" ] || RUN_URL="$WORKFLOW_PAGE"
           echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
 
       - name: 💬 Link the deploy run on the PR
@@ -81,4 +104,4 @@ jobs:
         run: |
           set -eu
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "🚀 \`deploy:console\` label detected — triggered a **beta** console deployment to jitsu-cloud-infra.${RUN_URL:+ Track it here: ${RUN_URL}}"
+            --body "🚀 \`deploy:console\` label detected — triggered a **beta** console deployment to jitsu-cloud-infra. Track it here: ${RUN_URL}"

--- a/.github/workflows/deploy-console-on-merge.yml
+++ b/.github/workflows/deploy-console-on-merge.yml
@@ -73,26 +73,37 @@ jobs:
 
           echo "Dispatched console beta deploy for PR #${PR_NUMBER}"
 
-          # workflow_dispatch doesn't return a run id, so resolve it best-effort:
-          # poll for the newest workflow_dispatch run of deploy.yaml created at or
-          # after SINCE. If indexing lags and we can't find it, fall back to the
-          # workflow's runs page — never emit an empty or literal `null` URL.
-          WORKFLOW_PAGE="${GITHUB_SERVER_URL}/jitsucom/jitsu-cloud-infra/actions/workflows/deploy.yaml"
+          # workflow_dispatch doesn't return a run id, and deploy.yaml is a shared
+          # workflow we don't want to alter just to thread a correlation nonce —
+          # so we resolve the run *conservatively*: poll for deploy.yaml
+          # workflow_dispatch runs created at/after SINCE, and only link a
+          # specific run when there's exactly one candidate (unambiguously ours).
+          # If a concurrent deploy was dispatched around the same time (>1
+          # candidate) we refuse to guess, and if none is indexed yet we keep
+          # polling — either way the fallback is the filtered runs page. We never
+          # attach a wrong, empty, or literal `null` URL.
+          RUNS_PAGE="${GITHUB_SERVER_URL}/jitsucom/jitsu-cloud-infra/actions/workflows/deploy.yaml?query=event%3Aworkflow_dispatch"
           RUN_URL=""
           for _ in 1 2 3 4 5 6; do
             sleep 5
-            RUN_URL=$(gh run list \
+            CANDIDATES=$(gh run list \
               --repo jitsucom/jitsu-cloud-infra \
               --workflow deploy.yaml \
               --event workflow_dispatch \
-              --limit 20 \
+              --limit 30 \
               --json url,createdAt \
-              --jq "[.[] | select(.createdAt >= \"$SINCE\")] | sort_by(.createdAt) | last | .url // empty" 2>/dev/null || echo "")
-            if [ -n "$RUN_URL" ]; then
+              --jq "[.[] | select(.createdAt >= \"$SINCE\") | .url]" 2>/dev/null || echo "[]")
+            COUNT=$(printf '%s' "$CANDIDATES" | jq 'length')
+            if [ "$COUNT" = "1" ]; then
+              RUN_URL=$(printf '%s' "$CANDIDATES" | jq -r '.[0]')
+              break
+            elif [ "$COUNT" -gt 1 ]; then
+              # Ambiguous — a concurrent dispatch exists; don't risk the wrong run.
               break
             fi
+            # COUNT == 0: not indexed yet, keep polling.
           done
-          [ -n "$RUN_URL" ] || RUN_URL="$WORKFLOW_PAGE"
+          [ -n "$RUN_URL" ] || RUN_URL="$RUNS_PAGE"
           echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
 
       - name: 💬 Link the deploy run on the PR

--- a/.github/workflows/deploy-console-on-merge.yml
+++ b/.github/workflows/deploy-console-on-merge.yml
@@ -25,6 +25,20 @@ name: 🚀 Deploy console on merge
 #   DEPLOY_GITHUB_TOKEN — org-level token with actions:write on
 #   jitsucom/jitsu-cloud-infra. Already used by services.yaml to dispatch
 #   new-release-notify.yaml in that repo.
+#
+# Security / fork PRs:
+#   This uses pull_request_target (see the trigger comment below) so that secrets
+#   are available even when the merged PR came from a fork — under plain
+#   pull_request, fork PRs run with no secrets and a read-only GITHUB_TOKEN, so
+#   both the dispatch and the PR comment would fail. pull_request_target is safe
+#   here ONLY because the job runs the workflow definition from the base branch
+#   (newjitsu), never checks out the PR head, and never executes any
+#   contributor-supplied code — it reads event metadata (merged flag, labels) and
+#   dispatches. Do NOT add `actions/checkout` of the PR ref or run PR code in this
+#   workflow: that would expose the secrets above to untrusted forks.
+#   In practice a deploy still can't be self-triggered by an outside contributor:
+#   both gates — adding the `deploy:console` label and merging into newjitsu —
+#   require write/triage access, so a maintainer is always in the loop.
 
 on:
   # pull_request_target, not pull_request: a PR opened from a fork runs the

--- a/.github/workflows/deploy-console-on-merge.yml
+++ b/.github/workflows/deploy-console-on-merge.yml
@@ -63,6 +63,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # `gh pr comment` posts via the GraphQL addComment mutation (governed by
+      # pull-requests: write), but the REST issue-comments path it can fall back
+      # to is governed by issues: write. Grant both so the comment step can't
+      # fail at runtime on a permissions edge — the token is ephemeral and
+      # repo-scoped, so the extra scope is cheap.
+      issues: write
     steps:
       - name: 🚀 Dispatch jitsu-cloud-infra deploy.yaml
         id: dispatch

--- a/.github/workflows/deploy-console-on-merge.yml
+++ b/.github/workflows/deploy-console-on-merge.yml
@@ -72,11 +72,6 @@ jobs:
         run: |
           set -eu
 
-          # Stamp the time just before dispatching so we can later pick out *our*
-          # run rather than whatever happens to be newest repo-wide (another
-          # deploy could be dispatched around the same time).
-          SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
           gh workflow run deploy.yaml \
             --repo jitsucom/jitsu-cloud-infra \
             --ref main \
@@ -87,40 +82,18 @@ jobs:
 
           echo "Dispatched console beta deploy for PR #${PR_NUMBER}"
 
-          # workflow_dispatch doesn't return a run id, and deploy.yaml is a shared
-          # workflow we don't want to alter just to thread a correlation nonce —
-          # so we resolve the run *conservatively*: poll for deploy.yaml
-          # workflow_dispatch runs created at/after SINCE, and only link a
-          # specific run when there's exactly one candidate (unambiguously ours).
-          # If a concurrent deploy was dispatched around the same time (>1
-          # candidate) we refuse to guess, and if none is indexed yet we keep
-          # polling — either way the fallback is the filtered runs page. We never
-          # attach a wrong, empty, or literal `null` URL.
-          RUNS_PAGE="${GITHUB_SERVER_URL}/jitsucom/jitsu-cloud-infra/actions/workflows/deploy.yaml?query=event%3Aworkflow_dispatch"
-          RUN_URL=""
-          for _ in 1 2 3 4 5 6; do
-            sleep 5
-            CANDIDATES=$(gh run list \
-              --repo jitsucom/jitsu-cloud-infra \
-              --workflow deploy.yaml \
-              --event workflow_dispatch \
-              --limit 30 \
-              --json url,createdAt \
-              --jq "[.[] | select(.createdAt >= \"$SINCE\") | .url]" 2>/dev/null || echo "[]")
-            COUNT=$(printf '%s' "$CANDIDATES" | jq 'length')
-            if [ "$COUNT" = "1" ]; then
-              RUN_URL=$(printf '%s' "$CANDIDATES" | jq -r '.[0]')
-              break
-            elif [ "$COUNT" -gt 1 ]; then
-              # Ambiguous — a concurrent dispatch exists; don't risk the wrong run.
-              break
-            fi
-            # COUNT == 0: not indexed yet, keep polling.
-          done
-          [ -n "$RUN_URL" ] || RUN_URL="$RUNS_PAGE"
+          # Link the deploy.yaml runs page (filtered to manual dispatches) rather
+          # than a specific run. workflow_dispatch returns no run id, and without
+          # a correlation nonce threaded through the shared deploy.yaml there is
+          # no way to *positively* identify our run — any heuristic
+          # (newest-after-timestamp, single-candidate-after-timestamp, etc.) can
+          # mis-attribute under concurrency or API indexing lag and link someone
+          # else's deploy. The run we just dispatched sorts to the top of this
+          # list, so the page is both always-correct and good enough to find it.
+          RUN_URL="${GITHUB_SERVER_URL}/jitsucom/jitsu-cloud-infra/actions/workflows/deploy.yaml?query=event%3Aworkflow_dispatch"
           echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
 
-      - name: 💬 Link the deploy run on the PR
+      - name: 💬 Link the deploy runs on the PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -129,4 +102,4 @@ jobs:
         run: |
           set -eu
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "🚀 \`deploy:console\` label detected — triggered a **beta** console deployment to jitsu-cloud-infra. Track it here: ${RUN_URL}"
+            --body "🚀 \`deploy:console\` label detected — triggered a **beta** console deployment to jitsu-cloud-infra. Track it in the deploy runs (newest at top): ${RUN_URL}"

--- a/.github/workflows/deploy-console-on-merge.yml
+++ b/.github/workflows/deploy-console-on-merge.yml
@@ -1,0 +1,84 @@
+name: 🚀 Deploy console on merge
+
+# Auto-deploy the console to the beta environment when a PR labeled
+# `deploy:console` is merged into newjitsu. Removes the easily-forgotten manual
+# step of triggering jitsu-cloud-infra's deploy workflow after a merge — by the
+# time someone remembers, the momentum (and the context for catching post-deploy
+# bugs) is gone. See JITSU-68.
+#
+# Scope is intentionally limited to `console`: its error tolerance is high (a
+# brief outage doesn't drop data). `bulker` / `rotor` deploy manually and more
+# carefully — do NOT extend this workflow to them without a deliberate decision.
+#
+# How it works:
+#   - Fires on a PR closed against `newjitsu`, but only acts when the PR was
+#     actually merged AND carries the `deploy:console` label.
+#   - Dispatches jitsu-cloud-infra's deploy.yaml with version=beta, which builds
+#     a fresh beta image from newjitsu HEAD (now including the merged change) and
+#     deploys + syncs it. A fresh build is what's needed here: lint.yml only
+#     auto-publishes a beta when a *.version.json file is bumped, so an ordinary
+#     console fix produces no beta image on its own. version=beta also keeps this
+#     race-free — the deployed image is guaranteed to contain exactly the merged
+#     code, rather than whatever beta tag happened to exist before.
+#
+# Secret:
+#   DEPLOY_GITHUB_TOKEN — org-level token with actions:write on
+#   jitsucom/jitsu-cloud-infra. Already used by services.yaml to dispatch
+#   new-release-notify.yaml in that repo.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [newjitsu]
+
+jobs:
+  deploy-console:
+    name: 🚀 Trigger console beta deploy
+    # Only on a real merge with the opt-in label. PRs closed without merging,
+    # or merged without the label, are no-ops.
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'deploy:console')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: 🚀 Dispatch jitsu-cloud-infra deploy.yaml
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          gh workflow run deploy.yaml \
+            --repo jitsucom/jitsu-cloud-infra \
+            --ref main \
+            -f services=console \
+            -f version=beta \
+            -f dry_run=false \
+            -f sync_argocd=true
+
+          echo "Dispatched console beta deploy for PR #${PR_NUMBER}"
+
+          # Give GitHub a moment to register the run, then grab its URL so we can
+          # link it from the PR (mirrors services.yaml's notify step).
+          sleep 5
+          RUN_URL=$(gh run list \
+            --repo jitsucom/jitsu-cloud-infra \
+            --workflow deploy.yaml \
+            --limit 1 \
+            --json url \
+            --jq '.[0].url' || true)
+          echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: 💬 Link the deploy run on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ steps.dispatch.outputs.run_url }}
+        run: |
+          set -eu
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "🚀 \`deploy:console\` label detected — triggered a **beta** console deployment to jitsu-cloud-infra.${RUN_URL:+ Track it here: ${RUN_URL}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,14 @@ name: 📤 Publish
 
 # Single trigger entry point for releases. Two ways in:
 #
-#   1. Automatic — lint.yml dispatches this after lint+test pass on push to
-#      newjitsu, with no inputs. The detect job inspects the latest commit
-#      and decides what to publish (services and/or client-libraries) and
-#      under which channel (stable if the relevant .version.json was bumped,
-#      otherwise beta).
+#   1. Automatic — on a push to newjitsu, lint.yml dispatches this only when a
+#      version file (.services.version.json / .jsclient.version.json) was bumped
+#      in that push, after lint+test pass. It forwards the push range
+#      (from_sha/to_sha); the detect job diffs that range and decides what to
+#      publish (services and/or client-libraries) and under which channel
+#      (stable if the matching .version.json was bumped, otherwise beta).
+#      Commits that don't bump a version file publish nothing — use a manual
+#      dispatch (below) for off-cycle canary/beta builds.
 #
 #   2. Manual — via the Actions UI (workflow_dispatch). Pick scope and channel
 #      explicitly, e.g. canary builds from a feature branch, or force a stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,3 +141,20 @@ go test ./...
 When you need to create branches, make commits, or open pull requests, read
 [CONTRIBUTING.md](CONTRIBUTING.md) first. No need to read it for code exploration —
 only when interacting with git.
+
+## Deployments
+
+The console can be auto-deployed to **beta** on PR merge via the
+[`deploy-console-on-merge`](.github/workflows/deploy-console-on-merge.yml)
+workflow: any PR carrying the **`deploy:console`** label triggers a beta console
+deployment in `jitsu-cloud-infra` the moment it merges into `newjitsu`. This
+exists because the post-merge deploy step is easy to forget, so fixes sit
+undeployed for weeks (see JITSU-68). It's scoped to `console` only — its error
+tolerance is high (a brief outage doesn't drop data); `bulker` and `rotor` still
+deploy manually and deliberately.
+
+**When you open a PR (including a draft), explicitly ask the user whether they
+want the console to auto-deploy on merge.** If yes, add the `deploy:console`
+label to the PR (e.g. `gh pr edit <pr> --add-label deploy:console`). Only offer
+this for PRs that actually touch the console; never add the label to `bulker` /
+`rotor` changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,11 @@ Each pipeline publishes to three channels determined by the branch:
 - The base version `X.Y` is defined in `.services.version.json` or `.jsclient.version.json`;
   `Z` is the patch number, incremented per release
 
-Builds are triggered automatically by [lint.yml](.github/workflows/lint.yml) after tests
-pass on `newjitsu` or the stable branches. On a successful beta or stable release, a
-GitHub release is created and the infra repo is notified via webhook to update deployment
-configs.
+Builds are **not** produced on every merge. A push to `newjitsu` publishes only when a
+version file (`.services.version.json` or `.jsclient.version.json`) is bumped in that
+push: [lint.yml](.github/workflows/lint.yml) waits for tests to pass, then dispatches
+[publish.yml](.github/workflows/publish.yml), which builds the affected stack(s) — stable
+if the matching version file changed, otherwise beta. Commits that don't bump a version
+file publish nothing; trigger off-cycle canary/beta builds with a manual `publish.yml`
+dispatch. On a successful beta or stable release, a GitHub release is created and the infra
+repo is notified via webhook to update deployment configs.


### PR DESCRIPTION
## Problem

After merging a console fix, the deploy still has to be triggered manually from
[`jitsu-cloud-infra`'s deploy workflow](https://github.com/jitsucom/jitsu-cloud-infra/actions/workflows/deploy.yaml).
That step is easy to forget — PRs end up deployed weeks later, after the
momentum (and the context for catching post-deploy bugs) is gone.

Closes JITSU-68.

## Solution

- **New workflow** `.github/workflows/deploy-console-on-merge.yml` — fires on a
  PR closed against `newjitsu`, acts only when the PR was **merged** and carries
  the **`deploy:console`** label. It dispatches `jitsu-cloud-infra/deploy.yaml`
  with `services=console version=beta dry_run=false sync_argocd=true`, then
  comments the deploy-run link back on the PR.
- **`AGENTS.md`** — new "Deployments" section documenting the label and
  instructing the agent to ask, on PR creation (incl. draft), whether to
  auto-deploy console on merge.
- **`deploy:console` label** created on `jitsucom/jitsu`.

Scoped to `console` only — its error tolerance is high (a brief outage doesn't
drop data). `bulker` / `rotor` still deploy manually and deliberately.

## Notes

- Uses the existing org `DEPLOY_GITHUB_TOKEN` secret, which already has
  `actions:write` on `jitsu-cloud-infra` (used by `services.yaml` to dispatch
  `new-release-notify.yaml`).
- `version=beta` builds a fresh image from `newjitsu` HEAD rather than deploying
  an existing tag. This is necessary: `lint.yml` only auto-publishes a beta when
  a `*.version.json` file is bumped, so an ordinary console fix produces no beta
  image on its own. Building fresh is also race-free — the deployed image is
  guaranteed to contain exactly the merged code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
