### PR TITLE
feat(console): MCP auth via personal API key (JITSU-66)

### DIFF
--- a/webapps/console/__tests__/mcp-auth.test.ts
+++ b/webapps/console/__tests__/mcp-auth.test.ts
@@ -16,142 +16,51 @@ function makeReq(authorization: string) {
   return { headers: { authorization } } as any;
 }
 
-// Minimal NextApiResponse stand-in. `json()` marks headers as sent, mirroring
-// how a real response ends after `res.status(...).json(...)` — the checker uses
-// res.headersSent to decide whether the OAuth path already answered.
 function makeRes() {
   const res: any = {
     statusCode: 200,
     body: undefined,
-    headers: {} as Record<string, string>,
-    headersSent: false,
-    setHeader(k: string, v: string) {
-      this.headers[k] = v;
-    },
+    setHeader() {},
     status(code: number) {
       this.statusCode = code;
       return this;
     },
     json(payload: any) {
       this.body = payload;
-      this.headersSent = true;
       return this;
     },
   };
   return res;
 }
 
-const user = {
-  id: "user-1",
-  email: "u1@example.com",
-  name: "User One",
-  externalId: "ext-1",
-  loginProvider: "github",
-};
+const user = { id: "user-1", email: "u1@example.com", name: "User One", externalId: "ext-1", loginProvider: "github" };
 
-function makePrisma(overrides: any = {}) {
+function makePrisma(userApiToken: any) {
   return {
-    oAuthAccessToken: {
-      findUnique: vi.fn(async () => null),
-      update: vi.fn(async () => ({})),
-      ...overrides.oAuthAccessToken,
-    },
-    userApiToken: {
-      findUnique: vi.fn(async () => null),
-      update: vi.fn(async () => ({})),
-      ...overrides.userApiToken,
-    },
+    oAuthAccessToken: { findUnique: vi.fn(async () => null) },
+    userApiToken: { findUnique: vi.fn(async () => userApiToken), update: vi.fn(async () => ({})) },
   } as any;
 }
 
-describe("AuthChecker.requireAccessToken", () => {
-  it("authenticates a valid OAuth access token without consulting the API-key path", async () => {
-    const secret = "s3cret";
-    const prisma = makePrisma({
-      oAuthAccessToken: {
-        findUnique: vi.fn(async () => ({
-          id: "at-1",
-          hash: createHash(secret),
-          expiresAt: new Date(Date.now() + 60_000),
-          refreshTokenId: "rt-1",
-          refreshToken: { user, oauthClientId: "client-1", oauthClient: { name: "Claude" } },
-        })),
-      },
-    });
-    const auth = await new AuthChecker(prisma, noopSchedule).requireAccessToken(
-      makeReq(`Bearer at-1:${secret}`),
-      makeRes()
-    );
-    expect(auth?.extra?.userId).toBe("user-1");
-    expect(auth?.extra?.refreshTokenId).toBe("rt-1");
-    expect(prisma.userApiToken.findUnique).not.toHaveBeenCalled();
-  });
-
-  it("authenticates a personal API key when the id is not an OAuth token, and bumps lastUsed", async () => {
+describe("AuthChecker: MCP auth via personal API key", () => {
+  it("authenticates a personal key (oauthClientId null)", async () => {
     const secret = "keysecret";
-    const bump = vi.fn(async () => ({}));
-    const prisma = makePrisma({
-      userApiToken: {
-        findUnique: vi.fn(async () => ({
-          id: "key-1",
-          hash: createHash(secret),
-          oauthClientId: null,
-          expiresAt: null, // never expires — the CI case
-          name: "ci-key",
-          user,
-        })),
-        update: bump,
-      },
-    });
-    const scheduled: Array<() => Promise<any>> = [];
-    const auth = await new AuthChecker(prisma, fn => scheduled.push(fn)).requireAccessToken(
-      makeReq(`Bearer key-1:${secret}`),
-      makeRes()
-    );
+    const auth = await new AuthChecker(
+      makePrisma({ id: "key-1", hash: createHash(secret), oauthClientId: null, expiresAt: null, user }),
+      noopSchedule
+    ).requireAccessToken(makeReq(`Bearer key-1:${secret}`), makeRes());
     expect(auth?.extra?.userId).toBe("user-1");
-    expect(auth?.extra?.refreshTokenId).toBe("key-1");
     expect(auth?.clientId).toBe("api-key");
-    await Promise.all(scheduled.map(fn => fn()));
-    expect(bump).toHaveBeenCalledWith({ where: { id: "key-1" }, data: { lastUsed: expect.any(Date) } });
   });
 
-  it("rejects an OAuth refresh token (oauthClientId set) presented as an API key", async () => {
+  it("rejects an OAuth refresh token (oauthClientId set) presented as a key", async () => {
     const secret = "refreshsecret";
-    const prisma = makePrisma({
-      userApiToken: {
-        findUnique: vi.fn(async () => ({
-          id: "rt-1",
-          hash: createHash(secret),
-          oauthClientId: "client-1", // a refresh token, not a personal key
-          expiresAt: null,
-          user,
-        })),
-      },
-    });
     const res = makeRes();
-    const auth = await new AuthChecker(prisma, noopSchedule).requireAccessToken(makeReq(`Bearer rt-1:${secret}`), res);
+    const auth = await new AuthChecker(
+      makePrisma({ id: "rt-1", hash: createHash(secret), oauthClientId: "client-1", expiresAt: null, user }),
+      noopSchedule
+    ).requireAccessToken(makeReq(`Bearer rt-1:${secret}`), res);
     expect(auth).toBeUndefined();
     expect(res.statusCode).toBe(401);
-    expect(res.body.error_description).toMatch(/refresh tokens cannot be used/i);
-  });
-
-  it("does not fall through to the API-key path when an OAuth token exists but the secret is wrong", async () => {
-    const prisma = makePrisma({
-      oAuthAccessToken: {
-        findUnique: vi.fn(async () => ({
-          id: "at-1",
-          hash: createHash("right"),
-          expiresAt: new Date(Date.now() + 60_000),
-          refreshTokenId: "rt-1",
-          refreshToken: { user, oauthClientId: "client-1", oauthClient: { name: "Claude" } },
-        })),
-      },
-    });
-    const res = makeRes();
-    const auth = await new AuthChecker(prisma, noopSchedule).requireAccessToken(makeReq("Bearer at-1:wrong"), res);
-    expect(auth).toBeUndefined();
-    expect(res.statusCode).toBe(401);
-    // The wrong secret must not send a second 401 via the key path.
-    expect(prisma.userApiToken.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/webapps/console/__tests__/mcp-auth.test.ts
+++ b/webapps/console/__tests__/mcp-auth.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHash } from "juava";
+
+// send401 reaches for the public origin to build the WWW-Authenticate metadata
+// URL. Stub it so the checker doesn't depend on env config.
+vi.mock("../lib/server/origin", async importOriginal => ({
+  ...(await importOriginal<any>()),
+  getPublicOrigin: () => "https://console.example.com",
+}));
+
+import { AuthChecker } from "../lib/server/mcp-server/auth";
+
+const noopSchedule = (_fn: () => Promise<any>) => {};
+
+function makeReq(authorization: string) {
+  return { headers: { authorization } } as any;
+}
+
+// Minimal NextApiResponse stand-in. `json()` marks headers as sent, mirroring
+// how a real response ends after `res.status(...).json(...)` — the checker uses
+// res.headersSent to decide whether the OAuth path already answered.
+function makeRes() {
+  const res: any = {
+    statusCode: 200,
+    body: undefined,
+    headers: {} as Record<string, string>,
+    headersSent: false,
+    setHeader(k: string, v: string) {
+      this.headers[k] = v;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.body = payload;
+      this.headersSent = true;
+      return this;
+    },
+  };
+  return res;
+}
+
+const user = {
+  id: "user-1",
+  email: "u1@example.com",
+  name: "User One",
+  externalId: "ext-1",
+  loginProvider: "github",
+};
+
+function makePrisma(overrides: any = {}) {
+  return {
+    oAuthAccessToken: {
+      findUnique: vi.fn(async () => null),
+      update: vi.fn(async () => ({})),
+      ...overrides.oAuthAccessToken,
+    },
+    userApiToken: {
+      findUnique: vi.fn(async () => null),
+      update: vi.fn(async () => ({})),
+      ...overrides.userApiToken,
+    },
+  } as any;
+}
+
+describe("AuthChecker.requireAccessToken", () => {
+  it("authenticates a valid OAuth access token without consulting the API-key path", async () => {
+    const secret = "s3cret";
+    const prisma = makePrisma({
+      oAuthAccessToken: {
+        findUnique: vi.fn(async () => ({
+          id: "at-1",
+          hash: createHash(secret),
+          expiresAt: new Date(Date.now() + 60_000),
+          refreshTokenId: "rt-1",
+          refreshToken: { user, oauthClientId: "client-1", oauthClient: { name: "Claude" } },
+        })),
+      },
+    });
+    const auth = await new AuthChecker(prisma, noopSchedule).requireAccessToken(
+      makeReq(`Bearer at-1:${secret}`),
+      makeRes()
+    );
+    expect(auth?.extra?.userId).toBe("user-1");
+    expect(auth?.extra?.refreshTokenId).toBe("rt-1");
+    expect(prisma.userApiToken.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("authenticates a personal API key when the id is not an OAuth token, and bumps lastUsed", async () => {
+    const secret = "keysecret";
+    const bump = vi.fn(async () => ({}));
+    const prisma = makePrisma({
+      userApiToken: {
+        findUnique: vi.fn(async () => ({
+          id: "key-1",
+          hash: createHash(secret),
+          oauthClientId: null,
+          expiresAt: null, // never expires — the CI case
+          name: "ci-key",
+          user,
+        })),
+        update: bump,
+      },
+    });
+    const scheduled: Array<() => Promise<any>> = [];
+    const auth = await new AuthChecker(prisma, fn => scheduled.push(fn)).requireAccessToken(
+      makeReq(`Bearer key-1:${secret}`),
+      makeRes()
+    );
+    expect(auth?.extra?.userId).toBe("user-1");
+    expect(auth?.extra?.refreshTokenId).toBe("key-1");
+    expect(auth?.clientId).toBe("api-key");
+    await Promise.all(scheduled.map(fn => fn()));
+    expect(bump).toHaveBeenCalledWith({ where: { id: "key-1" }, data: { lastUsed: expect.any(Date) } });
+  });
+
+  it("rejects an OAuth refresh token (oauthClientId set) presented as an API key", async () => {
+    const secret = "refreshsecret";
+    const prisma = makePrisma({
+      userApiToken: {
+        findUnique: vi.fn(async () => ({
+          id: "rt-1",
+          hash: createHash(secret),
+          oauthClientId: "client-1", // a refresh token, not a personal key
+          expiresAt: null,
+          user,
+        })),
+      },
+    });
+    const res = makeRes();
+    const auth = await new AuthChecker(prisma, noopSchedule).requireAccessToken(makeReq(`Bearer rt-1:${secret}`), res);
+    expect(auth).toBeUndefined();
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error_description).toMatch(/refresh tokens cannot be used/i);
+  });
+
+  it("does not fall through to the API-key path when an OAuth token exists but the secret is wrong", async () => {
+    const prisma = makePrisma({
+      oAuthAccessToken: {
+        findUnique: vi.fn(async () => ({
+          id: "at-1",
+          hash: createHash("right"),
+          expiresAt: new Date(Date.now() + 60_000),
+          refreshTokenId: "rt-1",
+          refreshToken: { user, oauthClientId: "client-1", oauthClient: { name: "Claude" } },
+        })),
+      },
+    });
+    const res = makeRes();
+    const auth = await new AuthChecker(prisma, noopSchedule).requireAccessToken(makeReq("Bearer at-1:wrong"), res);
+    expect(auth).toBeUndefined();
+    expect(res.statusCode).toBe(401);
+    // The wrong secret must not send a second 401 via the key path.
+    expect(prisma.userApiToken.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/webapps/console/lib/server/mcp-server/auth.ts
+++ b/webapps/console/lib/server/mcp-server/auth.ts
@@ -41,14 +41,34 @@ export class AuthChecker {
       send401(res, "invalid_token", "Token format must be tokenId:secret");
       return undefined;
     }
+    // Two auth paths share the `keyId:secret` bearer shape. The OAuth path
+    // (interactive clients) is the hot one, so try it first; on a miss, fall
+    // back to a personal API key — the same key the management REST API accepts,
+    // for CI / headless where the browser OAuth flow can't run.
+    const oauth = await this.fromOAuthAccessToken(res, raw, tokenId, secret);
+    if (oauth) return oauth;
+    // A found-but-invalid OAuth token (bad secret / expired) already sent its
+    // 401; only fall through to the API-key path when the id simply wasn't an
+    // OAuth access token.
+    if (res.headersSent) return undefined;
+    return this.fromApiKey(res, raw, tokenId, secret);
+  }
+
+  // OAuth path: short-lived OAuthAccessToken minted via the authorize flow.
+  // Returns undefined (without sending a response) when no such token exists,
+  // so the caller can try the API-key path. A found-but-invalid token (bad
+  // secret / expired) sends its own 401 and returns undefined.
+  private async fromOAuthAccessToken(
+    res: NextApiResponse,
+    raw: string,
+    tokenId: string,
+    secret: string
+  ): Promise<AuthInfo | undefined> {
     const at = await this.prisma.oAuthAccessToken.findUnique({
       where: { id: tokenId },
       include: { refreshToken: { include: { user: true, oauthClient: true } } },
     });
-    if (!at) {
-      send401(res, "invalid_token", "Access token not found");
-      return undefined;
-    }
+    if (!at) return undefined;
     if (!checkHash(at.hash, secret)) {
       send401(res, "invalid_token", "Access token secret mismatch");
       return undefined;
@@ -68,10 +88,9 @@ export class AuthChecker {
     });
 
     const user = at.refreshToken.user;
-    const clientId = at.refreshToken.oauthClientId ?? "unknown";
     return {
       token: raw,
-      clientId,
+      clientId: at.refreshToken.oauthClientId ?? "unknown",
       scopes: [],
       expiresAt: Math.floor(at.expiresAt.getTime() / 1000),
       extra: {
@@ -85,6 +104,64 @@ export class AuthChecker {
         loginProvider: user.loginProvider,
         refreshTokenId: at.refreshTokenId,
         clientName: at.refreshToken.oauthClient?.name,
+      },
+    };
+  }
+
+  // API-key path: a personal UserApiToken (oauthClientId IS NULL), the same key
+  // type the management REST API accepts (see lib/api.ts). Always sends a 401 on
+  // failure — it's the last path tried, so an unknown id here means the whole
+  // bearer is invalid.
+  private async fromApiKey(
+    res: NextApiResponse,
+    raw: string,
+    tokenId: string,
+    secret: string
+  ): Promise<AuthInfo | undefined> {
+    const token = await this.prisma.userApiToken.findUnique({
+      where: { id: tokenId },
+      include: { user: true },
+    });
+    if (!token) {
+      send401(res, "invalid_token", "Access token not found");
+      return undefined;
+    }
+    // OAuth refresh tokens live in UserApiToken too, but must not be usable as
+    // MCP bearer keys — symmetric to the rejection in lib/api.ts for the REST API.
+    if (token.oauthClientId) {
+      send401(res, "invalid_token", "OAuth refresh tokens cannot be used as MCP API keys");
+      return undefined;
+    }
+    if (!checkHash(token.hash, secret)) {
+      send401(res, "invalid_token", "Access token secret mismatch");
+      return undefined;
+    }
+    if (token.expiresAt && token.expiresAt.getTime() < Date.now()) {
+      send401(res, "expired_token", "API key has expired");
+      return undefined;
+    }
+    this.schedule(async () => {
+      await this.prisma.userApiToken
+        .update({ where: { id: token.id }, data: { lastUsed: new Date() } })
+        .catch(e => log.atWarn().withCause(e).log("Failed to bump UserApiToken.lastUsed"));
+    });
+
+    const user = token.user;
+    return {
+      token: raw,
+      clientId: "api-key",
+      scopes: [],
+      // No server-side expiry for a non-expiring key; carry the row's expiry if set.
+      expiresAt: token.expiresAt ? Math.floor(token.expiresAt.getTime() / 1000) : undefined,
+      extra: {
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+        externalId: user.externalId,
+        loginProvider: user.loginProvider,
+        // Attribute audit rows to the API key itself (no OAuth refresh token here).
+        refreshTokenId: token.id,
+        clientName: token.name ?? undefined,
       },
     };
   }

--- a/webapps/console/lib/server/mcp-server/auth.ts
+++ b/webapps/console/lib/server/mcp-server/auth.ts
@@ -126,14 +126,18 @@ export class AuthChecker {
       send401(res, "invalid_token", "Access token not found");
       return undefined;
     }
+    // Verify the secret before branching on the token's kind, so a bad secret
+    // returns the same error for every id — without this, the oauthClientId
+    // check below would be a token-type oracle for callers who don't hold the
+    // secret. Matches the check order in lib/api.ts for the REST API.
+    if (!checkHash(token.hash, secret)) {
+      send401(res, "invalid_token", "Access token secret mismatch");
+      return undefined;
+    }
     // OAuth refresh tokens live in UserApiToken too, but must not be usable as
     // MCP bearer keys — symmetric to the rejection in lib/api.ts for the REST API.
     if (token.oauthClientId) {
       send401(res, "invalid_token", "OAuth refresh tokens cannot be used as MCP API keys");
-      return undefined;
-    }
-    if (!checkHash(token.hash, secret)) {
-      send401(res, "invalid_token", "Access token secret mismatch");
       return undefined;
     }
     if (token.expiresAt && token.expiresAt.getTime() < Date.now()) {


### PR DESCRIPTION
Lets MCP clients authenticate with a personal API key, so the server can be used in CI and other headless environments where the browser OAuth flow can't run. This is a follow-up on the MCP work in #1371; the remaining JITSU-66 tool groups (syncs, test/debug, reports) land separately.

## What changed

`AuthChecker.requireAccessToken` now tries two token kinds behind the same `Bearer keyId:secret` shape:

1. **OAuth access token** (unchanged, hot path) — minted by the browser OAuth flow, short-lived.
2. **Personal API key** — a `UserApiToken` with `oauthClientId IS NULL`, the *same* key the management REST API already accepts. Can be non-expiring, which is what CI wants.

OAuth refresh tokens also live in `UserApiToken`, so they're explicitly rejected on the key path — symmetric to the existing rejection in `lib/api.ts`. A found-but-invalid OAuth token doesn't fall through to the key path (guards against a double-401 once headers are sent).

No schema change: one key works for both the REST API and MCP, managed through the existing keys UI.

## Docs

User-facing docs (an "Automation and CI" section on the MCP page) go in a separate PR on the `websites` repo.

## Tests

`__tests__/mcp-auth.test.ts` — OAuth path still authenticates and doesn't consult the key path; personal key authenticates and bumps `lastUsed`; refresh token rejected on the key path; wrong-secret OAuth token doesn't fall through.