### PR TITLE
JITSU-70: require work email on signup

### DIFF
--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -1,39 +1,60 @@
 import React, { ReactNode, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Alert, Button, Divider, Input } from "antd";
+import { Alert, Button, Divider, Input, Tooltip } from "antd";
 import { branding } from "../../lib/branding";
-import { useFirebaseSession } from "../../lib/firebase-client";
+import { PersonalEmailRejectedError, useFirebaseSession } from "../../lib/firebase-client";
 import { safeRedirect } from "../../lib/auth-redirect";
 import { useJitsu } from "@jitsu/jitsu-react";
 import { OAuthButtons } from "./OAuthButtons";
 import { SignupMarketingPanel } from "./SignupMarketingPanel";
 import { AuthType, handleFirebaseError } from "./SignInOrUp";
 import { useQueryStringCopy } from "./use-query-string-copy";
+import { getErrorMessage, rpc } from "juava";
+import { CreateUserResult } from "../../lib/schema";
+import { useAppConfig } from "../../lib/context";
+import { Briefcase } from "lucide-react";
 
-export const FirebaseSignup: React.FC = () => {
+export const FirebaseSignup: React.FC<{ initialError?: ReactNode }> = ({ initialError }) => {
   const router = useRouter();
   const firebaseSession = useFirebaseSession();
   const { analytics } = useJitsu();
   const queryStringCopy = useQueryStringCopy();
+  const appConfig = useAppConfig();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
-  const [error, setError] = useState<ReactNode | null>(null);
+  const [error, setError] = useState<ReactNode | null>(initialError ?? null);
   const [submitting, setSubmitting] = useState(false);
+  const [checking, setChecking] = useState(false);
   const [emailConfirmed, setEmailConfirmed] = useState(false);
 
   const callbackUrl = (router.query.callbackUrl as string) || "/";
 
-  // Step 1 → 2: reveal the password fields only once a plausible email is entered.
-  const handleContinue = () => {
+  // Step 1 → 2: reveal the password fields only once a plausible email is
+  // entered. JITSU-70: ask the server whether this email may sign up before
+  // creating any Firebase account, so a personal-email signup is refused here
+  // rather than after a wasted verification email.
+  const handleContinue = async () => {
     if (!email || !email.includes("@")) {
       setError("Please enter a valid email address");
       return;
     }
     setError(null);
-    setEmailConfirmed(true);
+    setChecking(true);
+    try {
+      const result: CreateUserResult = await rpc("/api/auth/signup-email-check", { body: { email } });
+      if (!result.ok && result.rejected === "personal-email") {
+        setError(result.message);
+        return;
+      }
+      setEmailConfirmed(true);
+    } catch (e: any) {
+      setError(getErrorMessage(e) || "Something went wrong, please try again");
+    } finally {
+      setChecking(false);
+    }
   };
 
   const validate = (): string | null => {
@@ -105,6 +126,14 @@ export const FirebaseSignup: React.FC = () => {
       await firebaseSession.signInWith(provider === "firebase-google" ? "google.com" : "github.com");
       safeRedirect(router, callbackUrl);
     } catch (e: any) {
+      // JITSU-70: the server refused a personal-email Google signup and already
+      // deleted the Firebase account. Show the message and clear the now-stale
+      // client session so a retry with a work email starts clean.
+      if (e instanceof PersonalEmailRejectedError) {
+        setError(e.message);
+        await firebaseSession.signOut();
+        return;
+      }
       setError(handleFirebaseError(e));
       await analytics.track("login_error", {
         type: "social",
@@ -127,27 +156,44 @@ export const FirebaseSignup: React.FC = () => {
         </div>
 
         <div className="flex flex-1 justify-center px-6">
-          <div className="my-auto w-full max-w-[420px] py-8">
-            <div className="mb-6 h-12 w-12 drop-shadow-sm">{branding.logo}</div>
+          <div className="w-full max-w-[420px] py-6">
+            <div className="mb-4 h-10 w-10 drop-shadow-sm">{branding.logo}</div>
 
-            <h1 className="font-header text-3xl xl:text-4xl font-bold leading-tight text-textDark">
+            <h1 className="font-header text-2xl xl:text-3xl font-bold leading-tight text-textDark">
               Join 8,000+ teams shipping data with Jitsu.
             </h1>
-            <p className="mt-3 text-textLight">Free for 200k events/month. No credit card required.</p>
+            <p className="mt-2 text-textLight">Free for 200k events/month. No credit card required.</p>
+
+            {error && (
+              <Alert className="mt-4" type="error" showIcon message={error} closable onClose={() => setError(null)} />
+            )}
 
             <div className="mt-4">
               <OAuthButtons
                 prefix="Continue"
                 providers={["firebase-google", "firebase-github"]}
                 onSSOLogin={handleSSOLogin}
+                notes={
+                  appConfig.limitPersonalEmails
+                    ? {
+                        "firebase-google": (
+                          <Tooltip title="Work email required">
+                            <span className="flex h-5 w-5 cursor-help items-center justify-center rounded-full bg-primary text-white shadow-sm ring-2 ring-white">
+                              <Briefcase className="h-3 w-3" />
+                            </span>
+                          </Tooltip>
+                        ),
+                      }
+                    : undefined
+                }
               />
             </div>
 
-            <Divider plain>
+            <Divider plain className="!my-4">
               <span className="text-xs uppercase tracking-widest text-textLight">or with email</span>
             </Divider>
 
-            <div className="space-y-4">
+            <div className="space-y-3">
               <div>
                 <label className="mb-1.5 block text-sm font-semibold text-textDark">Work email</label>
                 <Input
@@ -172,8 +218,9 @@ export const FirebaseSignup: React.FC = () => {
                   block
                   type="primary"
                   size="large"
+                  loading={checking}
                   onClick={handleContinue}
-                  disabled={!email || !email.includes("@")}
+                  disabled={!email || !email.includes("@") || checking}
                 >
                   Continue →
                 </Button>
@@ -228,8 +275,6 @@ export const FirebaseSignup: React.FC = () => {
                   </Button>
                 </>
               )}
-
-              {error && <Alert type="error" message={error} closable onClose={() => setError(null)} />}
 
               <p className="text-center text-xs text-textLight">
                 By signing up, you agree to our{" "}

--- a/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
+++ b/webapps/console/components/SignInOrUp/FirebaseSignup.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Alert, Button, Divider, Input, Tooltip } from "antd";
 import { branding } from "../../lib/branding";
-import { PersonalEmailRejectedError, useFirebaseSession } from "../../lib/firebase-client";
+import { useFirebaseSession } from "../../lib/firebase-client";
 import { safeRedirect } from "../../lib/auth-redirect";
 import { useJitsu } from "@jitsu/jitsu-react";
 import { OAuthButtons } from "./OAuthButtons";
@@ -123,17 +123,17 @@ export const FirebaseSignup: React.FC<{ initialError?: ReactNode }> = ({ initial
   const handleSSOLogin = async (provider: AuthType) => {
     setError(null);
     try {
-      await firebaseSession.signInWith(provider === "firebase-google" ? "google.com" : "github.com");
-      safeRedirect(router, callbackUrl);
-    } catch (e: any) {
+      const result = await firebaseSession.signInWith(provider === "firebase-google" ? "google.com" : "github.com");
       // JITSU-70: the server refused a personal-email Google signup and already
       // deleted the Firebase account. Show the message and clear the now-stale
       // client session so a retry with a work email starts clean.
-      if (e instanceof PersonalEmailRejectedError) {
-        setError(e.message);
+      if (result.status === "personal-email-rejected") {
+        setError(result.message);
         await firebaseSession.signOut();
         return;
       }
+      safeRedirect(router, callbackUrl);
+    } catch (e: any) {
       setError(handleFirebaseError(e));
       await analytics.track("login_error", {
         type: "social",

--- a/webapps/console/components/SignInOrUp/OAuthButtons.tsx
+++ b/webapps/console/components/SignInOrUp/OAuthButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { ReactNode, useState } from "react";
 import { Button } from "antd";
 import { GithubOutlined, GoogleOutlined, KeyOutlined } from "@ant-design/icons";
 import { getLog } from "juava";
@@ -6,16 +6,22 @@ import { AuthType } from "./SignInOrUp";
 
 const log = getLog("oauth-buttons");
 
+type OAuthProvider = "firebase-google" | "firebase-github" | "nextauth-github" | "nextauth-oidc";
+
 interface OAuthButtonsProps {
-  providers?: Array<"firebase-google" | "firebase-github" | "nextauth-github" | "nextauth-oidc">;
+  providers?: Array<OAuthProvider>;
   prefix?: string;
   onSSOLogin: (type: AuthType, providerId: string) => Promise<void>;
+  // Optional badge floated over the top of a specific provider's button (e.g.
+  // the work-email hint on "Continue with Google" — JITSU-70).
+  notes?: Partial<Record<OAuthProvider, ReactNode>>;
 }
 
 export const OAuthButtons: React.FC<OAuthButtonsProps> = ({
   providers = ["firebase-google", "firebase-github", "nextauth-github", "nextauth-oidc"],
   prefix = "Sign in",
   onSSOLogin,
+  notes,
 }) => {
   const [loading, setLoading] = useState<string | undefined>();
 
@@ -28,10 +34,27 @@ export const OAuthButtons: React.FC<OAuthButtonsProps> = ({
     }
   };
 
+  // Float the note as a small badge over the button's top-right corner. It's a
+  // sibling of the button (not a child), so it doesn't intercept the button's
+  // click — and it stays interactive so a tooltip on it works.
+  const withBadge = (provider: OAuthProvider, button: ReactNode) => {
+    const note = notes?.[provider];
+    if (!note) {
+      return button;
+    }
+    return (
+      <div key={provider} className="relative flex">
+        {button}
+        <div className="absolute -right-1.5 -top-1.5 z-10">{note}</div>
+      </div>
+    );
+  };
+
   const renderButton = (provider: string) => {
     switch (provider) {
       case "firebase-google":
-        return (
+        return withBadge(
+          "firebase-google",
           <Button
             key={provider}
             loading={loading === "firebase-google"}
@@ -44,7 +67,8 @@ export const OAuthButtons: React.FC<OAuthButtonsProps> = ({
           </Button>
         );
       case "firebase-github":
-        return (
+        return withBadge(
+          "firebase-github",
           <Button
             key={provider}
             size="large"
@@ -57,7 +81,8 @@ export const OAuthButtons: React.FC<OAuthButtonsProps> = ({
           </Button>
         );
       case "nextauth-github":
-        return (
+        return withBadge(
+          "nextauth-github",
           <Button
             key={provider}
             size="large"
@@ -70,7 +95,8 @@ export const OAuthButtons: React.FC<OAuthButtonsProps> = ({
           </Button>
         );
       case "nextauth-oidc":
-        return (
+        return withBadge(
+          "nextauth-oidc",
           <Button
             key={provider}
             size="large"

--- a/webapps/console/components/SignInOrUp/SignInOrUp.tsx
+++ b/webapps/console/components/SignInOrUp/SignInOrUp.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/router";
 import { EmailFirstLogin } from "./EmailFirstLogin";
 import { OAuthButtons } from "./OAuthButtons";
 import { signIn } from "next-auth/react";
-import { EmailNotVerifiedError, PersonalEmailRejectedError, useFirebaseSession } from "../../lib/firebase-client";
+import { useFirebaseSession } from "../../lib/firebase-client";
 import { useJitsu } from "@jitsu/jitsu-react";
 import { useAppConfig } from "../../lib/context";
 import { safeRedirect } from "../../lib/auth-redirect";
@@ -96,12 +96,26 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
           setError("Invalid email or password");
           return;
         }
-        const user = await firebaseSession!.resolveUser().user;
-        if (!user) {
+        const result = await firebaseSession!.resolveUser().user;
+        if (!result) {
           setError("Sign in failed");
+          return;
+        }
+        if (result.status === "personal-email-rejected") {
+          // JITSU-70: the server refused the personal-email account and deleted
+          // it server-side. Clear the stale client session.
+          setError(result.message);
+          await firebaseSession!.signOut();
+          return;
+        }
+        if (result.status === "email-not-verified") {
+          // Hand off to the route gate (FirebaseAuthorizer), which renders the
+          // verification screen.
+          safeRedirect(router, callbackUrl);
+          return;
         }
         await analytics.track("login", {
-          traits: { ...user, type: "password", loginProvider: "firebase/email" },
+          traits: { ...result.user, type: "password", loginProvider: "firebase/email" },
         });
         safeRedirect(router, callbackUrl);
       } else if (type === "nextauth-credentials") {
@@ -125,19 +139,6 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
         setError("Unsupported authentication method");
       }
     } catch (e: any) {
-      if (e instanceof PersonalEmailRejectedError) {
-        // JITSU-70: the server refused the personal-email account and deleted it
-        // server-side. Clear the stale client session.
-        setError(e.message);
-        await firebaseSession!.signOut();
-        return;
-      }
-      if (e instanceof EmailNotVerifiedError) {
-        // Sign-in succeeded but the email is unverified — hand off to the route
-        // gate (FirebaseAuthorizer), which renders the verification screen.
-        safeRedirect(router, callbackUrl);
-        return;
-      }
       if (type === "firebase-password") {
         setError(handleFirebaseError(e));
         await analytics.track("login_error", {
@@ -156,18 +157,26 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
     try {
       switch (provider) {
         case "firebase-google":
-        case "firebase-github":
-          await firebaseSession!.signInWith(provider === "firebase-google" ? "google.com" : "github.com");
-          const user = await firebaseSession!.resolveUser().user;
-          if (!user) {
-            setError("Sign in failed");
+        case "firebase-github": {
+          const result = await firebaseSession!.signInWith(
+            provider === "firebase-google" ? "google.com" : "github.com"
+          );
+          if (result.status === "personal-email-rejected") {
+            // Server refused a personal-email signup and deleted the account —
+            // clear the stale client session.
+            setError(result.message);
+            await firebaseSession!.signOut();
             return;
           }
-          await analytics.track("login", {
-            traits: { ...user, type: "social", loginProvider: `firebase/${provider}` },
-          });
+          if (result.status === "authenticated") {
+            await analytics.track("login", {
+              traits: { ...result.user, type: "social", loginProvider: `firebase/${provider}` },
+            });
+          }
+          // authenticated, or email-not-verified (the route gate handles that)
           safeRedirect(router, callbackUrl);
           break;
+        }
         case "nextauth-github":
           await signIn("github", { callbackUrl }, { ...(loginHint ? { login_hint: loginHint } : {}), prompt: "login" });
           break;
@@ -183,14 +192,6 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
           setError(`Unsupported authentication provider: ${provider}`);
       }
     } catch (e: any) {
-      // JITSU-70: signing up via SSO with a personal email is refused server-side,
-      // which already deleted the Firebase account. Sign out so the deleted user
-      // doesn't linger in the client session and break follow-up fb-auth calls.
-      if (e instanceof PersonalEmailRejectedError) {
-        setError(e.message);
-        await firebaseSession!.signOut();
-        return;
-      }
       if (provider.startsWith("firebase-")) {
         setError(handleFirebaseError(e));
         await analytics.track("login_error", {

--- a/webapps/console/components/SignInOrUp/SignInOrUp.tsx
+++ b/webapps/console/components/SignInOrUp/SignInOrUp.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/router";
 import { EmailFirstLogin } from "./EmailFirstLogin";
 import { OAuthButtons } from "./OAuthButtons";
 import { signIn } from "next-auth/react";
-import { EmailNotVerifiedError, useFirebaseSession } from "../../lib/firebase-client";
+import { EmailNotVerifiedError, PersonalEmailRejectedError, useFirebaseSession } from "../../lib/firebase-client";
 import { useJitsu } from "@jitsu/jitsu-react";
 import { useAppConfig } from "../../lib/context";
 import { safeRedirect } from "../../lib/auth-redirect";
@@ -125,6 +125,13 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
         setError("Unsupported authentication method");
       }
     } catch (e: any) {
+      if (e instanceof PersonalEmailRejectedError) {
+        // JITSU-70: the server refused the personal-email account and deleted it
+        // server-side. Clear the stale client session.
+        setError(e.message);
+        await firebaseSession!.signOut();
+        return;
+      }
       if (e instanceof EmailNotVerifiedError) {
         // Sign-in succeeded but the email is unverified — hand off to the route
         // gate (FirebaseAuthorizer), which renders the verification screen.
@@ -176,6 +183,14 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
           setError(`Unsupported authentication provider: ${provider}`);
       }
     } catch (e: any) {
+      // JITSU-70: signing up via SSO with a personal email is refused server-side,
+      // which already deleted the Firebase account. Sign out so the deleted user
+      // doesn't linger in the client session and break follow-up fb-auth calls.
+      if (e instanceof PersonalEmailRejectedError) {
+        setError(e.message);
+        await firebaseSession!.signOut();
+        return;
+      }
       if (provider.startsWith("firebase-")) {
         setError(handleFirebaseError(e));
         await analytics.track("login_error", {

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -11,36 +11,21 @@ export type FirebaseProviderInstance =
   | { enabled: true; settings: FirebaseClientSettings };
 
 /**
- * Thrown by {@link getUserFromFirebase} when an email+password account signs in
- * before its email address has been verified. OAuth providers (Google, GitHub)
- * verify the address themselves, so the check only applies to the `password`
- * provider. See JITSU-018.
+ * Outcome of resolving the current Firebase user into a Jitsu session. Returned
+ * (not thrown) so callers branch on `status` instead of catching control-flow
+ * exceptions. Genuine failures (popup closed, network, etc.) still reject.
+ *
+ * - `authenticated` — a Jitsu user is ready.
+ * - `email-not-verified` — a single-provider password account hasn't verified
+ *   its email yet (JITSU-018); the caller should show the verification gate.
+ * - `personal-email-rejected` — the server refused a personal-email signup and
+ *   already deleted the orphaned Firebase account (JITSU-70); the caller should
+ *   surface `message` and sign the stale client session out.
  */
-export class EmailNotVerifiedError extends Error {
-  readonly email: string;
-
-  constructor(email: string) {
-    super(`Email ${email} is not verified`);
-    this.name = "EmailNotVerifiedError";
-    this.email = email;
-  }
-}
-
-/**
- * Thrown by {@link getUserFromFirebase} when the server refuses a signup because
- * it came from a personal email domain and a work email is required (JITSU-70).
- * The server has already deleted the orphaned Firebase account by this point, so
- * callers should surface {@link message} and sign the stale client session out.
- */
-export class PersonalEmailRejectedError extends Error {
-  readonly email: string;
-
-  constructor(message: string, email: string) {
-    super(message);
-    this.name = "PersonalEmailRejectedError";
-    this.email = email;
-  }
-}
+export type FirebaseAuthResult =
+  | { status: "authenticated"; user: ContextApiResponse["user"] }
+  | { status: "email-not-verified"; email: string }
+  | { status: "personal-email-rejected"; message: string };
 
 const FirebaseContext = createContext<FirebaseProviderInstance | null>(null);
 
@@ -74,7 +59,7 @@ export interface FirebaseSession {
    */
   signUp(email: string, password: string): Promise<void>;
 
-  signInWith(type: string): Promise<void>;
+  signInWith(type: string): Promise<FirebaseAuthResult>;
 
   signOut(): Promise<void>;
 
@@ -104,7 +89,7 @@ export interface FirebaseSession {
   /**
    * Waits until auth state of the user is resolved
    */
-  resolveUser(token?: string): { user: Promise<ContextApiResponse["user"] | null>; cleanup: () => void };
+  resolveUser(token?: string): { user: Promise<FirebaseAuthResult | null>; cleanup: () => void };
 }
 
 export function getFirebaseAuth(config: FirebaseClientSettings): typeof auth {
@@ -140,7 +125,7 @@ function emailActionSettings(): auth.ActionCodeSettings | undefined {
   return undefined;
 }
 
-async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiResponse["user"]> {
+async function getUserFromFirebase(currentUser: auth.User): Promise<FirebaseAuthResult> {
   const email = requireDefined(currentUser.email, "email of firebase user is undefined");
   // JITSU-018: email+password sign-up issues a valid Firebase JWT before the
   // address is verified. Block such accounts here — before any internal user or
@@ -149,7 +134,7 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiRe
   const providerData = currentUser.providerData;
   const isPasswordOnly = providerData.length === 1 && providerData[0]?.providerId === "password";
   if (isPasswordOnly && !currentUser.emailVerified) {
-    throw new EmailNotVerifiedError(email);
+    return { status: "email-not-verified", email };
   }
   let internalId = await getCustomClaim(currentUser, "internalId");
   let shouldRefreshToken = false;
@@ -165,10 +150,10 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiRe
       },
     });
     // JITSU-70: the server refused a personal-email signup and already deleted
-    // the Firebase account. Unwind via a typed error the authorizer / signup
-    // handlers can render.
+    // the Firebase account. Report it as a result the authorizer / signup
+    // handlers branch on.
     if (!createResult.ok && createResult.rejected === "personal-email") {
-      throw new PersonalEmailRejectedError(createResult.message, email);
+      return { status: "personal-email-rejected", message: createResult.message };
     }
     const newToken = await currentUser.getIdTokenResult(true);
     internalId = newToken.claims.internalId as string;
@@ -191,13 +176,16 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiRe
   log.atDebug().log(`Firebase token expires in ${expirationMs / (1000 * 60)}min, at ${expirationTime.toISOString()}`);
 
   return {
-    email,
-    externalId: currentUser.uid,
-    externalUsername: email,
-    image: currentUser.photoURL,
-    internalId,
-    loginProvider: "firebase/" + currentUser.providerData[0]?.providerId,
-    name: currentUser.displayName || email,
+    status: "authenticated",
+    user: {
+      email,
+      externalId: currentUser.uid,
+      externalUsername: email,
+      image: currentUser.photoURL,
+      internalId,
+      loginProvider: "firebase/" + currentUser.providerData[0]?.providerId,
+      name: currentUser.displayName || email,
+    },
   };
 }
 
@@ -284,18 +272,20 @@ export function useFirebaseSession(): FirebaseSession {
   const a = getFirebaseAuth(config);
 
   return {
-    async signInWith(type: string): Promise<void> {
+    async signInWith(type: string): Promise<FirebaseAuthResult> {
       try {
-        let user;
         if (type === "github.com") {
-          user = await a.signInWithPopup(a.getAuth(), new auth.GithubAuthProvider());
+          await a.signInWithPopup(a.getAuth(), new auth.GithubAuthProvider());
         } else {
-          user = await a.signInWithPopup(a.getAuth(), new auth.GoogleAuthProvider());
+          await a.signInWithPopup(a.getAuth(), new auth.GoogleAuthProvider());
         }
         await recordFirebaseLogin(a.getAuth().currentUser);
-        const firebaseUser = await getUserFromFirebase(a.getAuth().currentUser!);
-        await analytics.identify(firebaseUser.internalId, { email: firebaseUser.email, name: firebaseUser.name });
-        await analytics.track("login");
+        const result = await getUserFromFirebase(a.getAuth().currentUser!);
+        if (result.status === "authenticated") {
+          await analytics.identify(result.user.internalId, { email: result.user.email, name: result.user.name });
+          await analytics.track("login");
+        }
+        return result;
       } catch (e) {
         log.atError().withCause(e).log(`Can't sign in with ${type}`);
         throw e;
@@ -303,7 +293,7 @@ export function useFirebaseSession(): FirebaseSession {
     },
     resolveUser(token?: string) {
       log.atDebug().log("Authorizing through firebase...");
-      const userPromise: Promise<ContextApiResponse["user"] | null> = new Promise(async (resolve, reject) => {
+      const userPromise: Promise<FirebaseAuthResult | null> = new Promise(async (resolve, reject) => {
         if (token) {
           await auth.signInWithCustomToken(auth.getAuth(), token);
         }
@@ -314,9 +304,9 @@ export function useFirebaseSession(): FirebaseSession {
             try {
               resolve(user ? await getUserFromFirebase(user) : null);
             } catch (e) {
-              // getUserFromFirebase rejecting (e.g. EmailNotVerifiedError) must
-              // reject the outer promise — without this catch the throw escapes
-              // the async callback as an unhandled rejection and the caller hangs.
+              // Genuine errors (token mint, network) must reject the outer
+              // promise — without this catch the throw escapes the async callback
+              // as an unhandled rejection and the caller hangs.
               reject(e);
             } finally {
               unregister();

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -1,7 +1,7 @@
 import { createContext, PropsWithChildren, useContext } from "react";
 import { getApps, initializeApp } from "firebase/app";
 import * as auth from "firebase/auth";
-import { AppConfig, ContextApiResponse } from "./schema";
+import { AppConfig, ContextApiResponse, CreateUserResult } from "./schema";
 import { getLog, randomId, requireDefined, rpc } from "juava";
 import { useJitsu } from "@jitsu/jitsu-react";
 
@@ -22,6 +22,22 @@ export class EmailNotVerifiedError extends Error {
   constructor(email: string) {
     super(`Email ${email} is not verified`);
     this.name = "EmailNotVerifiedError";
+    this.email = email;
+  }
+}
+
+/**
+ * Thrown by {@link getUserFromFirebase} when the server refuses a signup because
+ * it came from a personal email domain and a work email is required (JITSU-70).
+ * The server has already deleted the orphaned Firebase account by this point, so
+ * callers should surface {@link message} and sign the stale client session out.
+ */
+export class PersonalEmailRejectedError extends Error {
+  readonly email: string;
+
+  constructor(message: string, email: string) {
+    super(message);
+    this.name = "PersonalEmailRejectedError";
     this.email = email;
   }
 }
@@ -139,7 +155,7 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiRe
   let shouldRefreshToken = false;
   if (!internalId) {
     log.atInfo().log(`Firebase user ${currentUser.uid} / ${email} doesn't have internalId, requesting...`);
-    await rpc(`/api/fb-auth/create-user`, {
+    const createResult: CreateUserResult = await rpc(`/api/fb-auth/create-user`, {
       body: {},
       headers: {
         // Force-refresh so the token's email_verified claim is current. The
@@ -148,6 +164,12 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<ContextApiRe
         Authorization: `Bearer ${await currentUser.getIdToken(true)}`,
       },
     });
+    // JITSU-70: the server refused a personal-email signup and already deleted
+    // the Firebase account. Unwind via a typed error the authorizer / signup
+    // handlers can render.
+    if (!createResult.ok && createResult.rejected === "personal-email") {
+      throw new PersonalEmailRejectedError(createResult.message, email);
+    }
     const newToken = await currentUser.getIdTokenResult(true);
     internalId = newToken.claims.internalId as string;
     log.atDebug().log(`Refreshed firebase token`, newToken);

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -77,6 +77,18 @@ export const noRestrictions: BillingSettings = {
   profileBuilderEnabled: true,
 };
 
+/**
+ * Result of POST /api/fb-auth/create-user. A discriminated union rather than an
+ * HTTP error: `ok: false` is a normal 200 response carrying the reason a signup
+ * was refused (JITSU-70 — personal email rejected), so the client can show a
+ * friendly message instead of treating it as a request failure.
+ */
+export const CreateUserResult = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), rejected: z.literal("personal-email"), message: z.string() }),
+]);
+export type CreateUserResult = z.infer<typeof CreateUserResult>;
+
 export const AppConfig = z.object({
   docsUrl: z.string().optional(),
   websiteUrl: z.string().optional(),
@@ -94,6 +106,9 @@ export const AppConfig = z.object({
     })
     .optional(),
   disableSignup: z.boolean().optional(),
+  // Display-only hint: signup requires a work email (JITSU-70). Enforcement is
+  // server-side; this only drives the badge on the signup form.
+  limitPersonalEmails: z.boolean().optional(),
   customDomainsEnabled: z.boolean().optional(),
   ee: z.object({
     available: z.boolean(),

--- a/webapps/console/lib/server/serverEnv.ts
+++ b/webapps/console/lib/server/serverEnv.ts
@@ -232,6 +232,11 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   // Disable new user registration
   DISABLE_SIGNUP: z.string().default("false").transform(isTruish),
 
+  // Reject signups from personal email domains (require a work email). Applies to
+  // Google and email/password signups; GitHub is exempt (devs often have a
+  // personal email on their GitHub account). See JITSU-70.
+  LIMIT_PERSONAL_EMAILS: z.string().default("false").transform(isTruish),
+
   // Enable MIT-compliant mode (disables proprietary features)
   MIT_COMPLIANT: z.string().default("false").transform(isTruish),
 

--- a/webapps/console/lib/server/signup-restrictions.ts
+++ b/webapps/console/lib/server/signup-restrictions.ts
@@ -2,6 +2,7 @@ import { firebase } from "./firebase-server";
 import { getServerEnv } from "./serverEnv";
 import { isPersonalEmail } from "../shared/email-domains";
 import { getServerLog } from "./log";
+import { db } from "./db";
 
 const log = getServerLog("signup");
 
@@ -39,7 +40,19 @@ export async function shouldRejectPersonalEmailSignup(user: {
   if (!isPersonalEmailSignupBlocked(user)) {
     return false;
   }
+  // Never reject a returning user. An existing account that lost its internalId
+  // custom claim (claim reset / migration) still has a Jitsu profile and must be
+  // relinked, not deleted. Match any Firebase-provider row for this externalId:
+  // create-user stores `firebase`, init-user recovery stores `firebase/<provider>`.
   if (user.externalId) {
+    const existing = await db
+      .prisma()
+      .userProfile.findFirst({ where: { externalId: user.externalId, loginProvider: { startsWith: "firebase" } } });
+    if (existing) {
+      return false;
+    }
+    // Truly new — delete the orphaned Firebase account so nothing lingers
+    // without a Jitsu profile and the user can retry with a work email.
     try {
       await firebase().auth().deleteUser(user.externalId);
     } catch (e) {

--- a/webapps/console/lib/server/signup-restrictions.ts
+++ b/webapps/console/lib/server/signup-restrictions.ts
@@ -1,0 +1,51 @@
+import { firebase } from "./firebase-server";
+import { getServerEnv } from "./serverEnv";
+import { isPersonalEmail } from "../shared/email-domains";
+import { getServerLog } from "./log";
+
+const log = getServerLog("signup");
+
+/**
+ * JITSU-70 policy decision (no side effects): should a signup with this email be
+ * refused because it comes from a personal domain and a work email is required?
+ *
+ * The rule is Firebase-only and exempts GitHub (devs often have a personal email
+ * tied to their GitHub account). Firebase OAuth paths pass the provider as
+ * `firebase/<sign_in_provider>`; the email precheck passes no provider, which is
+ * the email/password path (never GitHub) and is always subject to the check.
+ */
+export function isPersonalEmailSignupBlocked(opts: { email: string; loginProvider?: string | null }): boolean {
+  if (!getServerEnv().LIMIT_PERSONAL_EMAILS) {
+    return false;
+  }
+  const provider = opts.loginProvider ?? "";
+  if (provider && (!provider.startsWith("firebase/") || provider === "firebase/github.com")) {
+    return false;
+  }
+  return isPersonalEmail(opts.email);
+}
+
+/**
+ * Enforcement at a new-profile path (create-user, the init-user remediation
+ * branch). When the signup must be rejected it deletes the orphaned Firebase
+ * account so nothing lingers without a Jitsu profile and the user can retry
+ * cleanly with a work email, then returns true. The caller surfaces the refusal.
+ */
+export async function shouldRejectPersonalEmailSignup(user: {
+  email: string;
+  loginProvider?: string | null;
+  externalId?: string | null;
+}): Promise<boolean> {
+  if (!isPersonalEmailSignupBlocked(user)) {
+    return false;
+  }
+  if (user.externalId) {
+    try {
+      await firebase().auth().deleteUser(user.externalId);
+    } catch (e) {
+      log.atWarn().withCause(e).log(`Failed to delete rejected personal-email firebase user ${user.externalId}`);
+    }
+  }
+  log.atInfo().log(`Rejected personal-email signup: ${user.email} (${user.loginProvider})`);
+  return true;
+}

--- a/webapps/console/lib/shared/email-domains.ts
+++ b/webapps/console/lib/shared/email-domains.ts
@@ -12,3 +12,21 @@ export const publicEmailDomains = [
   "icloud.com",
   "hey.com",
 ];
+
+/**
+ * User-facing copy shown when a signup is refused for using a personal email
+ * (JITSU-70). Kept here (client-safe) so the server endpoints and the signup
+ * form share one wording.
+ */
+export const WORK_EMAIL_REQUIRED_MESSAGE =
+  "Please use your work email to sign up. Personal email addresses (Gmail, Outlook, etc.) aren't accepted.";
+
+/**
+ * Whether an email address belongs to a known personal/consumer provider
+ * (gmail, yahoo, icloud, …) rather than a company domain. Used to enforce the
+ * work-email signup requirement (JITSU-70).
+ */
+export function isPersonalEmail(email: string): boolean {
+  const domain = email.split("@")[1]?.toLowerCase().trim();
+  return !!domain && publicEmailDomains.includes(domain);
+}

--- a/webapps/console/pages/_app.tsx
+++ b/webapps/console/pages/_app.tsx
@@ -105,6 +105,18 @@ const FirebaseAuthorizer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
     }
   }, [router.query.projectName]);
 
+  // JITSU-70: the server already deleted the rejected account, so clear the
+  // stale client session — otherwise `auth().currentUser` stays a deleted user
+  // and later fb-auth calls fail until a refresh. We still render the signup
+  // form below; signing out only resets the in-memory Firebase session.
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    if (result?.status === "personal-email-rejected") {
+      session.signOut();
+    }
+  }, [result?.status]);
+  /* eslint-enable */
+
   if (loading) {
     return <GlobalLoader title={"Authorizing"} />;
   } else if (authError) {

--- a/webapps/console/pages/_app.tsx
+++ b/webapps/console/pages/_app.tsx
@@ -26,8 +26,14 @@ import { AntdTheme } from "../components/AntdTheme/AntdTheme";
 import { AntdModalProvider } from "../lib/modal";
 import Head from "next/head";
 import { JitsuProvider, useJitsu } from "@jitsu/jitsu-react";
-import { EmailNotVerifiedError, FirebaseProvider, useFirebaseSession } from "../lib/firebase-client";
+import {
+  EmailNotVerifiedError,
+  FirebaseProvider,
+  PersonalEmailRejectedError,
+  useFirebaseSession,
+} from "../lib/firebase-client";
 import { VerifyEmailGate } from "../components/SignInOrUp/VerifyEmailGate";
+import { FirebaseSignup } from "../components/SignInOrUp/FirebaseSignup";
 import { JitsuButton } from "../components/JitsuButton/JitsuButton";
 import { BillingProvider } from "../components/Billing/BillingProvider";
 import { useEeApi } from "../lib/eeApi";
@@ -109,6 +115,10 @@ const FirebaseAuthorizer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   } else if (authError) {
     if (authError instanceof EmailNotVerifiedError) {
       return <VerifyEmailGate email={authError.email} />;
+    }
+    if (authError instanceof PersonalEmailRejectedError) {
+      // No special page — drop the user back on the signup form with the note.
+      return <FirebaseSignup initialError={authError.message} />;
     }
     return <GlobalError error={authError} title={"Authorization error"} />;
   } else if (user) {

--- a/webapps/console/pages/_app.tsx
+++ b/webapps/console/pages/_app.tsx
@@ -26,12 +26,7 @@ import { AntdTheme } from "../components/AntdTheme/AntdTheme";
 import { AntdModalProvider } from "../lib/modal";
 import Head from "next/head";
 import { JitsuProvider, useJitsu } from "@jitsu/jitsu-react";
-import {
-  EmailNotVerifiedError,
-  FirebaseProvider,
-  PersonalEmailRejectedError,
-  useFirebaseSession,
-} from "../lib/firebase-client";
+import { FirebaseAuthResult, FirebaseProvider, useFirebaseSession } from "../lib/firebase-client";
 import { VerifyEmailGate } from "../components/SignInOrUp/VerifyEmailGate";
 import { FirebaseSignup } from "../components/SignInOrUp/FirebaseSignup";
 import { JitsuButton } from "../components/JitsuButton/JitsuButton";
@@ -86,7 +81,7 @@ export function Analytics({ user }: { user?: SessionUser }) {
 
 const FirebaseAuthorizer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   const session = useFirebaseSession();
-  const [user, setUser] = useState<ContextApiResponse["user"] | null>();
+  const [result, setResult] = useState<FirebaseAuthResult | null>();
   const [loading, setLoading] = useState<boolean>(true);
   const [authError, setAuthError] = useState<any>(undefined);
   const router = useRouter();
@@ -97,7 +92,7 @@ const FirebaseAuthorizer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   useEffect(() => {
     const { user, cleanup } = session.resolveUser(router.query.token as string);
     user
-      .then(setUser)
+      .then(setResult)
       .catch(setAuthError)
       .finally(() => setLoading(false));
     return cleanup;
@@ -113,21 +108,21 @@ const FirebaseAuthorizer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   if (loading) {
     return <GlobalLoader title={"Authorizing"} />;
   } else if (authError) {
-    if (authError instanceof EmailNotVerifiedError) {
-      return <VerifyEmailGate email={authError.email} />;
-    }
-    if (authError instanceof PersonalEmailRejectedError) {
-      // No special page — drop the user back on the signup form with the note.
-      return <FirebaseSignup initialError={authError.message} />;
-    }
     return <GlobalError error={authError} title={"Authorization error"} />;
-  } else if (user) {
+  } else if (!result) {
+    return <RedirectToSignIn />;
+  } else if (result.status === "email-not-verified") {
+    return <VerifyEmailGate email={result.email} />;
+  } else if (result.status === "personal-email-rejected") {
+    // No special page — drop the user back on the signup form with the note.
+    return <FirebaseSignup initialError={result.message} />;
+  } else {
     return (
       <UserContextProvider
-        user={user}
+        user={result.user}
         logout={async () => {
           await session.signOut().then(() => {
-            setUser(null);
+            setResult(null);
           });
           router.push("/signin");
         }}
@@ -135,8 +130,6 @@ const FirebaseAuthorizer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
         {children}
       </UserContextProvider>
     );
-  } else {
-    return <RedirectToSignIn />;
   }
 };
 

--- a/webapps/console/pages/api/app-config.ts
+++ b/webapps/console/pages/api/app-config.ts
@@ -15,8 +15,12 @@ function isSignupDisabled() {
   const serverEnv = getServerEnv();
   return (
     serverEnv.DISABLE_SIGNUP || //explicitly disabled
-    (!githubLoginEnabled && !oidcLoginEnabled)
-  ); // we don't support credentials signup yet ;
+    // Signup needs a provider that supports it: Firebase (Cloud), GitHub, or
+    // OIDC. Credentials signup isn't supported. Firebase was missing here, so a
+    // Firebase-only deployment hid the signup link (prod only worked because it
+    // also sets GITHUB_CLIENT_ID).
+    (!isFirebaseEnabled() && !githubLoginEnabled && !oidcLoginEnabled)
+  );
 }
 
 export default createRoute()
@@ -61,6 +65,9 @@ export default createRoute()
         host: eeBrowserAvailable ? getEeConnection().host : undefined,
       },
       disableSignup: isSignupDisabled(),
+      // Display-only hint for the signup form (JITSU-70). Enforcement stays
+      // server-side; the browser never gets the personal-domain list.
+      limitPersonalEmails: serverEnv.LIMIT_PERSONAL_EMAILS,
       auth,
       billingEnabled: eeBrowserAvailable,
       customDomainsEnabled: customDomainCnames && customDomainCnames.length > 0,

--- a/webapps/console/pages/api/auth/signup-email-check.ts
+++ b/webapps/console/pages/api/auth/signup-email-check.ts
@@ -1,0 +1,29 @@
+import { createRoute } from "../../../lib/api";
+import { z } from "zod";
+import { CreateUserResult } from "../../../lib/schema";
+import { isPersonalEmailSignupBlocked } from "../../../lib/server/signup-restrictions";
+import { WORK_EMAIL_REQUIRED_MESSAGE } from "../../../lib/shared/email-domains";
+
+/**
+ * JITSU-70: pre-signup check for the email/password path. The form calls this
+ * before creating the Firebase account so a personal-email signup is refused
+ * upfront (no account, no verification email) instead of only after the user
+ * verifies. The policy + domain list stay server-side; the typed result mirrors
+ * create-user. create-user / init-user remain the authoritative backstops.
+ */
+export default createRoute()
+  .POST({
+    auth: false,
+    // A pure policy check that touches no DB — keep it working during maintenance
+    // so the signup form stays responsive.
+    allowDuringMaintenance: true,
+    body: z.object({ email: z.string() }),
+    result: CreateUserResult,
+  })
+  .handler(async ({ body }) => {
+    if (isPersonalEmailSignupBlocked({ email: body.email })) {
+      return { ok: false, rejected: "personal-email", message: WORK_EMAIL_REQUIRED_MESSAGE } as const;
+    }
+    return { ok: true } as const;
+  })
+  .toNextApiHandler();

--- a/webapps/console/pages/api/fb-auth/create-user.ts
+++ b/webapps/console/pages/api/fb-auth/create-user.ts
@@ -2,7 +2,6 @@ import { Api, inferUrl, nextJsApiHandler } from "../../../lib/api";
 import { requireDefined } from "juava";
 import { getFirebaseUser, linkFirebaseUser } from "../../../lib/server/firebase-server";
 import { getOrCreateUser } from "../../../lib/nextauth.config";
-import { db } from "../../../lib/server/db";
 import { shouldRejectPersonalEmailSignup } from "../../../lib/server/signup-restrictions";
 import { CreateUserResult } from "../../../lib/schema";
 import { WORK_EMAIL_REQUIRED_MESSAGE } from "../../../lib/shared/email-domains";
@@ -19,18 +18,11 @@ export const api: Api = {
           `Firebase user already has internalId (${user.internalId}), this endpoint should not be called`
         );
       }
-      // JITSU-70: enforce the work-email policy only on true first-time signups.
-      // An existing user who lost their internalId custom claim (claim reset /
-      // stale migration) is matched here by externalId and must be relinked by
-      // getOrCreateUser below — never rejected/deleted as if new. The lookup
-      // mirrors getOrCreateUser's own (externalId + loginProvider "firebase").
-      const existing = await db
-        .prisma()
-        .userProfile.findFirst({ where: { externalId: user.externalId, loginProvider: "firebase" } });
-      // The policy (Firebase-only, GitHub exempt) and the orphan-account cleanup
-      // live in the shared helper; here we just report the refusal as a typed
-      // result rather than throwing.
-      if (!existing && (await shouldRejectPersonalEmailSignup(user))) {
+      // JITSU-70: require a work email. The policy (Firebase-only, GitHub exempt),
+      // the existing-user guard (never reject a returning account), and the
+      // orphan-account cleanup all live in the shared helper; here we just report
+      // the refusal as a typed result rather than throwing.
+      if (await shouldRejectPersonalEmailSignup(user)) {
         return { ok: false, rejected: "personal-email", message: WORK_EMAIL_REQUIRED_MESSAGE };
       }
       const dbUser = await getOrCreateUser({

--- a/webapps/console/pages/api/fb-auth/create-user.ts
+++ b/webapps/console/pages/api/fb-auth/create-user.ts
@@ -2,28 +2,38 @@ import { Api, inferUrl, nextJsApiHandler } from "../../../lib/api";
 import { requireDefined } from "juava";
 import { getFirebaseUser, linkFirebaseUser } from "../../../lib/server/firebase-server";
 import { getOrCreateUser } from "../../../lib/nextauth.config";
+import { shouldRejectPersonalEmailSignup } from "../../../lib/server/signup-restrictions";
+import { CreateUserResult } from "../../../lib/schema";
+import { WORK_EMAIL_REQUIRED_MESSAGE } from "../../../lib/shared/email-domains";
 
 export const api: Api = {
   url: inferUrl(__filename),
   POST: {
     auth: false,
-    handle: async ({ req, res }) => {
+    types: { result: CreateUserResult },
+    handle: async ({ req }): Promise<CreateUserResult> => {
       const user = requireDefined(await getFirebaseUser(req), `Not authorized`);
-      if (!user.internalId) {
-        const dbUser = await getOrCreateUser({
-          externalId: user.externalId,
-          // TODO: fill with user.loginProvider and update all existing users
-          loginProvider: "firebase",
-          email: user.email,
-          name: user.name || user.email,
-          req,
-        });
-        await linkFirebaseUser(user.externalId, dbUser.id);
-      } else {
+      if (user.internalId) {
         throw new Error(
           `Firebase user already has internalId (${user.internalId}), this endpoint should not be called`
         );
       }
+      // JITSU-70: require a work email. The policy (Firebase-only, GitHub exempt)
+      // and the orphan-account cleanup live in the shared helper; here we just
+      // report the refusal as a typed result rather than throwing.
+      if (await shouldRejectPersonalEmailSignup(user)) {
+        return { ok: false, rejected: "personal-email", message: WORK_EMAIL_REQUIRED_MESSAGE };
+      }
+      const dbUser = await getOrCreateUser({
+        externalId: user.externalId,
+        // TODO: fill with user.loginProvider and update all existing users
+        loginProvider: "firebase",
+        email: user.email,
+        name: user.name || user.email,
+        req,
+      });
+      await linkFirebaseUser(user.externalId, dbUser.id);
+      return { ok: true };
     },
   },
 };

--- a/webapps/console/pages/api/fb-auth/create-user.ts
+++ b/webapps/console/pages/api/fb-auth/create-user.ts
@@ -2,6 +2,7 @@ import { Api, inferUrl, nextJsApiHandler } from "../../../lib/api";
 import { requireDefined } from "juava";
 import { getFirebaseUser, linkFirebaseUser } from "../../../lib/server/firebase-server";
 import { getOrCreateUser } from "../../../lib/nextauth.config";
+import { db } from "../../../lib/server/db";
 import { shouldRejectPersonalEmailSignup } from "../../../lib/server/signup-restrictions";
 import { CreateUserResult } from "../../../lib/schema";
 import { WORK_EMAIL_REQUIRED_MESSAGE } from "../../../lib/shared/email-domains";
@@ -18,10 +19,18 @@ export const api: Api = {
           `Firebase user already has internalId (${user.internalId}), this endpoint should not be called`
         );
       }
-      // JITSU-70: require a work email. The policy (Firebase-only, GitHub exempt)
-      // and the orphan-account cleanup live in the shared helper; here we just
-      // report the refusal as a typed result rather than throwing.
-      if (await shouldRejectPersonalEmailSignup(user)) {
+      // JITSU-70: enforce the work-email policy only on true first-time signups.
+      // An existing user who lost their internalId custom claim (claim reset /
+      // stale migration) is matched here by externalId and must be relinked by
+      // getOrCreateUser below — never rejected/deleted as if new. The lookup
+      // mirrors getOrCreateUser's own (externalId + loginProvider "firebase").
+      const existing = await db
+        .prisma()
+        .userProfile.findFirst({ where: { externalId: user.externalId, loginProvider: "firebase" } });
+      // The policy (Firebase-only, GitHub exempt) and the orphan-account cleanup
+      // live in the shared helper; here we just report the refusal as a typed
+      // result rather than throwing.
+      if (!existing && (await shouldRejectPersonalEmailSignup(user))) {
         return { ok: false, rejected: "personal-email", message: WORK_EMAIL_REQUIRED_MESSAGE };
       }
       const dbUser = await getOrCreateUser({

--- a/webapps/console/pages/api/init-user.ts
+++ b/webapps/console/pages/api/init-user.ts
@@ -49,13 +49,6 @@ export default createRoute()
         if (serverEnv.DISABLE_SIGNUP) {
           throw new ApiError("Sign up is disabled", { code: "signup-disabled" });
         }
-        // JITSU-70: a Firebase account can already carry an internalId claim
-        // while its Jitsu profile is missing, which skips create-user and lands
-        // here. Enforce the work-email requirement on this path too; the helper
-        // deletes the orphaned Firebase account.
-        if (await shouldRejectPersonalEmailSignup(user)) {
-          throw new ApiError(WORK_EMAIL_REQUIRED_MESSAGE, { code: "personal-email-rejected" }, { status: 403 });
-        }
         if (!user.loginProvider && !user.externalId) {
           //double check so we won't pull first of all users from DB
           throw new ApiError(`Inconsistent state, loginProvider or externalId is empty in users JWT`);
@@ -68,6 +61,16 @@ export default createRoute()
           throw new ApiError(
             `There's another user with given external id (${user.loginProvider}/${user.externalId}, but different internal id - ${dbUser.id}. Please, delete this user. Passed user id: ${user.internalId}`
           );
+        }
+
+        // JITSU-70: a Firebase account can already carry an internalId claim while
+        // its Jitsu profile is missing, which skips create-user and lands here.
+        // Enforce the work-email requirement only once we've confirmed no existing
+        // profile (above) — so we never reject/delete a recovering user — i.e. a
+        // genuinely new account is about to be created. The helper deletes the
+        // orphaned Firebase account.
+        if (await shouldRejectPersonalEmailSignup(user)) {
+          throw new ApiError(WORK_EMAIL_REQUIRED_MESSAGE, { code: "personal-email-rejected" }, { status: 403 });
         }
 
         const newUser = await db.prisma().userProfile.create({

--- a/webapps/console/pages/api/init-user.ts
+++ b/webapps/console/pages/api/init-user.ts
@@ -8,6 +8,8 @@ import { initTelemetry, withProductAnalytics } from "../../lib/server/telemetry"
 import { onUserCreated } from "../../lib/server/ee";
 import { getServerEnv } from "../../lib/server/serverEnv";
 import { isMaintenanceActive } from "../../lib/server/maintenance";
+import { shouldRejectPersonalEmailSignup } from "../../lib/server/signup-restrictions";
+import { WORK_EMAIL_REQUIRED_MESSAGE } from "../../lib/shared/email-domains";
 
 const log = getServerLog("api/init-user");
 const serverEnv = getServerEnv();
@@ -46,6 +48,13 @@ export default createRoute()
         }
         if (serverEnv.DISABLE_SIGNUP) {
           throw new ApiError("Sign up is disabled", { code: "signup-disabled" });
+        }
+        // JITSU-70: a Firebase account can already carry an internalId claim
+        // while its Jitsu profile is missing, which skips create-user and lands
+        // here. Enforce the work-email requirement on this path too; the helper
+        // deletes the orphaned Firebase account.
+        if (await shouldRejectPersonalEmailSignup(user)) {
+          throw new ApiError(WORK_EMAIL_REQUIRED_MESSAGE, { code: "personal-email-rejected" }, { status: 403 });
         }
         if (!user.loginProvider && !user.externalId) {
           //double check so we won't pull first of all users from DB

--- a/webapps/console/pages/index.tsx
+++ b/webapps/console/pages/index.tsx
@@ -4,6 +4,8 @@ import { EmbeddedErrorMessage, GlobalError } from "../components/GlobalError/Glo
 import React from "react";
 import { useApi } from "../lib/useApi";
 import { ContextApiResponse } from "../lib/schema";
+import { FirebaseSignup } from "../components/SignInOrUp/FirebaseSignup";
+import { WORK_EMAIL_REQUIRED_MESSAGE } from "../lib/shared/email-domains";
 import { Button, Modal } from "antd";
 import { encrypt, getLog, randomId, rpc } from "juava";
 import { useUserSessionControls } from "../lib/context";
@@ -36,6 +38,12 @@ function WorkspaceRedirect() {
           </EmbeddedErrorMessage>
         </div>
       );
+    }
+    if ((error as any).response?.code === "personal-email-rejected") {
+      // No special page — render the signup form with the note. The user's
+      // Firebase account was already deleted server-side, so a retry with a work
+      // email starts clean.
+      return <FirebaseSignup initialError={WORK_EMAIL_REQUIRED_MESSAGE} />;
     }
     return <GlobalError error={error} />;
   } else if (data) {


### PR DESCRIPTION
Closes `JITSU-70`.

## Goal

Cut down low-quality signups from personal email accounts on `use.jitsu.com` by requiring a work email. Gated behind `LIMIT_PERSONAL_EMAILS` (off by default).

## Behavior

- **Google** and **email/password** signups from a personal domain (`gmail.com`, `outlook.com`, …) are rejected and the user is asked for a work email.
- **GitHub** signups are exempt — devs often have a personal email tied to GitHub.
- Existing users are unaffected (only new-profile paths are checked).

## Implementation

- `LIMIT_PERSONAL_EMAILS` env flag; `isPersonalEmail` + shared message live in `lib/shared/email-domains.ts`.
- One server-side policy helper (`lib/server/signup-restrictions.ts`, Firebase-only, GitHub-exempt) used at every new-profile chokepoint:
  - `fb-auth/create-user` — returns a typed discriminated union (`CreateUserResult`), not an HTTP error.
  - `init-user` — guards the remediation branch (Firebase account with a stale `internalId` claim but no Jitsu profile).
  - It deletes the orphaned Firebase account so retries start clean.
- New `POST /api/auth/signup-email-check` — the form calls it on **Continue** so a personal email is refused *before* the Firebase account is created / a verification email is sent. `create-user`/`init-user` remain the authoritative backstops.
- UX: rejection renders the signup form inline with a top-of-form banner (no separate page); a subtle "Work email required" badge sits on the Google button when the flag is on (`appConfig.limitPersonalEmails` is display-only — the domain list never reaches the browser).
- Fix: `isSignupDisabled` now treats Firebase as a valid signup provider (a Firebase-only deployment previously hid the "Create an account" link unless `GITHUB_CLIENT_ID` happened to be set).

## Test plan

- [x] Email/password with a personal domain → refused instantly on Continue (no account, no verification email), banner shown.
- [x] `isSignupDisabled` / signup link restored on Firebase-only local env.
- [x] `pnpm typecheck` + Prettier clean.
- [ ] Live **Google** popup → instant reject + Firebase deletion.
- [ ] Live **GitHub** popup → passes through with any email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)