### PR TITLE
JITSU-86 refactor(helm): merge container env into a single map to prevent duplicates

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -76,10 +76,14 @@ Value precedence (which definition wins on a name clash), lowest first:
 in env.common.CONSOLE_URL as its own fallback via jitsu-dev.consoleUrl.)
 
 Emission order (independent of precedence) is chart-provided bases first, user
-config last: computed, extra, env.common, env.<service>. Kubernetes $(VAR)
-expansion only sees vars defined earlier in the list, so a user override like
-env.common.A="$(HTTP_PORT)" must render after the chart's HTTP_PORT. Each name
-is emitted at its first appearance in that order, carrying its winning value.
+config last — by the phase that produced each name's *winning* value, ordered:
+computed, extra, env.common, env.<service>. Kubernetes $(VAR) expansion only
+sees vars defined earlier in the list, so a name whose value references another
+must render after it: a user override like env.common.A="$(HTTP_PORT)" emits
+after the chart's HTTP_PORT, and even env.<service>.CONSOLE_URL="$(HTTP_PORT)"
+(overriding a computed key) emits at the service phase, after HTTP_PORT.
+Limitation: two overrides in the *same* phase referencing each other still
+order alphabetically — expansion between them is not guaranteed.
 
 Args (dict):
   ctx      — root template context (required)
@@ -106,20 +110,28 @@ Args (dict):
 {{- $extra := .extra | default dict -}}
 {{- $service := index $ctx.Values.env .service | default dict -}}
 {{- $exclude := .exclude | default list -}}
-{{- /* Winning value per name: overlay low→high precedence so the last write wins. */ -}}
+{{- /* Winning value and its source phase per name. Overlay in low→high
+       precedence order (env.common < computed < extra < service) so the last
+       write wins; record which phase that was for emission ordering. */ -}}
 {{- $winner := dict -}}
-{{- range $k, $v := $common }}{{- $_ := set $winner $k $v }}{{- end }}
-{{- range $k, $v := $computed }}{{- $_ := set $winner $k $v }}{{- end }}
-{{- range $k, $v := $extra }}{{- $_ := set $winner $k $v }}{{- end }}
-{{- range $k, $v := $service }}{{- $_ := set $winner $k $v }}{{- end }}
-{{- /* Emit in bases-first order, each name once at its first appearance. */ -}}
-{{- $emitted := dict -}}
-{{- range $group := (list $computed $extra $common $service) }}
-{{- range $k, $_v := $group }}
-{{- if and (not (hasKey $emitted $k)) (not (has $k $exclude)) }}
-{{- $_ := set $emitted $k true }}
+{{- $source := dict -}}
+{{- range $phase := (list
+      (dict "name" "common" "vars" $common)
+      (dict "name" "computed" "vars" $computed)
+      (dict "name" "extra" "vars" $extra)
+      (dict "name" "service" "vars" $service)) }}
+{{- range $k, $v := $phase.vars }}
+{{- $_ := set $winner $k $v }}
+{{- $_ := set $source $k $phase.name }}
+{{- end }}
+{{- end }}
+{{- /* Emit each name once, grouped by the phase of its winning value, in
+       bases-first order so referenced vars precede the vars that use them. */ -}}
+{{- range $phase := (list "computed" "extra" "common" "service") }}
+{{- range $k, $v := $winner }}
+{{- if and (eq (get $source $k) $phase) (not (has $k $exclude)) }}
 - name: {{ $k }}
-  value: {{ get $winner $k | quote }}
+  value: {{ $v | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -66,40 +66,42 @@ http://console:3000
 {{- end }}
 
 {{/*
-Common environment variables
+Container env, merged into a single map so every name is emitted exactly
+once — Helm 4 applies manifests with server-side apply, which rejects
+duplicate env names (helm/helm#31529); Helm 3 silently used the last entry.
+Precedence, later wins:
+  env.common < computed console/service URLs < template defaults ("extra") < env.<service>
+Args (dict):
+  ctx      — root template context (required)
+  service  — key into .Values.env for per-service overrides (required)
+  extra    — dict of service-specific defaults the template used to hardcode
+  exclude  — list of names the template emits manually (valueFrom entries),
+             so a per-service override can't duplicate them
 */}}
-{{- define "jitsu-dev.commonEnv" -}}
-{{- $consoleUrl := include "jitsu-dev.consoleUrl" . -}}
-{{- range $key, $value := .Values.env.common }}
-{{- if ne $key "CONSOLE_URL" }}
+{{- define "jitsu-dev.env" -}}
+{{- $ctx := .ctx -}}
+{{- $consoleUrl := include "jitsu-dev.consoleUrl" $ctx -}}
+{{- $vars := deepCopy ($ctx.Values.env.common | default dict) -}}
+{{- $_ := set $vars "CONSOLE_URL" $consoleUrl -}}
+{{- $_ := set $vars "REPOSITORY_URL" (printf "%s/api/admin/export/streams-with-destinations" $consoleUrl) -}}
+{{- $_ := set $vars "REPOSITORY_BASE_URL" (printf "%s/api/admin/export" $consoleUrl) -}}
+{{- $_ := set $vars "SCRIPT_ORIGIN" (printf "%s/api/s/javascript-library" $consoleUrl) -}}
+{{- $_ := set $vars "CONFIG_SOURCE" (printf "%s/api/admin/export/bulker-connections" $consoleUrl) -}}
+{{- $_ := set $vars "ROTOR_URL" "http://rotor:3401" -}}
+{{- $_ := set $vars "BULKER_URL" "http://bulker:3042" -}}
+{{- $_ := set $vars "INGEST_URL" "http://ingest:3049" -}}
+{{- $_ := set $vars "SYNCCTL_URL" "http://syncctl:3043" -}}
+{{- range $key, $value := (.extra | default dict) }}
+{{- $_ := set $vars $key $value }}
+{{- end }}
+{{- range $key, $value := (index $ctx.Values.env .service | default dict) }}
+{{- $_ := set $vars $key $value }}
+{{- end }}
+{{- $exclude := .exclude | default list -}}
+{{- range $key, $value := $vars }}
+{{- if not (has $key $exclude) }}
 - name: {{ $key }}
   value: {{ $value | quote }}
 {{- end }}
 {{- end }}
-- name: CONSOLE_URL
-  value: {{ $consoleUrl | quote }}
-- name: REPOSITORY_URL
-  value: "{{ $consoleUrl }}/api/admin/export/streams-with-destinations"
-- name: REPOSITORY_BASE_URL
-  value: "{{ $consoleUrl }}/api/admin/export"
-- name: SCRIPT_ORIGIN
-  value: "{{ $consoleUrl }}/api/s/javascript-library"
-- name: CONFIG_SOURCE
-  value: "{{ $consoleUrl }}/api/admin/export/bulker-connections"
-{{- end }}
-
-{{/*
-Inter-service URLs (k8s service discovery).
-CONSOLE_URL is emitted by commonEnv — don't add it here, duplicate env
-names fail strict server-side validation on newer Kubernetes.
-*/}}
-{{- define "jitsu-dev.serviceUrls" -}}
-- name: ROTOR_URL
-  value: "http://rotor:3401"
-- name: BULKER_URL
-  value: "http://bulker:3042"
-- name: INGEST_URL
-  value: "http://ingest:3049"
-- name: SYNCCTL_URL
-  value: "http://syncctl:3043"
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -81,27 +81,39 @@ Args (dict):
 {{- define "jitsu-dev.env" -}}
 {{- $ctx := .ctx -}}
 {{- $consoleUrl := include "jitsu-dev.consoleUrl" $ctx -}}
-{{- $vars := deepCopy ($ctx.Values.env.common | default dict) -}}
-{{- $_ := set $vars "CONSOLE_URL" $consoleUrl -}}
-{{- $_ := set $vars "REPOSITORY_URL" (printf "%s/api/admin/export/streams-with-destinations" $consoleUrl) -}}
-{{- $_ := set $vars "REPOSITORY_BASE_URL" (printf "%s/api/admin/export" $consoleUrl) -}}
-{{- $_ := set $vars "SCRIPT_ORIGIN" (printf "%s/api/s/javascript-library" $consoleUrl) -}}
-{{- $_ := set $vars "CONFIG_SOURCE" (printf "%s/api/admin/export/bulker-connections" $consoleUrl) -}}
-{{- $_ := set $vars "ROTOR_URL" "http://rotor:3401" -}}
-{{- $_ := set $vars "BULKER_URL" "http://bulker:3042" -}}
-{{- $_ := set $vars "INGEST_URL" "http://ingest:3049" -}}
-{{- $_ := set $vars "SYNCCTL_URL" "http://syncctl:3043" -}}
-{{- range $key, $value := (.extra | default dict) }}
-{{- $_ := set $vars $key $value }}
-{{- end }}
-{{- range $key, $value := (index $ctx.Values.env .service | default dict) }}
-{{- $_ := set $vars $key $value }}
-{{- end }}
+{{- $computed := dict
+      "CONSOLE_URL" $consoleUrl
+      "REPOSITORY_URL" (printf "%s/api/admin/export/streams-with-destinations" $consoleUrl)
+      "REPOSITORY_BASE_URL" (printf "%s/api/admin/export" $consoleUrl)
+      "SCRIPT_ORIGIN" (printf "%s/api/s/javascript-library" $consoleUrl)
+      "CONFIG_SOURCE" (printf "%s/api/admin/export/bulker-connections" $consoleUrl)
+      "ROTOR_URL" "http://rotor:3401"
+      "BULKER_URL" "http://bulker:3042"
+      "INGEST_URL" "http://ingest:3049"
+      "SYNCCTL_URL" "http://syncctl:3043"
+-}}
+{{- $phases := list
+      ($ctx.Values.env.common | default dict)
+      $computed
+      (.extra | default dict)
+      (index $ctx.Values.env .service | default dict)
+-}}
 {{- $exclude := .exclude | default list -}}
-{{- range $key, $value := $vars }}
-{{- if not (has $key $exclude) }}
+{{- /* Emit each key once, at the phase of its winning (last) definition,
+       alphabetical within a phase. Position matters beyond aesthetics:
+       Kubernetes $(VAR) expansion only sees vars defined earlier in the
+       list, so an override referencing a chart-provided var must render
+       after it. */ -}}
+{{- range $i, $phase := $phases }}
+{{- range $key, $value := $phase }}
+{{- $winner := true }}
+{{- range $j, $later := $phases }}
+{{- if and (gt $j $i) (hasKey $later $key) }}{{- $winner = false }}{{- end }}
+{{- end }}
+{{- if and $winner (not (has $key $exclude)) }}
 - name: {{ $key }}
   value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -66,11 +66,21 @@ http://console:3000
 {{- end }}
 
 {{/*
-Container env, merged into a single map so every name is emitted exactly
-once — Helm 4 applies manifests with server-side apply, which rejects
-duplicate env names (helm/helm#31529); Helm 3 silently used the last entry.
-Precedence, later wins:
+Container env, merged so every name is emitted exactly once — Helm 4 applies
+manifests with server-side apply, which rejects duplicate env names
+(helm/helm#31529); Helm 3 silently used the last entry.
+
+Value precedence (which definition wins on a name clash), lowest first:
   env.common < computed console/service URLs < template defaults ("extra") < env.<service>
+(computed URLs must beat env.common: the in-cluster CONSOLE_URL already folds
+in env.common.CONSOLE_URL as its own fallback via jitsu-dev.consoleUrl.)
+
+Emission order (independent of precedence) is chart-provided bases first, user
+config last: computed, extra, env.common, env.<service>. Kubernetes $(VAR)
+expansion only sees vars defined earlier in the list, so a user override like
+env.common.A="$(HTTP_PORT)" must render after the chart's HTTP_PORT. Each name
+is emitted at its first appearance in that order, carrying its winning value.
+
 Args (dict):
   ctx      — root template context (required)
   service  — key into .Values.env for per-service overrides (required)
@@ -92,27 +102,24 @@ Args (dict):
       "INGEST_URL" "http://ingest:3049"
       "SYNCCTL_URL" "http://syncctl:3043"
 -}}
-{{- $phases := list
-      ($ctx.Values.env.common | default dict)
-      $computed
-      (.extra | default dict)
-      (index $ctx.Values.env .service | default dict)
--}}
+{{- $common := $ctx.Values.env.common | default dict -}}
+{{- $extra := .extra | default dict -}}
+{{- $service := index $ctx.Values.env .service | default dict -}}
 {{- $exclude := .exclude | default list -}}
-{{- /* Emit each key once, at the phase of its winning (last) definition,
-       alphabetical within a phase. Position matters beyond aesthetics:
-       Kubernetes $(VAR) expansion only sees vars defined earlier in the
-       list, so an override referencing a chart-provided var must render
-       after it. */ -}}
-{{- range $i, $phase := $phases }}
-{{- range $key, $value := $phase }}
-{{- $winner := true }}
-{{- range $j, $later := $phases }}
-{{- if and (gt $j $i) (hasKey $later $key) }}{{- $winner = false }}{{- end }}
-{{- end }}
-{{- if and $winner (not (has $key $exclude)) }}
-- name: {{ $key }}
-  value: {{ $value | quote }}
+{{- /* Winning value per name: overlay low→high precedence so the last write wins. */ -}}
+{{- $winner := dict -}}
+{{- range $k, $v := $common }}{{- $_ := set $winner $k $v }}{{- end }}
+{{- range $k, $v := $computed }}{{- $_ := set $winner $k $v }}{{- end }}
+{{- range $k, $v := $extra }}{{- $_ := set $winner $k $v }}{{- end }}
+{{- range $k, $v := $service }}{{- $_ := set $winner $k $v }}{{- end }}
+{{- /* Emit in bases-first order, each name once at its first appearance. */ -}}
+{{- $emitted := dict -}}
+{{- range $group := (list $computed $extra $common $service) }}
+{{- range $k, $_v := $group }}
+{{- if and (not (hasKey $emitted $k)) (not (has $k $exclude)) }}
+{{- $_ := set $emitted $k true }}
+- name: {{ $k }}
+  value: {{ get $winner $k | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/templates/bulker.yaml
+++ b/helm/templates/bulker.yaml
@@ -66,14 +66,8 @@ spec:
             - secretRef:
                 name: jitsu-secrets
           env:
-            - name: HTTP_PORT
-              value: "3042"
-            {{- include "jitsu-dev.commonEnv" . | nindent 12 }}
-            {{- include "jitsu-dev.serviceUrls" . | nindent 12 }}
-            {{- range $key, $value := .Values.env.bulker }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "jitsu-dev.env" (dict "ctx" . "service" "bulker"
+                  "extra" (dict "HTTP_PORT" "3042")) | nindent 12 }}
           volumeMounts:
             - name: build
               mountPath: /build

--- a/helm/templates/console.yaml
+++ b/helm/templates/console.yaml
@@ -55,26 +55,19 @@ spec:
             - secretRef:
                 name: jitsu-secrets
           env:
-            {{- include "jitsu-dev.commonEnv" . | nindent 12 }}
-            {{- include "jitsu-dev.serviceUrls" . | nindent 12 }}
-            # Override K8s-injected *_PORT vars (tcp://...) that break zod number coercion
-            - name: BULKER_PORT
-              value: ""
-            - name: ROTOR_PORT
-              value: ""
-            - name: SYNCCTL_PORT
-              value: ""
-            - name: INGMGR_PORT
-              value: ""
-            # Maintenance descriptor mounted from `jitsu-console-maintenance`
-            # (optional ConfigMap, key `maintenance.json`). Manage via
+            # Empty *_PORT entries override K8s-injected service-link vars
+            # (tcp://...) that break zod number coercion.
+            # MAINTENANCE_CONFIG_FILE: maintenance descriptor mounted from
+            # `jitsu-console-maintenance` (optional ConfigMap, key
+            # `maintenance.json`). Manage via
             # webapps/console/scripts/maintenance-mode.sh.
-            - name: MAINTENANCE_CONFIG_FILE
-              value: /etc/jitsu/maintenance/maintenance.json
-            {{- range $key, $value := .Values.env.console }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "jitsu-dev.env" (dict "ctx" . "service" "console"
+                  "extra" (dict
+                    "BULKER_PORT" ""
+                    "ROTOR_PORT" ""
+                    "SYNCCTL_PORT" ""
+                    "INGMGR_PORT" ""
+                    "MAINTENANCE_CONFIG_FILE" "/etc/jitsu/maintenance/maintenance.json")) | nindent 12 }}
           volumeMounts:
             - name: project
               mountPath: /project

--- a/helm/templates/ingest.yaml
+++ b/helm/templates/ingest.yaml
@@ -61,14 +61,8 @@ spec:
             - secretRef:
                 name: jitsu-secrets
           env:
-            - name: HTTP_PORT
-              value: "3049"
-            {{- include "jitsu-dev.commonEnv" . | nindent 12 }}
-            {{- include "jitsu-dev.serviceUrls" . | nindent 12 }}
-            {{- range $key, $value := .Values.env.ingest }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "jitsu-dev.env" (dict "ctx" . "service" "ingest"
+                  "extra" (dict "HTTP_PORT" "3049")) | nindent 12 }}
           volumeMounts:
             - name: build
               mountPath: /build

--- a/helm/templates/operator.yaml
+++ b/helm/templates/operator.yaml
@@ -62,14 +62,8 @@ spec:
             - secretRef:
                 name: jitsu-secrets
           env:
-            - name: HTTP_PORT
-              value: "3052"
-            {{- include "jitsu-dev.commonEnv" . | nindent 12 }}
-            {{- include "jitsu-dev.serviceUrls" . | nindent 12 }}
-            {{- range $key, $value := .Values.env.operator }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "jitsu-dev.env" (dict "ctx" . "service" "operator"
+                  "extra" (dict "HTTP_PORT" "3052")) | nindent 12 }}
           volumeMounts:
             - name: build
               mountPath: /build

--- a/helm/templates/profiles.yaml
+++ b/helm/templates/profiles.yaml
@@ -34,20 +34,12 @@ spec:
             - secretRef:
                 name: jitsu-secrets
           env:
-            {{- include "jitsu-dev.commonEnv" . | nindent 12 }}
-            {{- include "jitsu-dev.serviceUrls" . | nindent 12 }}
-            - name: ROTOR_MODE
-              value: "profiles"
-            - name: MONGODB_TIMEOUT_MS
-              value: "120000"
-            - name: WAREHOUSE_TIMEOUT_MS
-              value: "5000"
-            - name: UDF_TIMEOUT_MS
-              value: "300000"
-            {{- range $key, $value := .Values.env.profiles }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "jitsu-dev.env" (dict "ctx" . "service" "profiles"
+                  "extra" (dict
+                    "ROTOR_MODE" "profiles"
+                    "MONGODB_TIMEOUT_MS" "120000"
+                    "WAREHOUSE_TIMEOUT_MS" "5000"
+                    "UDF_TIMEOUT_MS" "300000")) | nindent 12 }}
           volumeMounts:
             - name: node-cache
               mountPath: /cache

--- a/helm/templates/rotor.yaml
+++ b/helm/templates/rotor.yaml
@@ -34,12 +34,7 @@ spec:
             - secretRef:
                 name: jitsu-secrets
           env:
-            {{- include "jitsu-dev.commonEnv" . | nindent 12 }}
-            {{- include "jitsu-dev.serviceUrls" . | nindent 12 }}
-            {{- range $key, $value := .Values.env.rotor }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "jitsu-dev.env" (dict "ctx" . "service" "rotor") | nindent 12 }}
           volumeMounts:
             - name: node-cache
               mountPath: /cache

--- a/helm/templates/syncctl.yaml
+++ b/helm/templates/syncctl.yaml
@@ -62,24 +62,19 @@ spec:
             - secretRef:
                 name: jitsu-secrets
           env:
-            - name: HTTP_PORT
-              value: "3043"
-            # Sync Pods (CronJob + ad-hoc job_runner) run as `sync-pod`, a
-            # least-privilege SA bound only to coordination.k8s.io/leases.
-            # Separating it from syncctl's own SA keeps the pod-side blast
-            # radius tiny (no pod create/delete, no Secret read, no log access).
-            - name: PODS_SERVICE_ACCOUNT
-              value: sync-pod
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- include "jitsu-dev.commonEnv" . | nindent 12 }}
-            {{- include "jitsu-dev.serviceUrls" . | nindent 12 }}
-            {{- range $key, $value := .Values.env.syncctl }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            # Sync Pods (CronJob + ad-hoc job_runner) run as `sync-pod`, a
+            # least-privilege SA bound only to coordination.k8s.io/leases.
+            # Separating it from syncctl's own SA keeps the pod-side blast
+            # radius tiny (no pod create/delete, no Secret read, no log access).
+            {{- include "jitsu-dev.env" (dict "ctx" . "service" "syncctl"
+                  "extra" (dict
+                    "HTTP_PORT" "3043"
+                    "PODS_SERVICE_ACCOUNT" "sync-pod")
+                  "exclude" (list "KUBERNETES_NAMESPACE")) | nindent 12 }}
           volumeMounts:
             - name: build
               mountPath: /build

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,7 +13,8 @@ env:
     LOG_FORMAT: "text"
     CONSOLE_URL: http://host.minikube.internal:3000
     KAFKA_BOOTSTRAP_SERVERS: host.minikube.internal:9094
-  # Per-service overrides
+  # Per-service overrides — a key set here wins over env.common, computed
+  # URLs (CONSOLE_URL, REPOSITORY_URL, ...) and chart defaults for that service
   ingest: {}
   bulker: {}
   rotor: {}


### PR DESCRIPTION
Fixes `JITSU-86`.

## Why

Helm 4 applies manifests with server-side apply, which rejects duplicate env names in a container (helm/helm#31529); Helm 3 silently kept the last entry. The dev chart built each container's env from four concatenated sources — `env.common`, computed console/service URLs, template-hardcoded defaults, and `env.<service>` — so any key present in two sources rendered twice and failed the deploy for anyone on a freshly installed Helm. The `CONSOLE_URL` failure fixed in 5cddfae5b was one instance; every per-service override of a common var was another waiting to happen (which also means the "Per-service overrides" section in `values.yaml` never actually worked for keys that exist in `env.common` or as chart defaults).

## What

- Replace the `commonEnv` / `serviceUrls` helpers with a single `jitsu-dev.env` helper that merges all sources into one map and emits each name exactly once.
- Precedence, later wins: `env.common` < computed URLs (`CONSOLE_URL`, `REPOSITORY_URL`, ...) < template defaults (`extra`) < `env.<service>`. Collisions are now overrides instead of render-then-crash.
- Template-hardcoded defaults (`HTTP_PORT`, profiles timeouts, console `*_PORT` blanks, `MAINTENANCE_CONFIG_FILE`, `PODS_SERVICE_ACCOUNT`) move into each template's `extra` dict.
- syncctl's `KUBERNETES_NAMESPACE` (`valueFrom: fieldRef`) can't live in a string map; it stays a literal entry and is excluded from the merge so a per-service override can't duplicate it.

## Verification

- Rendered `helm template` before/after and compared every container's env as a name→value map: semantically identical for default values and for `scaling.console.replicas=0` (external-console fallback).
- Rendered with a hostile values set covering all four collision classes (`env.rotor.LOG_FORMAT`, `env.common.REPOSITORY_URL`, `env.profiles.UDF_TIMEOUT_MS`, `env.syncctl.KUBERNETES_NAMESPACE`, `env.console.CONSOLE_URL`): zero duplicate names, expected winners everywhere.
- `helm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)