### PR TITLE
JITSU-73 docs: add CHANGES.md with 2.14.0 release notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,11 +66,17 @@ cluster.
 - **The enterprise billing API (`webapps/ee-api`) was removed** from the repository;
   it is no longer part of the open-source distribution.
 
-#### docker-compose setup rewritten
+#### docker-compose is deprecated in favor of the development Helm chart
 
-The `docker/` compose file was rebuilt around profiles (`jitsu-services`,
-`jitsu-dependencies`, `jitsu-services-dev` with hot reload) and now builds from source or
-pulls images. Notable operator-facing changes:
+**The Docker Compose setup (`docker/`) is deprecated and will be removed in a future
+release.** It predates the function-server architecture: it runs neither the operator nor
+function servers, so functions, profile builders and connector syncs are not available
+there. The recommended way to run development builds of the full Jitsu architecture is
+the **development Helm chart** (`helm/`, deploys to Minikube — see `helm/README.md`).
+
+For now the compose file remains in the repository. It was rebuilt around profiles
+(`jitsu-services`, `jitsu-dependencies`, `jitsu-services-dev` with hot reload) and builds
+from source or pulls images. Notable operator-facing changes:
 
 - **Redis is no longer part of the default stack** — functions state lives in MongoDB
   and the events log in ClickHouse. Redis is still supported as an alternative functions
@@ -138,10 +144,11 @@ pulls images. Notable operator-facing changes:
   verification, plus OIDC (`AUTH_OIDC_PROVIDER`) improvements.
 - **Segment-style `sentAt` clock-skew correction** for batch ingestion.
 - **events_log retention via ClickHouse TTL** instead of periodic scan-and-delete.
-- **Dev Helm chart** (`helm/`) — deploy development builds of all Jitsu services
-  (including the operator) to Minikube, building each service in init containers from
-  local sources (#1240). This is the recommended way to run development builds of the
-  full Kubernetes architecture; see `helm/README.md`.
+- **Development Helm chart** (`helm/`) — deploy development builds of all Jitsu services
+  (including the operator and function servers) to Minikube, building each service in
+  init containers from local sources (#1240). It **replaces the deprecated Docker Compose
+  setup** as the recommended way to run development builds of the full Kubernetes
+  architecture; see `helm/README.md`.
 - **Dev experience**: layered `.env.local` loading, `dev-scripts` package (`pnpm dev`),
   hot-reload docker-compose profile, `copy-db` tool.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,190 @@
+# Jitsu Release Notes
+
+## 2.14.0
+
+First stable release since `jitsu2-v2.11.0` (August 2025). It aggregates ~1,600 commits
+of work, including two architectural changes that affect every self-hosted deployment.
+Read the **Breaking changes** section before upgrading.
+
+> Versioning note: starting with this release, service images and GitHub releases are
+> tagged `jitsu-services<version>` (e.g. `jitsu-services2.14.0`) instead of the previous
+> `jitsu2-v<version>` scheme.
+
+---
+
+### ⚠️ Breaking changes
+
+#### Kubernetes is now required for a feature-complete Jitsu
+
+Two core subsystems moved to Kubernetes-native architectures. A plain docker-compose
+deployment can still be used for exploration and development, but a production setup —
+functions, profile builders and connector syncs included — now requires a Kubernetes
+cluster.
+
+**1. Functions pipeline extracted to dedicated Function Servers managed by an operator** (#1239, #1249, #1252)
+
+- User functions (UDFs) and profile builders no longer run inside the `rotor` event
+  consumer. They run in dedicated **function-server** deployments (the same
+  `jitsucom/rotor` image started with `ROTOR_MODE=functions`), one per workspace for
+  `dedicated` class or shared sharded deployments for `free` class.
+- A new **operator** service (`jitsucom/operator`) reconciles these deployments in
+  Kubernetes: it polls the console export, creates/updates per-deployment `Deployment`,
+  `Service` (`fs-<deploymentId>:3456`), `ConfigMap`, `HorizontalPodAutoscaler` and
+  `PodDisruptionBudget` objects, and records deployment routing in the new
+  `FunctionsServer` Postgres table.
+- `ingest`, `rotor` and `console` reach function servers via the new
+  `FUNCTIONS_SERVER_URL_TEMPLATE` env var (default `http://fs-${workspaceId}:3456`).
+- **Upgrade impact: the operator is mandatory for event delivery.** Rotor routes events
+  based on the `FunctionsServer` table; connections without function-server routing
+  information are dropped. Deploy the operator (with RBAC for pods, services,
+  configmaps, secrets, deployments, HPAs and PDBs) before upgrading rotor.
+- The legacy in-rotor UDF pipeline was removed (#1280).
+
+**2. Connector syncs moved from Google Cloud Scheduler to Kubernetes CronJobs** (#1287)
+
+- `syncctl` now polls the console's `/api/admin/export/syncs` endpoint and reconciles
+  one Kubernetes `CronJob` per scheduled sync (labeled `jitsu.com/managed-by=syncctl`),
+  each with its config in a per-sync `Secret`. Scheduled runs execute as autonomous pods
+  without calling back into syncctl.
+- **`GOOGLE_SCHEDULER_KEY` and all Google Cloud Scheduler integration removed.** No
+  replacement configuration is needed — scheduling is native to the cluster. New
+  syncctl env vars: `SYNCCTL_REPOSITORY_BASE_URL`, `SYNCCTL_REPOSITORY_AUTH_TOKEN`,
+  `SYNCCTL_CRON_TEMPLATE_REVISION`, `SYNCCTL_JOB_ACTIVE_DEADLINE_SECONDS`,
+  `SYNCCTL_JOB_BACKOFF_LIMIT`, `SYNCCTL_JITTER_MAX_SECONDS`.
+- Synchronous (inline) syncs were removed.
+- Task-log retention settings `SYNC_TASK_LOG_SIZE` / `SYNC_TASK_LOG_AGE` moved from
+  console to syncctl.
+- OAuth token refresh for sources now runs as an init container; syncctl gained
+  `NANGO_API_HOST`, `NANGO_SECRET_KEY` and `GOOGLE_ADS_DEVELOPER_TOKEN` settings.
+
+#### Repository and image changes
+
+- **Bulker, ingest, syncctl, sync-sidecar and the connectors codebase were consolidated
+  into the `jitsucom/jitsu` monorepo.** Docker images keep their names
+  (`jitsucom/bulker`, `jitsucom/ingest`, `jitsucom/syncctl`, `jitsucom/sidecar`) but are
+  now built and versioned together with the rest of Jitsu.
+- **The enterprise billing API (`webapps/ee-api`) was extracted** to a separate
+  repository ([jitsucom/jitsu-cloud-billing](https://github.com/jitsucom/jitsu-cloud-billing));
+  it is no longer part of the open-source distribution.
+
+#### docker-compose setup rewritten
+
+The `docker/` compose file was rebuilt around profiles (`jitsu-services`,
+`jitsu-dependencies`, `jitsu-services-dev` with hot reload) and now builds from source or
+pulls images. Notable operator-facing changes:
+
+- **Redis is no longer part of the default stack** — functions state lives in MongoDB
+  and the events log in ClickHouse. Redis is still supported as an alternative functions
+  state store via `REDIS_URL`.
+- Kafka (bitnami image) replaced with **Redpanda**; new admin UIs included (Redpanda
+  Console, PgWeb, Mongo Express, Keycloak).
+- `docker/.env.example` removed — configuration is done via environment or `.env.local`;
+  defaults work out of the box (seeded login `admin@jitsu.com` / `admin123`, customizable
+  via `SEED_USER_EMAIL` / `SEED_USER_PASSWORD`).
+- Renamed variables: `DOCKER_TAG` → `RELEASE_TAG`, `JITSU_UI_PORT` → `CONSOLE_PORT`,
+  `JITSU_INGEST_PORT` → `INGEST_PORT` (default changed 8080 → 3049);
+  `EXTERNAL_POSTGRES_HOST` removed; Postgres is exposed on `PG_PORT` (default 5438).
+- Default passwords are no longer `default` (see `docker/README.md`).
+
+#### Console behavior changes
+
+- **Auth session cookie is host-only by default.** Set the new `AUTH_COOKIE_DOMAIN` env
+  var to share the session across subdomains.
+- **Signups can be restricted to work emails**: new `LIMIT_PERSONAL_EMAILS` env var
+  (default `false`) rejects personal-email domains (JITSU-70).
+- `JITSU_CONSOLE_READ_ONLY_UNTIL` removed — replaced by the new maintenance mode
+  (`MAINTENANCE` / `MAINTENANCE_CONFIG_FILE`).
+- API tokens and internal secrets are now generated with a cryptographically secure RNG
+  (#1356).
+- Console API is rate-limited by default with a sliding-window per-minute limiter
+  (`MINUTE_RATE_LIMIT_ENABLED`, default on; tune with `MINUTE_RATE_LIMIT_BASE`).
+- Invalid or missing environment configuration now fails console startup with an
+  explicit error instead of silently falling back to defaults.
+
+#### Other breaking / behavior changes
+
+- `MAX_INGEST_PAYLOAD_SIZE` default lowered to 1,000,000 bytes.
+- Functions `fetch()` timeout is now controlled by `FETCH_TIMEOUT_MS` (default 2000 ms)
+  instead of being hardcoded (#1254).
+- Ingest no longer restricts `track` event names and strips all Jitsu special
+  properties (`JITSU_TABLE_NAME`, `__sql_type_*`, …) from ingested events.
+- Toolchain: Node.js ≥ 22, pnpm ≥ 10, Go 1.26, Next.js 16; rotor migrated to the
+  Confluent Kafka client (#1222); npm packages published via OIDC trusted publishing
+  (#1255).
+
+---
+
+### ✨ New features
+
+- **Functions Server platform** — per-workspace function execution with `free` /
+  `dedicated` / `premium` classes, seamless class transitions, sharding, autoscaling
+  (HPA), pod disruption budgets and a Deno-based runtime (#1239, #1249).
+- **Profile Builder v2** running on function servers, with configurable MongoDB /
+  warehouse / UDF timeouts (#1252).
+- **MCP server** — Jitsu console now exposes a Model Context Protocol server with OAuth
+  2.1 and Dynamic Client Registration (#1303), plus MCP auth via personal API keys
+  (JITSU-66). MCP tools cover config CRUD and live event inspection.
+- **OpenAPI spec + API reference** — the console API (including the Sync API) is
+  described by a generated OpenAPI spec with a built-in Scalar API viewer.
+- **User API tokens** with names, types and expiration dates, managed on a redesigned
+  account page.
+- **Audit log** (SOC2-oriented) with account-activity alerts and UI/API/CLI origin tags
+  (#1288).
+- **Maintenance mode** — read-only API mode and a friendly "database down" page.
+- **Dead-letter queue and reprocessing** — failed events are dead-lettered (#1227) and
+  can be replayed by the new reprocessing worker; oversized messages are trimmed before
+  dead-lettering. Email notifications for unrecoverable events.
+- **Batched sync/connection notifications** summarized by table, with flapping detection.
+- **Redesigned signup flow** — real email/password auth with server-side email
+  verification, plus OIDC (`AUTH_OIDC_PROVIDER`) improvements.
+- **Segment-style `sentAt` clock-skew correction** for batch ingestion.
+- **events_log retention via ClickHouse TTL** instead of periodic scan-and-delete.
+- **Dev Helm chart** (`helm/`) — deploy development builds of all Jitsu services
+  (including the operator) to Minikube, building each service in init containers from
+  local sources (#1240). This is the recommended way to run development builds of the
+  full Kubernetes architecture; see `helm/README.md`.
+- **Dev experience**: layered `.env.local` loading, `dev-scripts` package (`pnpm dev`),
+  hot-reload docker-compose profile, `copy-db` tool.
+
+### 🔌 New integrations
+
+- **Resend** email destination (JITSU-71)
+- **SendGrid** email destination (JITSU-71)
+- **Statsig** destination
+- **DuckDB / MotherDuck** warehouse destination
+- **Xero** source connector (Jitsu-maintained)
+- **Google Tag Manager**: "Load GTM" toggle, `resetDataLayer` option
+- **Snowflake**: key-pair authentication
+- **Firebase source**: subcollection sync via CollectionGroup queries
+- **Postgres destination**: Google Cloud Private Service Connect authentication
+- **Redshift**: IAM role-based authentication improvements, SUPER type for JSON columns
+
+### 🛠 Improvements and fixes
+
+- Sources: connector specs auto-reload when the image is newer than the cached spec;
+  per-stream error isolation for Firebase; sidecar watchdogs and bounded state writes.
+- Sync jobs: cancellation scoped to task (not whole sync); accurate started-at times
+  from pod status; sync quota initialization.
+- Bulker / warehouses: Snowflake MERGE split into dedup + UPDATE + INSERT with large
+  performance gains; ClickHouse batch inserts, partial JSON type support and `ON CLUSTER`
+  quoting; multi-partition retry topics; batch deduplication; consumer backpressure;
+  `spreadTablesSchedule` option; memory and allocation optimizations.
+- Ingest: pixel endpoint click tracking (`destination_url`), event throttling, weighted
+  partition selection (optional), batch endpoint deduplication, failover logger with S3
+  offload.
+- Console: search filters on all entity lists; linked-entity checks on deletion;
+  provisioned destination credentials masked; billing/subscription-status fixes;
+  hardened HTTP security headers; numerous UI fixes.
+- JS SDK (`@jitsu/js`): `identify()` on init when `userId` is provided,
+  `preInitAnonymousId` option, GA4 new session-cookie format support (#1219).
+- `jitsu-cli`: config command tree, OpenAPI spec dump, default workspace support,
+  function cache consistency fixes.
+- Security: continuous dependency CVE patching across Go and npm stacks; tokens no
+  longer exposed in error messages; DNS caching for outbound HTTP pools.
+- CI/CD: multi-arch (amd64 + arm64) images, AI code review on every PR, automated beta
+  releases from `newjitsu`, MIT license declaration with third-party notices.
+
+---
+
+For configuration details of the new services (operator, function servers, CronJob-based
+syncs), see the [self-hosting documentation](https://docs.jitsu.com/self-hosting).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,6 @@ First stable release since `jitsu2-v2.11.0` (August 2025). It aggregates ~1,600 
 of work, including two architectural changes that affect every self-hosted deployment.
 Read the **Breaking changes** section before upgrading.
 
-> Versioning note: starting with this release, service images and GitHub releases are
-> tagged `jitsu-services<version>` (e.g. `jitsu-services2.14.0`) instead of the previous
-> `jitsu2-v<version>` scheme.
-
 ---
 
 ### ⚠️ Breaking changes
@@ -25,8 +21,7 @@ cluster.
 
 - User functions (UDFs) and profile builders no longer run inside the `rotor` event
   consumer. They run in dedicated **function-server** deployments (the same
-  `jitsucom/functions-server` image started with `ROTOR_MODE=functions`), one per workspace for
-  `dedicated` class or shared sharded deployments for `free` class.
+  `jitsucom/functions-server` image started with `ROTOR_MODE=functions`)
 - A new **operator** service (`jitsucom/operator`) reconciles these deployments in
   Kubernetes: it polls the console export, creates/updates per-deployment `Deployment`,
   `Service` (`fs-<deploymentId>:3456`), `ConfigMap`, `HorizontalPodAutoscaler` and
@@ -51,7 +46,6 @@ cluster.
   syncctl env vars: `SYNCCTL_REPOSITORY_BASE_URL`, `SYNCCTL_REPOSITORY_AUTH_TOKEN`,
   `SYNCCTL_CRON_TEMPLATE_REVISION`, `SYNCCTL_JOB_ACTIVE_DEADLINE_SECONDS`,
   `SYNCCTL_JOB_BACKOFF_LIMIT`, `SYNCCTL_JITTER_MAX_SECONDS`.
-- Synchronous (inline) syncs were removed.
 - Task-log retention settings `SYNC_TASK_LOG_SIZE` / `SYNC_TASK_LOG_AGE` moved from
   console to syncctl.
 - OAuth token refresh for sources now runs as an init container; syncctl gained
@@ -63,8 +57,6 @@ cluster.
   into the `jitsucom/jitsu` monorepo.** Docker images keep their names
   (`jitsucom/bulker`, `jitsucom/ingest`, `jitsucom/syncctl`, `jitsucom/sidecar`) but are
   now built and versioned together with the rest of Jitsu.
-- **The enterprise billing API (`webapps/ee-api`) was removed** from the repository;
-  it is no longer part of the open-source distribution.
 
 #### docker-compose is deprecated in favor of the development Helm chart
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ cluster.
 
 - User functions (UDFs) and profile builders no longer run inside the `rotor` event
   consumer. They run in dedicated **function-server** deployments (the same
-  `jitsucom/rotor` image started with `ROTOR_MODE=functions`), one per workspace for
+  `jitsucom/functions-server` image started with `ROTOR_MODE=functions`), one per workspace for
   `dedicated` class or shared sharded deployments for `free` class.
 - A new **operator** service (`jitsucom/operator`) reconciles these deployments in
   Kubernetes: it polls the console export, creates/updates per-deployment `Deployment`,
@@ -111,8 +111,7 @@ from source or pulls images. Notable operator-facing changes:
 - `MAX_INGEST_PAYLOAD_SIZE` default lowered to 1,000,000 bytes.
 - Functions `fetch()` timeout is now controlled by `FETCH_TIMEOUT_MS` (default 2000 ms)
   instead of being hardcoded (#1254).
-- Ingest no longer restricts `track` event names and strips all Jitsu special
-  properties (`JITSU_TABLE_NAME`, `__sql_type_*`, …) from ingested events.
+- Ingest no longer restricts `track` event names
 - Toolchain: Node.js ≥ 22, pnpm ≥ 10, Go 1.26, Next.js 16; rotor migrated to the
   Confluent Kafka client (#1222); npm packages published via OIDC trusted publishing
   (#1255).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,8 +133,8 @@ from source or pulls images. Notable operator-facing changes:
   described by a generated OpenAPI spec with a built-in Scalar API viewer.
 - **User API tokens** with names, types and expiration dates, managed on a redesigned
   account page.
-- **Audit log** (SOC2-oriented) with account-activity alerts and UI/API/CLI origin tags
-  (#1288).
+- **Audit log** (SOC2-oriented) with account-activity alerts, UI/API/CLI origin tags
+  (#1288) and a workspace filter in the admin view (#1386).
 - **Maintenance mode** — read-only API mode and a friendly "database down" page.
 - **Dead-letter queue and reprocessing** — failed events are dead-lettered (#1227) and
   can be replayed by the new reprocessing worker; oversized messages are trimmed before
@@ -146,9 +146,11 @@ from source or pulls images. Notable operator-facing changes:
 - **events_log retention via ClickHouse TTL** instead of periodic scan-and-delete.
 - **Development Helm chart** (`helm/`) — deploy development builds of all Jitsu services
   (including the operator and function servers) to Minikube, building each service in
-  init containers from local sources (#1240). It **replaces the deprecated Docker Compose
-  setup** as the recommended way to run development builds of the full Kubernetes
-  architecture; see `helm/README.md`.
+  init containers from local sources (#1240). It ships an in-cluster single-node Kafka
+  (Redpanda), enabled by default — set `scaling.kafka.replicas: 0` to use an external
+  broker instead (#1384). It **replaces the deprecated Docker Compose setup** as the
+  recommended way to run development builds of the full Kubernetes architecture; see
+  `helm/README.md`.
 - **Dev experience**: layered `.env.local` loading, `dev-scripts` package (`pnpm dev`),
   hot-reload docker-compose profile, `copy-db` tool.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,8 +63,7 @@ cluster.
   into the `jitsucom/jitsu` monorepo.** Docker images keep their names
   (`jitsucom/bulker`, `jitsucom/ingest`, `jitsucom/syncctl`, `jitsucom/sidecar`) but are
   now built and versioned together with the rest of Jitsu.
-- **The enterprise billing API (`webapps/ee-api`) was extracted** to a separate
-  repository ([jitsucom/jitsu-cloud-billing](https://github.com/jitsucom/jitsu-cloud-billing));
+- **The enterprise billing API (`webapps/ee-api`) was removed** from the repository;
   it is no longer part of the open-source distribution.
 
 #### docker-compose setup rewritten

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,13 +144,17 @@ from source or pulls images. Notable operator-facing changes:
   verification, plus OIDC (`AUTH_OIDC_PROVIDER`) improvements.
 - **Segment-style `sentAt` clock-skew correction** for batch ingestion.
 - **events_log retention via ClickHouse TTL** instead of periodic scan-and-delete.
-- **Development Helm chart** (`helm/`) — deploy development builds of all Jitsu services
-  (including the operator and function servers) to Minikube, building each service in
-  init containers from local sources (#1240). It ships an in-cluster single-node Kafka
-  (Redpanda), enabled by default — set `scaling.kafka.replicas: 0` to use an external
-  broker instead (#1384). It **replaces the deprecated Docker Compose setup** as the
-  recommended way to run development builds of the full Kubernetes architecture; see
-  `helm/README.md`.
+- **Development Helm charts** (`helm/` + `helm-deps/`) — deploy development builds of
+  all Jitsu services (including the operator and function servers) to Minikube with
+  **zero configuration**, building each service in init containers from local sources
+  (#1240, #1384, #1387). All dependencies — single-node PostgreSQL, ClickHouse, MongoDB
+  and Kafka (Redpanda) — run in-cluster via the separate `helm-deps` chart;
+  `dev-deploy.sh deploy` installs it first, waits for every dependency to be healthy,
+  auto-generates the inter-service secrets, applies the console DB schema on every
+  deploy, and reports per-component readiness. Go builds are serialized and
+  resource-capped so they can't overload the node. It **replaces the deprecated Docker
+  Compose setup** as the recommended way to run development builds of the full
+  Kubernetes architecture; see `helm/README.md`.
 - **Dev experience**: layered `.env.local` loading, `dev-scripts` package (`pnpm dev`),
   hot-reload docker-compose profile, `copy-db` tool.
 


### PR DESCRIPTION
JITSU-73

## What

Adds `CHANGES.md` with release notes for the upcoming **2.14.0** stable release — the first stable since `jitsu2-v2.11.0` (August 2025, ~1,600 commits).

## Structure

- **Breaking changes** (highlighted):
  - Functions pipeline extracted to dedicated **function servers** managed by the new **operator** service — Kubernetes is now required for a feature-complete setup, and the operator is mandatory for event delivery (rotor routes/drops events based on the `FunctionsServer` table)
  - Connector syncs moved from Google Cloud Scheduler to **Kubernetes CronJobs** (`GOOGLE_SCHEDULER_KEY` removed)
  - Bulker/ingest/syncctl/connectors consolidated into this monorepo; EE billing API removed from the open-source distribution
  - docker-compose **deprecated in favor of the development Helm chart** (plus its rewrite: profiles, Redpanda, no Redis in default stack, renamed vars)
  - Console: host-only auth cookie + `AUTH_COOKIE_DOMAIN`, `LIMIT_PERSONAL_EMAILS`, maintenance mode, default API rate limiting
- **New features** and **new integrations** (Resend, SendGrid, Statsig, DuckDB/MotherDuck, Xero, …) highlighted
- Everything else as a condensed improvements/fixes list

Facts were compiled from the full commit log `jitsu2-v2.11.0..newjitsu` and verified against current source (env schemas, operator/sync-controller code, compose file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


