### PR TITLE
JITSU-67: migrate config HTTP routes onto ConfigObjectsService

### DIFF
--- a/webapps/console/__tests__/config-objects-service.test.ts
+++ b/webapps/console/__tests__/config-objects-service.test.ts
@@ -82,10 +82,10 @@ describe("ConfigObjectsService", () => {
     await expect(svc.list(user, "ws1", "bogus")).rejects.toThrow(/Unknown resource type/);
   });
 
-  it("create mints an id and strips id/workspaceId from stored config", async () => {
+  it("create mints an id (generateId) and strips id/workspaceId from stored config", async () => {
     const prisma = makePrisma();
     const svc = new ConfigObjectsService({ prisma });
-    const res = await svc.create(user, "ws1", "domain", { name: "example.com" });
+    const res = await svc.create(user, "ws1", "domain", { name: "example.com" }, { generateId: true });
 
     expect(prisma.configurationObject.create).toHaveBeenCalledOnce();
     const arg = prisma.configurationObject.create.mock.calls[0][0];
@@ -96,6 +96,15 @@ describe("ConfigObjectsService", () => {
     expect(arg.data.config.id).toBeUndefined();
     expect(arg.data.config.workspaceId).toBeUndefined();
     expect(arg.data.config.name).toBe("example.com");
+  });
+
+  it("create without an id and no generateId fails validation (HTTP contract)", async () => {
+    const prisma = makePrisma();
+    const svc = new ConfigObjectsService({ prisma });
+    // The HTTP route requires the client to send an id; a missing one must stay a
+    // validation error rather than get an implicitly minted id.
+    await expect(svc.create(user, "ws1", "domain", { name: "example.com" })).rejects.toThrow(/validate schema/);
+    expect(prisma.configurationObject.create).not.toHaveBeenCalled();
   });
 
   it("delete returns null when the object is missing (idempotent)", async () => {

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -157,7 +157,7 @@ export class ConfigObjectsService {
     workspaceId: string,
     type: string,
     data: any,
-    opts: { req?: NextApiRequest } = {}
+    opts: { req?: NextApiRequest; generateId?: boolean } = {}
   ): Promise<{ id: string }> {
     await verifyAccessWithRole(user, workspaceId, "editEntities");
     this.assertKnownType(type);
@@ -166,11 +166,12 @@ export class ConfigObjectsService {
       `Workspace ${workspaceId} not found`
     );
     const configObjectType = getConfigObjectType(type);
-    // The HTTP route relies on the client sending id/type/workspaceId in the body
-    // (the base schema requires all three). An MCP caller passes `data` plus the
-    // type/workspaceId as separate args, so inject them here and mint an id when
-    // absent — otherwise parseObject would reject the payload.
-    const incoming = { ...data, type, workspaceId, id: data?.id ?? randomId() };
+    // Inject type/workspaceId so parseObject sees a complete object. `id` is
+    // caller-dependent: the HTTP route requires the client to send it (the base
+    // schema mandates it, and a missing id must stay a validation error so client
+    // payload bugs surface). An MCP caller passes `data` without an id, so it opts
+    // into `generateId` to have one minted here.
+    const incoming = { ...data, type, workspaceId, id: data?.id ?? (opts.generateId ? randomId() : undefined) };
     let object = parseObject(type, incoming);
     if (incoming.cloneId) {
       log.atInfo().log(`Unmasking secrets for ${type} clone: ${incoming.id}`);

--- a/webapps/console/lib/server/mcp-server/tools.ts
+++ b/webapps/console/lib/server/mcp-server/tools.ts
@@ -155,7 +155,8 @@ export function registerTools(sdkServer: SdkMcpServer, deps: ToolDeps) {
         if (type === CONNECTION) {
           return service.upsertLink(user, workspaceId, data as any, { strict: true });
         }
-        return service.create(user, workspaceId, type, data);
+        // MCP callers pass `data` without an id; mint one server-side.
+        return service.create(user, workspaceId, type, data, { generateId: true });
       })
   );
 

--- a/webapps/console/pages/api/[workspaceId]/config/[type]/[id].ts
+++ b/webapps/console/pages/api/[workspaceId]/config/[type]/[id].ts
@@ -1,17 +1,9 @@
-import { createRoute, verifyAccess, verifyAccessWithRole } from "../../../../../lib/api";
+import { createRoute } from "../../../../../lib/api";
 import { z } from "zod";
 import { db } from "../../../../../lib/server/db";
-import { ApiError } from "../../../../../lib/shared/errors";
-import {
-  getAllConfigObjectTypeNames,
-  getConfigObjectType,
-  parseObject,
-} from "../../../../../lib/schema/config-objects";
+import { getAllConfigObjectTypeNames, getConfigObjectType } from "../../../../../lib/schema/config-objects";
 import { AnyDestination, getAnnotatedConfigObjectSchema } from "../../../../../lib/openapi/annotations";
-import { prepareZodObjectForDeserialization } from "../../../../../lib/zod";
-import { configObjectAuditLog } from "../../../../../lib/server/audit-log";
-import { trackTelemetryEvent } from "../../../../../lib/server/telemetry";
-import { requireDefined, deepCopy } from "juava";
+import { ConfigObjectsService } from "../../../../../lib/server/config-objects-service";
 
 export const config = {
   api: {
@@ -24,6 +16,9 @@ export const config = {
 // Spec-visible types — runtime still serves every type from getAllConfigObjectTypeNames(),
 // but the `misc` catch-all is omitted from the public OpenAPI document.
 const publicTypeNames = getAllConfigObjectTypeNames().filter(t => t !== "misc");
+
+let service: ConfigObjectsService | undefined;
+const configObjects = () => (service ??= new ConfigObjectsService({ prisma: db.prisma() }));
 
 export const route = createRoute()
   .GET({
@@ -46,16 +41,7 @@ export const route = createRoute()
     },
   })
   .handler(async ({ user, query: { id, workspaceId, type } }) => {
-    await verifyAccess(user, workspaceId);
-    const configObjectType = getConfigObjectType(type);
-    const object = await db.prisma().configurationObject.findFirst({
-      where: { workspaceId, id, deleted: false },
-    });
-    if (!object) {
-      throw new ApiError(`${type} with id ${id} does not exist`, {}, { status: 400 });
-    }
-    const preFilter = { ...((object.config as any) || {}), workspaceId, id, type, updatedAt: object.updatedAt };
-    return await configObjectType.outputFilter(preFilter);
+    return await configObjects().get(user, workspaceId, type, id);
   })
   .PUT({
     auth: true,
@@ -76,40 +62,9 @@ export const route = createRoute()
       }),
     },
   })
-  .handler(async ({ user, body, query }) => {
-    body = prepareZodObjectForDeserialization(body);
-    const { id, workspaceId, type } = query;
-    // Read-only enforcement is centralized: the API-layer maintenance gate
-    // (lib/api.ts) returns 503 before this handler runs, and the Prisma
-    // backstop in lib/server/db.ts rejects writes per-operation. No need
-    // for an in-handler check.
-    await verifyAccessWithRole(user, workspaceId, "editEntities");
-    const workspace = requireDefined(
-      await db.prisma().workspace.findFirst({ where: { id: workspaceId } }),
-      `Workspace ${workspaceId} not found`
-    );
-    const configObjectType = getConfigObjectType(type);
-    const object = await db.prisma().configurationObject.findFirst({
-      where: { workspaceId: workspaceId, id, deleted: false },
-    });
-    if (!object) {
-      throw new ApiError(`${type} with id ${id} does not exist`);
-    }
-    // Snapshot before merge — `merge` may mutate `object.config` in place, so capture
-    // for the audit log up front (introduced in SOC2 audit-log work, PR #1288).
-    const prevVersion = deepCopy(object.config);
-    const merged = await configObjectType.merge(object.config, { ...body, id, workspaceId });
-    const data = parseObject(type, merged);
-    const filtered = await configObjectType.inputFilter(data, "update", workspace);
-
-    delete filtered.id;
-    delete filtered.workspaceId;
-    await db.prisma().configurationObject.update({ where: { id }, data: { config: filtered } });
-    await trackTelemetryEvent("config-object-update", { objectType: type });
-    await configObjectAuditLog(user, workspaceId, id, type, "update", {
-      prevVersion,
-      newVersion: filtered,
-    });
+  .handler(async ({ user, body, query: { id, workspaceId, type } }) => {
+    // The service applies `prepareZodObjectForDeserialization` internally.
+    await configObjects().update(user, workspaceId, type, id, body);
   })
   .DELETE({
     auth: true,
@@ -131,31 +86,11 @@ export const route = createRoute()
       }),
     },
   })
-  .handler(async ({ user, query }) => {
-    const { id, workspaceId, type, strict, cascade } = query;
-    await verifyAccessWithRole(user, workspaceId, "deleteEntities");
-    const object = await db.prisma().configurationObject.findFirst({
-      where: { workspaceId: workspaceId, id, deleted: false },
+  .handler(async ({ user, query: { id, workspaceId, type, strict, cascade } }) => {
+    return await configObjects().delete(user, workspaceId, type, id, {
+      strict: strict === "true",
+      cascade: cascade === "true",
     });
-    if (!object) {
-      return null;
-    }
-
-    const configObjectType = getConfigObjectType(type);
-    if (configObjectType.onDelete) {
-      await configObjectType.onDelete(object, {
-        strict: strict === "true",
-        cascade: cascade === "true",
-      });
-    }
-
-    await db.prisma().configurationObject.update({
-      where: { id: object.id },
-      data: { deleted: true },
-    });
-    await trackTelemetryEvent("config-object-delete", { objectType: type });
-    await configObjectAuditLog(user, workspaceId, id, type, "delete", { prevVersion: object.config });
-    return { ...((object.config as any) || {}), workspaceId, id, type };
   });
 
 export default route.toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/config/[type]/index.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/[type]/index.ts
@@ -1,19 +1,9 @@
-import { createRoute, verifyAccess, verifyAccessWithRole } from "../../../../../lib/api";
+import { createRoute } from "../../../../../lib/api";
 import { z } from "zod";
 import { db } from "../../../../../lib/server/db";
-import { assertDefined, requireDefined } from "juava";
-import {
-  getAllConfigObjectTypeNames,
-  getConfigObjectType,
-  parseObject,
-} from "../../../../../lib/schema/config-objects";
+import { getAllConfigObjectTypeNames, getConfigObjectType } from "../../../../../lib/schema/config-objects";
 import { AnyDestination, getAnnotatedConfigObjectSchema } from "../../../../../lib/openapi/annotations";
-import { configObjectAuditLog } from "../../../../../lib/server/audit-log";
-import { trackTelemetryEvent, withProductAnalytics } from "../../../../../lib/server/telemetry";
-import { containsMaskedSecrets, unmaskSecretsFromOriginal } from "../../../../../lib/schema/secrets";
-import { getServerLog } from "../../../../../lib/server/log";
-
-const log = getServerLog("api");
+import { ConfigObjectsService } from "../../../../../lib/server/config-objects-service";
 
 export const config = {
   api: {
@@ -27,6 +17,9 @@ export const config = {
 // but `misc` is an internal catch-all that we don't document publicly.
 const publicTypeNames = getAllConfigObjectTypeNames().filter(t => t !== "misc");
 const pluralType = (t: string) => `${t}s`;
+
+let service: ConfigObjectsService | undefined;
+const configObjects = () => (service ??= new ConfigObjectsService({ prisma: db.prisma() }));
 
 export const route = createRoute()
   .GET({
@@ -52,26 +45,8 @@ export const route = createRoute()
     },
   })
   .handler(async ({ user, query: { workspaceId, type } }) => {
-    await verifyAccess(user, workspaceId);
-    const configObjectType = getConfigObjectType(type);
-    assertDefined(configObjectType, `Invalid config object type: ${type}`);
-    const objects = await db.prisma().configurationObject.findMany({
-      where: { workspaceId: workspaceId, type, deleted: false },
-      orderBy: { createdAt: "asc" },
-    });
-    const mappedObjects = objects.map(({ id, workspaceId, config, updatedAt }) => ({
-      ...(config as any),
-      id,
-      workspaceId,
-      type,
-      updatedAt,
-    }));
-
-    const filteredObjects = await Promise.all(mappedObjects.map(obj => configObjectType.outputFilter(obj)));
-
-    return {
-      objects: filteredObjects,
-    };
+    const objects = await configObjects().list(user, workspaceId, type);
+    return { objects };
   })
   .POST({
     auth: true,
@@ -94,43 +69,7 @@ export const route = createRoute()
     },
   })
   .handler(async ({ req, body, user, query: { workspaceId, type } }) => {
-    await verifyAccessWithRole(user, workspaceId, "editEntities");
-    const workspace = requireDefined(
-      await db.prisma().workspace.findFirst({ where: { id: workspaceId } }),
-      `Workspace ${workspaceId} not found`
-    );
-    const configObjectTypes = getConfigObjectType(type);
-    let object = parseObject(type, body);
-    if (body.cloneId) {
-      log.atInfo().log(`Unmasking secrets for ${type} clone: ${body.id}`);
-      if (containsMaskedSecrets(object)) {
-        const clonesOriginal = await db.prisma().configurationObject.findFirst({
-          where: { id: body.cloneId, workspaceId },
-        });
-        if (clonesOriginal?.config) {
-          const dbConfig = clonesOriginal.config as any;
-          object = unmaskSecretsFromOriginal(object, dbConfig);
-        }
-      }
-    }
-    object = await configObjectTypes.inputFilter(object, "create", workspace);
-    const id = object.id;
-    delete object.id;
-    delete object.workspaceId;
-    delete object.cloneId;
-    const created = await db.prisma().configurationObject.create({
-      data: { id, workspaceId: workspaceId, config: object, type },
-    });
-    await trackTelemetryEvent("config-object-create", { objectType: type });
-    await withProductAnalytics(
-      p =>
-        p.track("create_object", {
-          objectType: type,
-        }),
-      { user, workspace: { id: workspaceId }, req }
-    );
-    await configObjectAuditLog(user, workspaceId, created.id, type, "create", { newVersion: object });
-    return { id: created.id };
+    return await configObjects().create(user, workspaceId, type, body, { req });
   });
 
 export default route.toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/config/link.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/link.ts
@@ -1,18 +1,7 @@
 import { z } from "zod";
-import { createRoute, verifyAccessWithRole } from "../../../../lib/api";
+import { createRoute } from "../../../../lib/api";
 import { db } from "../../../../lib/server/db";
-import { randomId } from "juava";
-import { scheduleSync, validateSyncSchedule } from "../../../../lib/server/sync";
-import { ConfigurationObjectLinkDbModel } from "../../../../prisma/schema";
-import { SyncOptionsType } from "../../../../lib/schema";
-import { ApiError } from "../../../../lib/shared/errors";
-import { MASKED_SECRET, getCoreDestinationTypeNonStrict } from "../../../../lib/schema/destinations";
-import { configObjectAuditLog } from "../../../../lib/server/audit-log";
-import { omitDeletedList } from "../../../../lib/server/omit-deleted";
-
-export type SyncDbModel = Omit<z.infer<typeof ConfigurationObjectLinkDbModel>, "data"> & {
-  data?: SyncOptionsType;
-};
+import { ConfigObjectsService } from "../../../../lib/server/config-objects-service";
 
 const linkBodySchema = z.object({
   id: z.string().optional(),
@@ -24,6 +13,9 @@ const linkBodySchema = z.object({
 
 const linkUpsertResult = z.object({ id: z.string(), created: z.boolean() });
 
+let service: ConfigObjectsService | undefined;
+const configObjects = () => (service ??= new ConfigObjectsService({ prisma: db.prisma() }));
+
 const upsertHandler = async (ctx: any) => {
   const {
     body,
@@ -31,123 +23,11 @@ const upsertHandler = async (ctx: any) => {
     query: { workspaceId, runSync, strict },
     req,
   } = ctx;
-  const { id, toId, fromId, data = undefined, type = "push" } = body;
-  await verifyAccessWithRole(user, workspaceId, "editEntities");
-
-  // Always validate the cron schedule + timezone for sync links — k8s
-  // CronJob (managed by syncctl from the polled syncs export) will reject
-  // an invalid spec hours later with no feedback to the user, so catching
-  // it at write time is the only good signal. Manual-only syncs (no
-  // schedule set) pass through untouched.
-  if (type === "sync" && data) {
-    try {
-      validateSyncSchedule(data);
-    } catch (e: any) {
-      throw new ApiError(e.message, {}, { status: 400 });
-    }
-  }
-
-  // Validate connection data if strict mode is enabled
-  if (strict === "true" && data !== undefined) {
-    if (type === "sync") {
-      const parseResult = SyncOptionsType.safeParse(data);
-      if (!parseResult.success) {
-        throw new ApiError(
-          `Invalid sync options: ${parseResult.error.message}`,
-          { zodError: parseResult.error },
-          { status: 400 }
-        );
-      }
-    } else {
-      const destination = await db.prisma().configurationObject.findFirst({
-        where: { workspaceId, id: toId, type: "destination", deleted: false },
-      });
-
-      if (destination) {
-        const destinationType = getCoreDestinationTypeNonStrict(destination.config?.["destinationType"]);
-        if (destinationType?.connectionOptions) {
-          const parseResult = destinationType.connectionOptions.safeParse(data);
-          if (!parseResult.success) {
-            throw new ApiError(
-              `Invalid connection options for ${destination.config?.["destinationType"]}: ${parseResult.error.message}`,
-              { zodError: parseResult.error },
-              { status: 400 }
-            );
-          }
-        }
-      }
-    }
-  }
-  const fromType = type === "sync" ? "service" : "stream";
-
-  const existingLink =
-    type === "push"
-      ? await db.prisma().configurationObjectLink.findFirst({
-          where: { workspaceId: workspaceId, toId, fromId, deleted: false },
-        })
-      : id
-      ? await db.prisma().configurationObjectLink.findFirst({ where: { workspaceId: workspaceId, id, deleted: false } })
-      : undefined;
-
-  if (!id && existingLink) {
-    throw new Error(`Link from '${fromId}' to '${toId}' already exists`);
-  }
-
-  const co = db.prisma().configurationObject;
-  if (
-    !(await co.findFirst({
-      where: { workspaceId: workspaceId, type: fromType, id: fromId, deleted: false },
-    }))
-  ) {
-    throw new Error(`${fromType} object with id '${fromId}' not found in the workspace '${workspaceId}'`);
-  }
-  if (
-    !(await co.findFirst({
-      where: { workspaceId: workspaceId, type: "destination", id: toId, deleted: false },
-    }))
-  ) {
-    throw new Error(`Destination object with id '${toId}' not found in the workspace '${workspaceId}'`);
-  }
-  let createdOrUpdated: SyncDbModel;
-  if (existingLink) {
-    createdOrUpdated = (await db.prisma().configurationObjectLink.update({
-      where: { id: existingLink.id },
-      data: { data, deleted: false, workspaceId },
-    })) as SyncDbModel;
-    if (
-      (type === "sync" && data.schedule !== existingLink!.data?.["schedule"]) ||
-      data.timezone !== existingLink!.data?.["timezone"]
-    ) {
-    }
-    await configObjectAuditLog(user, workspaceId, createdOrUpdated.id, "link", "update", {
-      prevVersion: existingLink,
-      newVersion: createdOrUpdated,
-    });
-  } else {
-    createdOrUpdated = (await db.prisma().configurationObjectLink.create({
-      data: {
-        id: `${workspaceId}-${fromId.substring(fromId.length - 4)}-${toId.substring(toId.length - 4)}-${randomId(6)}`,
-        workspaceId,
-        fromId,
-        toId,
-        data,
-        type,
-      },
-    })) as SyncDbModel;
-    await configObjectAuditLog(user, workspaceId, createdOrUpdated.id, "link", "create", {
-      newVersion: createdOrUpdated,
-    });
-  }
-  if (type === "sync" && (runSync === "true" || runSync === "1")) {
-    await scheduleSync({
-      req,
-      user,
-      trigger: "manual",
-      workspaceId,
-      syncIdOrModel: createdOrUpdated.id,
-    });
-  }
-  return { id: createdOrUpdated.id, created: !existingLink };
+  return await configObjects().upsertLink(user, workspaceId, body, {
+    strict: strict === "true",
+    runSync: runSync === "true" || runSync === "1",
+    req,
+  });
 };
 
 const upsertOptions = {
@@ -170,24 +50,8 @@ export const route = createRoute()
     tags: ["link"],
   })
   .handler(async ({ user, query: { workspaceId } }) => {
-    const role = await verifyAccessWithRole(user, workspaceId, "readEntities");
-    const links = await db.prisma().configurationObjectLink.findMany({
-      where: { workspaceId: workspaceId, deleted: false },
-      orderBy: { createdAt: "asc" },
-    });
-    if (!role.editEntities) {
-      for (const link of links) {
-        const functionsEnv = link.data?.["functionsEnv"];
-        if (typeof functionsEnv === "object" && functionsEnv !== null) {
-          for (const key in functionsEnv) {
-            functionsEnv[key] = MASKED_SECRET;
-          }
-        }
-      }
-    }
-    return {
-      links: omitDeletedList(links),
-    };
+    const links = await configObjects().listLinks(user, workspaceId);
+    return { links };
   })
   .POST({ ...upsertOptions, summary: "Create connection" })
   .handler(upsertHandler)
@@ -206,38 +70,7 @@ export const route = createRoute()
     tags: ["link"],
   })
   .handler(async ({ user, query: { workspaceId, fromId, toId, id } }) => {
-    await verifyAccessWithRole(user, workspaceId, "deleteEntities");
-    if (id) {
-      if (fromId || toId) {
-        throw new ApiError("You can't specify 'fromId' or 'toId' with 'id'", {}, { status: 400 });
-      }
-      const updatedLink = await db
-        .prisma()
-        .configurationObjectLink.update({ where: { workspaceId, id }, data: { deleted: true } });
-      if (!updatedLink) {
-        return { deleted: false };
-      }
-      await configObjectAuditLog(user, workspaceId, updatedLink.id, "link", "delete", {
-        prevVersion: updatedLink,
-      });
-      return { deleted: true };
-    } else if (fromId && toId) {
-      if (id) {
-        throw new ApiError("You can't specify 'id' with 'fromId' and 'toId'", {}, { status: 400 });
-      }
-      const updatedLinks = await db.prisma().configurationObjectLink.updateManyAndReturn({
-        where: { workspaceId, toId, fromId, deleted: false },
-        data: { deleted: true },
-      });
-      for (const updatedLink of updatedLinks) {
-        await configObjectAuditLog(user, workspaceId, updatedLink.id, "link", "delete", {
-          prevVersion: updatedLink,
-        });
-      }
-      return { deleted: updatedLinks.length > 0 };
-    } else {
-      return { deleted: false };
-    }
+    return await configObjects().deleteLink(user, workspaceId, { id, fromId, toId });
   });
 
 export default route.toNextApiHandler();


### PR DESCRIPTION
## What

Migrate the config route handlers onto the shared `ConfigObjectsService` (extracted for the MCP server in #1371), so HTTP and MCP share one implementation of validation, secret-masking, audit logging, and tenancy rules instead of two paths that drift.

Routes migrated:

| Route | Delegates to |
|---|---|
| `config/[type]/index.ts` GET/POST | `list()` / `create(…, { req })` |
| `config/[type]/[id].ts` GET/PUT/DELETE | `get()` / `update()` / `delete()` |
| `config/link.ts` GET/POST/PUT/DELETE | `listLinks()` / `upsertLink()` / `deleteLink()` |

Transport stays in the routes — `createRoute()` schemas, OpenAPI `expand` metadata, the 20mb `bodyParser` config, and the `{ objects }` / `{ links }` response wrapping are unchanged. Only handler bodies changed. Net −293 lines.

## Behavior changes (error paths)

Auth/role requirements and success response shapes are unchanged. The services set intentional status codes where the old routes fell through to a 500 default:

- Invalid config type: 500 → **400**
- GET/PUT/DELETE by id are now **type-scoped** (a cross-type id → not found — closes a hole where e.g. a destination's secrets could be returned through the stream filter)
- Missing object: GET 400 → **404**, PUT 500 → **404**
- Link upsert conflict / referenced object not found: 500 → **400**
- Delete of a missing link id: 500 → **200 `{ deleted: false }`**

## Scope

This is the first of the `JITSU-67` route groups (one group per PR). The `sources/*`, `function/run.ts`, and `config/[type]/test.ts` groups are blocked on `SyncService` / `DebugService`, which don't exist yet (planned in JITSU-66). Events-log routes (`log/[type]/[actorId].ts`, `dead-letter`) are a follow-up — they gzip-stream and need a buffering-vs-streaming decision.

## Testing

- `pnpm typecheck` (console): clean
- `config-objects-service.test.ts`: 11/11 · `openapi-route-spec.test.ts`: 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mFxNN48JPqDtADy2ZEu3P