### PR TITLE
feat(console): enrich & expand server-side product analytics

### DIFF
--- a/webapps/console/components/SignInOrUp/SignInOrUp.tsx
+++ b/webapps/console/components/SignInOrUp/SignInOrUp.tsx
@@ -114,9 +114,7 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
           safeRedirect(router, callbackUrl);
           return;
         }
-        await analytics.track("login", {
-          traits: { ...result.user, type: "password", loginProvider: "firebase/email" },
-        });
+        // `login` is tracked server-side (fb-auth/audit-login) — see telemetry.trackAuthEvent.
         safeRedirect(router, callbackUrl);
       } else if (type === "nextauth-credentials") {
         const result = await signIn("credentials", {
@@ -168,11 +166,7 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
             await firebaseSession!.signOut();
             return;
           }
-          if (result.status === "authenticated") {
-            await analytics.track("login", {
-              traits: { ...result.user, type: "social", loginProvider: `firebase/${provider}` },
-            });
-          }
+          // `login` is tracked server-side (fb-auth/audit-login) — see telemetry.trackAuthEvent.
           // authenticated, or email-not-verified (the route gate handles that)
           safeRedirect(router, callbackUrl);
           break;

--- a/webapps/console/components/SignInOrUp/SignInOrUp.tsx
+++ b/webapps/console/components/SignInOrUp/SignInOrUp.tsx
@@ -96,7 +96,7 @@ export const SignInOrUp: React.FC<SigninProps> = ({ signup }) => {
           setError("Invalid email or password");
           return;
         }
-        const result = await firebaseSession!.resolveUser().user;
+        const result = await firebaseSession!.resolveUser(undefined, { recordLogin: true }).user;
         if (!result) {
           setError("Sign in failed");
           return;

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -87,9 +87,14 @@ export interface FirebaseSession {
   confirmPasswordReset(oobCode: string, newPassword: string): Promise<void>;
 
   /**
-   * Waits until auth state of the user is resolved
+   * Waits until auth state of the user is resolved. Pass `recordLogin` from an explicit
+   * sign-in entry point so the `login` audit/telemetry event fires once internalId is
+   * minted; the implicit page-load callers omit it (they must not record a login).
    */
-  resolveUser(token?: string): { user: Promise<FirebaseAuthResult | null>; cleanup: () => void };
+  resolveUser(
+    token?: string,
+    opts?: { recordLogin?: boolean }
+  ): { user: Promise<FirebaseAuthResult | null>; cleanup: () => void };
 }
 
 export function getFirebaseAuth(config: FirebaseClientSettings): typeof auth {
@@ -296,7 +301,7 @@ export function useFirebaseSession(): FirebaseSession {
         throw e;
       }
     },
-    resolveUser(token?: string) {
+    resolveUser(token?: string, opts?: { recordLogin?: boolean }) {
       log.atDebug().log("Authorizing through firebase...");
       const userPromise: Promise<FirebaseAuthResult | null> = new Promise(async (resolve, reject) => {
         if (token) {
@@ -307,7 +312,15 @@ export function useFirebaseSession(): FirebaseSession {
           async user => {
             log.atDebug().log(`Firebase auth result`, user);
             try {
-              resolve(user ? await getUserFromFirebase(user) : null);
+              const result = user ? await getUserFromFirebase(user) : null;
+              // Record the login only for an explicit sign-in (recordLogin) and only after
+              // getUserFromFirebase has minted/linked internalId — otherwise a first-time
+              // verified password user's login hits /api/fb-auth/audit-login before the
+              // profile exists and is dropped. Implicit page-load resolveUser omits recordLogin.
+              if (opts?.recordLogin && user && result?.status === "authenticated") {
+                await recordFirebaseLogin(user);
+              }
+              resolve(result);
             } catch (e) {
               // Genuine errors (token mint, network) must reject the outer
               // promise — without this catch the throw escapes the async callback
@@ -335,10 +348,9 @@ export function useFirebaseSession(): FirebaseSession {
     },
     //user: () => (currentUser ? getUserFromFirebase(currentUser) : undefined),
     async signIn(username: string, password): Promise<boolean> {
+      // Note: the `login` event is recorded later, in resolveUser({ recordLogin: true }),
+      // once internalId is minted — not here, where a first-time user has no profile yet.
       const userCredential = await auth.signInWithEmailAndPassword(a.getAuth(), username, password);
-      if (userCredential?.user) {
-        await recordFirebaseLogin(userCredential.user);
-      }
       return !!userCredential?.user;
     },
     async signUp(email: string, password: string): Promise<void> {

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -279,11 +279,16 @@ export function useFirebaseSession(): FirebaseSession {
         } else {
           await a.signInWithPopup(a.getAuth(), new auth.GoogleAuthProvider());
         }
-        await recordFirebaseLogin(a.getAuth().currentUser);
         const result = await getUserFromFirebase(a.getAuth().currentUser!);
         if (result.status === "authenticated") {
+          // Record the login only after getUserFromFirebase has minted/linked the internalId.
+          // For a brand-new account the first sign-in reaches /api/fb-auth/audit-login before the
+          // profile exists, so it can't resolve internalId and skips both the audit row and the
+          // server-side `login` event; ordering it here fixes that (and avoids recording a login
+          // for a personal-email signup that getUserFromFirebase rejects). `login` is tracked
+          // server-side — see telemetry.trackAuthEvent.
+          await recordFirebaseLogin(a.getAuth().currentUser);
           await analytics.identify(result.user.internalId, { email: result.user.email, name: result.user.name });
-          // `login` is tracked server-side (fb-auth/audit-login) — see telemetry.trackAuthEvent.
         }
         return result;
       } catch (e) {

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -283,7 +283,7 @@ export function useFirebaseSession(): FirebaseSession {
         const result = await getUserFromFirebase(a.getAuth().currentUser!);
         if (result.status === "authenticated") {
           await analytics.identify(result.user.internalId, { email: result.user.email, name: result.user.name });
-          await analytics.track("login");
+          // `login` is tracked server-side (fb-auth/audit-login) — see telemetry.trackAuthEvent.
         }
         return result;
       } catch (e) {

--- a/webapps/console/lib/nextauth.config.ts
+++ b/webapps/console/lib/nextauth.config.ts
@@ -193,7 +193,10 @@ export const nextAuthConfig: NextAuthOptions = {
         if (internalId) {
           await authAuditLog({ internalId, email, name }, "logout", `nextauth-${loginProvider}`);
           await trackAuthEvent(
-            { internalId, email, name, externalId: token?.sub as string | undefined },
+            // Read the persisted externalId (what the jwt/session callbacks treat as
+            // canonical), not token.sub — for some providers sub diverges from the
+            // stored external id, which would overwrite the identify trait with the wrong value.
+            { internalId, email, name, externalId: token?.externalId as string | undefined },
             "logout",
             `nextauth-${loginProvider}`
           );

--- a/webapps/console/lib/nextauth.config.ts
+++ b/webapps/console/lib/nextauth.config.ts
@@ -6,7 +6,7 @@ import { OIDCProvider, ParseJSONConfigFromEnv } from "./oidc";
 import { checkHash, requireDefined } from "juava";
 import { ApiError } from "./shared/errors";
 import { getServerLog } from "./server/log";
-import { withProductAnalytics } from "./server/telemetry";
+import { trackAuthEvent, withProductAnalytics } from "./server/telemetry";
 import { NextApiRequest } from "next";
 import { onUserCreated } from "./server/ee";
 import { getServerEnv } from "./server/serverEnv";
@@ -192,6 +192,11 @@ export const nextAuthConfig: NextAuthOptions = {
         const loginProvider = (token?.loginProvider as string | undefined) || "credentials";
         if (internalId) {
           await authAuditLog({ internalId, email, name }, "logout", `nextauth-${loginProvider}`);
+          await trackAuthEvent(
+            { internalId, email, name, externalId: token?.sub as string | undefined },
+            "logout",
+            `nextauth-${loginProvider}`
+          );
         }
       } catch (err) {
         log.atError().withCause(err).log("Failed to record logout audit event");
@@ -215,6 +220,11 @@ export const nextAuthConfig: NextAuthOptions = {
         try {
           await authAuditLog(
             { internalId: user.id, email: user.email || email, name: user.name || email },
+            "login",
+            `nextauth-${loginProvider}`
+          );
+          await trackAuthEvent(
+            { internalId: user.id, email: user.email || email, name: user.name || email, externalId },
             "login",
             `nextauth-${loginProvider}`
           );

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -9,7 +9,7 @@ import { verifyAccess, verifyAccessWithRole } from "../api";
 import { prepareZodObjectForDeserialization } from "../zod";
 import { ApiError } from "../shared/errors";
 import { configObjectAuditLog } from "./audit-log";
-import { trackTelemetryEvent, withProductAnalytics } from "./telemetry";
+import { productTelemetryEnabled, trackTelemetryEvent, withProductAnalytics } from "./telemetry";
 import { scheduleSync, validateSyncSchedule } from "./sync";
 import { omitDeletedList } from "./omit-deleted";
 import { getServerLog } from "./log";
@@ -44,6 +44,31 @@ export type LinkSelector = { id?: string; fromId?: string; toId?: string };
  * is no split-brain. The existing HTTP routes are intentionally left untouched in this PR; they
  * can be migrated onto this service in a follow-up.
  */
+
+/**
+ * Non-secret descriptor props attached to create/update/delete_object product-analytics
+ * events. `objectSubtype` is the type-specific discriminator (destination kind, connector
+ * package, function kind); `connectorVersion` is the connector image version for services
+ * (i.e. the version of the `objectSubtype` package). All values are labels/enums — no secrets.
+ */
+function objectAnalyticsProps(type: string, id: string, config: any): Record<string, any> {
+  const objectSubtype =
+    type === "destination"
+      ? config?.destinationType
+      : type === "service"
+      ? config?.package
+      : type === "function"
+      ? config?.kind
+      : undefined;
+  return {
+    objectType: type,
+    objectId: id,
+    objectName: config?.name,
+    ...(objectSubtype ? { objectSubtype } : {}),
+    ...(type === "service" && config?.version ? { connectorVersion: config.version } : {}),
+  };
+}
+
 export class ConfigObjectsService {
   private readonly prisma: PrismaClient;
 
@@ -194,18 +219,28 @@ export class ConfigObjectsService {
     });
     await trackTelemetryEvent("config-object-create", { objectType: type });
     if (opts.req) {
-      await withProductAnalytics(p => p.track("create_object", { objectType: type }), {
-        user,
-        workspace,
-        req: opts.req,
-      });
+      await withProductAnalytics(
+        p =>
+          p.track("create_object", {
+            ...objectAnalyticsProps(type, id, object),
+            ...(incoming.cloneId ? { cloned: true } : {}),
+          }),
+        { user, workspace, req: opts.req }
+      );
     }
     await configObjectAuditLog(user, workspaceId, created.id, type, "create", { newVersion: object });
     return { id: created.id };
   }
 
   /** Mirrors `config/[type]/[id].ts` PUT. */
-  async update(user: SessionUser, workspaceId: string, type: string, id: string, patch: any): Promise<void> {
+  async update(
+    user: SessionUser,
+    workspaceId: string,
+    type: string,
+    id: string,
+    patch: any,
+    opts: { req?: NextApiRequest } = {}
+  ): Promise<void> {
     const body = prepareZodObjectForDeserialization(patch);
     await verifyAccessWithRole(user, workspaceId, "editEntities");
     this.assertKnownType(type);
@@ -230,6 +265,13 @@ export class ConfigObjectsService {
     delete filtered.workspaceId;
     await this.prisma.configurationObject.update({ where: { id }, data: { config: filtered } });
     await trackTelemetryEvent("config-object-update", { objectType: type });
+    if (opts.req) {
+      await withProductAnalytics(p => p.track("update_object", objectAnalyticsProps(type, id, filtered)), {
+        user,
+        workspace,
+        req: opts.req,
+      });
+    }
     await configObjectAuditLog(user, workspaceId, id, type, "update", { prevVersion, newVersion: filtered });
   }
 
@@ -239,7 +281,7 @@ export class ConfigObjectsService {
     workspaceId: string,
     type: string,
     id: string,
-    opts: { strict?: boolean; cascade?: boolean } = {}
+    opts: { strict?: boolean; cascade?: boolean; req?: NextApiRequest } = {}
   ): Promise<any | null> {
     await verifyAccessWithRole(user, workspaceId, "deleteEntities");
     this.assertKnownType(type);
@@ -256,6 +298,18 @@ export class ConfigObjectsService {
     }
     await this.prisma.configurationObject.update({ where: { id: object.id }, data: { deleted: true } });
     await trackTelemetryEvent("config-object-delete", { objectType: type });
+    if (opts.req) {
+      // delete() doesn't otherwise load the workspace — fetch it only when we're
+      // actually going to emit the event, so name/slug reach the group traits.
+      const workspace = await this.prisma.workspace.findFirst({ where: { id: workspaceId } });
+      if (workspace) {
+        await withProductAnalytics(p => p.track("delete_object", objectAnalyticsProps(type, id, object.config)), {
+          user,
+          workspace,
+          req: opts.req,
+        });
+      }
+    }
     await configObjectAuditLog(user, workspaceId, id, type, "delete", { prevVersion: object.config });
     return { ...((object.config as any) || {}), workspaceId, id, type };
   }
@@ -280,6 +334,45 @@ export class ConfigObjectsService {
       }
     }
     return omitDeletedList(links);
+  }
+
+  /**
+   * Emit a connection_created / connection_deleted product event. Loads the workspace and both
+   * endpoints only when product telemetry is on (Cloud), so self-hosted pays nothing. The `from`
+   * endpoint is a stream (push) or a connector service (sync); `to` is always a destination.
+   */
+  private async emitConnectionEvent(
+    user: SessionUser,
+    workspaceId: string,
+    req: NextApiRequest | undefined,
+    event: "connection_created" | "connection_deleted",
+    link: { id: string; fromId: string; toId: string; type?: string | null }
+  ): Promise<void> {
+    if (!req || !productTelemetryEnabled) {
+      return;
+    }
+    const [workspace, from, to] = await Promise.all([
+      this.prisma.workspace.findFirst({ where: { id: workspaceId } }),
+      this.prisma.configurationObject.findFirst({ where: { workspaceId, id: link.fromId } }),
+      this.prisma.configurationObject.findFirst({ where: { workspaceId, id: link.toId } }),
+    ]);
+    if (!workspace) {
+      return;
+    }
+    const fromConfig = from?.config as any;
+    const toConfig = to?.config as any;
+    await withProductAnalytics(
+      p =>
+        p.track(event, {
+          connectionId: link.id,
+          connectionType: link.type ?? "push",
+          fromId: link.fromId,
+          toId: link.toId,
+          ...(toConfig?.destinationType ? { destinationType: toConfig.destinationType } : {}),
+          ...(from?.type === "service" && fromConfig?.package ? { connectorPackage: fromConfig.package } : {}),
+        }),
+      { user, workspace, req }
+    );
   }
 
   /** Mirrors `config/link.ts` POST/PUT upsert. */
@@ -356,6 +449,7 @@ export class ConfigObjectsService {
       await configObjectAuditLog(user, workspaceId, createdOrUpdated.id, "link", "create", {
         newVersion: createdOrUpdated,
       });
+      await this.emitConnectionEvent(user, workspaceId, opts.req, "connection_created", createdOrUpdated);
     }
     if (type === "sync" && opts.runSync && opts.req) {
       await scheduleSync({ req: opts.req, user, trigger: "manual", workspaceId, syncIdOrModel: createdOrUpdated.id });
@@ -451,7 +545,12 @@ export class ConfigObjectsService {
   }
 
   /** Mirrors `config/link.ts` DELETE. Delete by `id`, or by `fromId`+`toId`. */
-  async deleteLink(user: SessionUser, workspaceId: string, sel: LinkSelector): Promise<{ deleted: boolean }> {
+  async deleteLink(
+    user: SessionUser,
+    workspaceId: string,
+    sel: LinkSelector,
+    opts: { req?: NextApiRequest } = {}
+  ): Promise<{ deleted: boolean }> {
     const { id, fromId, toId } = sel;
     await verifyAccessWithRole(user, workspaceId, "deleteEntities");
     if (id) {
@@ -468,6 +567,7 @@ export class ConfigObjectsService {
       }
       await this.prisma.configurationObjectLink.update({ where: { id: existing.id }, data: { deleted: true } });
       await configObjectAuditLog(user, workspaceId, existing.id, "link", "delete", { prevVersion: existing });
+      await this.emitConnectionEvent(user, workspaceId, opts.req, "connection_deleted", existing);
       return { deleted: true };
     } else if (fromId && toId) {
       const updatedLinks = await this.prisma.configurationObjectLink.updateManyAndReturn({
@@ -476,6 +576,7 @@ export class ConfigObjectsService {
       });
       for (const updatedLink of updatedLinks) {
         await configObjectAuditLog(user, workspaceId, updatedLink.id, "link", "delete", { prevVersion: updatedLink });
+        await this.emitConnectionEvent(user, workspaceId, opts.req, "connection_deleted", updatedLink);
       }
       return { deleted: updatedLinks.length > 0 };
     }

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -196,7 +196,7 @@ export class ConfigObjectsService {
     if (opts.req) {
       await withProductAnalytics(p => p.track("create_object", { objectType: type }), {
         user,
-        workspace: { id: workspaceId },
+        workspace,
         req: opts.req,
       });
     }

--- a/webapps/console/lib/server/telemetry.ts
+++ b/webapps/console/lib/server/telemetry.ts
@@ -71,7 +71,18 @@ export interface ProductAnalytics extends AnalyticsInterface {
   track(event: TrackEvents, props?: any): Promise<any>;
 }
 
-function createProductAnalytics(analytics: AnalyticsInterface, req?: NextApiRequest): ProductAnalytics {
+function createProductAnalytics(
+  analytics: AnalyticsInterface,
+  opts?: { req?: NextApiRequest; workspace?: Workspace | WorkspaceIdAndProps }
+): ProductAnalytics {
+  const req = opts?.req;
+  const ws = opts?.workspace;
+  // Injected into every track event so all workspace-scoped events carry the same
+  // workspace identity in their properties (in addition to the `groupId`). Omitted
+  // when the event isn't tied to a workspace (e.g. `user_created`).
+  const workspaceProps = ws
+    ? { workspaceId: ws.id, workspaceName: ws.name ?? undefined, workspaceSlug: ws.slug ?? undefined }
+    : undefined;
   return {
     ...analytics,
     identifyUser(sessionUser: SessionUser): Promise<void> {
@@ -100,7 +111,7 @@ function createProductAnalytics(analytics: AnalyticsInterface, req?: NextApiRequ
         ip: (req?.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() || req?.socket?.remoteAddress,
         //userAgent: req?.headers["user-agent"] as string,
       };
-      return analytics.track(event, { ...(props || {}), context });
+      return analytics.track(event, { ...(workspaceProps || {}), ...(props || {}), context });
     },
   };
 }
@@ -121,7 +132,7 @@ export function withProductAnalytics(
 ): Promise<any[]> {
   //we create new instance every time since analytics.js saves state in props and not thread safe
   //creating of an instance is cheap operation
-  const instance = createProductAnalytics(createAnalytics(), opts?.req);
+  const instance = createProductAnalytics(createAnalytics(), { req: opts?.req, workspace: opts.workspace });
   const allPromises: Promise<any>[] = [];
   if (opts.user) {
     allPromises.push(instance.identifyUser(opts.user));

--- a/webapps/console/lib/server/telemetry.ts
+++ b/webapps/console/lib/server/telemetry.ts
@@ -56,7 +56,14 @@ type TrackEvents =
   | "workspace_onboarded"
   | "workspace_ping"
   | "workspace_access"
-  | "create_object";
+  | "workspace_deleted"
+  | "create_object"
+  | "update_object"
+  | "delete_object"
+  | "connection_created"
+  | "connection_deleted"
+  | "login"
+  | "logout";
 
 export interface ProductAnalytics extends AnalyticsInterface {
   identifyUser(sessionUser: TrackedUser): Promise<any>;
@@ -85,11 +92,13 @@ function createProductAnalytics(
     : undefined;
   return {
     ...analytics,
-    identifyUser(sessionUser: SessionUser): Promise<void> {
+    identifyUser(sessionUser: TrackedUser): Promise<void> {
       return analytics.identify(sessionUser.internalId, {
         email: sessionUser.email,
         name: sessionUser.name,
-        externalId: sessionUser.externalId,
+        // externalId isn't available at every call site (e.g. auth events), so only
+        // send it when known — otherwise we'd blank out the trait set elsewhere.
+        ...(sessionUser.externalId ? { externalId: sessionUser.externalId } : {}),
       });
     },
     workspace(idOrObject: string | Workspace, opts?: WorkspaceProps) {
@@ -116,7 +125,24 @@ function createProductAnalytics(
   };
 }
 
-export type TrackedUser = Pick<SessionUser, "internalId" | "email" | "name" | "externalId" | "loginProvider">;
+export type TrackedUser = Pick<SessionUser, "internalId" | "email" | "name"> &
+  Partial<Pick<SessionUser, "externalId" | "loginProvider">>;
+
+/**
+ * Server-side login/logout product event. Account-level: fires an identify + the event,
+ * with no workspace group and no IP context. Best-effort — never throws into the auth flow.
+ */
+export async function trackAuthEvent(
+  user: Pick<SessionUser, "internalId" | "email" | "name"> & { externalId?: string },
+  event: "login" | "logout",
+  authType: string
+): Promise<void> {
+  try {
+    await withProductAnalytics(p => p.track(event, { authType }), { user: { ...user, loginProvider: authType } });
+  } catch (e) {
+    log.atWarn().withCause(e).log(`Failed to send ${event} product-analytics event`);
+  }
+}
 
 /**
  * Entry point for all analytics events. The method makes sure that all identify events

--- a/webapps/console/pages/api/[workspaceId]/config/[type]/[id].ts
+++ b/webapps/console/pages/api/[workspaceId]/config/[type]/[id].ts
@@ -62,9 +62,9 @@ export const route = createRoute()
       }),
     },
   })
-  .handler(async ({ user, body, query: { id, workspaceId, type } }) => {
+  .handler(async ({ req, user, body, query: { id, workspaceId, type } }) => {
     // The service applies `prepareZodObjectForDeserialization` internally.
-    await configObjects().update(user, workspaceId, type, id, body);
+    await configObjects().update(user, workspaceId, type, id, body, { req });
   })
   .DELETE({
     auth: true,
@@ -86,10 +86,11 @@ export const route = createRoute()
       }),
     },
   })
-  .handler(async ({ user, query: { id, workspaceId, type, strict, cascade } }) => {
+  .handler(async ({ req, user, query: { id, workspaceId, type, strict, cascade } }) => {
     return await configObjects().delete(user, workspaceId, type, id, {
       strict: strict === "true",
       cascade: cascade === "true",
+      req,
     });
   });
 

--- a/webapps/console/pages/api/[workspaceId]/config/link.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/link.ts
@@ -69,8 +69,8 @@ export const route = createRoute()
     summary: "Delete connection",
     tags: ["link"],
   })
-  .handler(async ({ user, query: { workspaceId, fromId, toId, id } }) => {
-    return await configObjects().deleteLink(user, workspaceId, { id, fromId, toId });
+  .handler(async ({ req, user, query: { workspaceId, fromId, toId, id } }) => {
+    return await configObjects().deleteLink(user, workspaceId, { id, fromId, toId }, { req });
   });
 
 export default route.toNextApiHandler();

--- a/webapps/console/pages/api/auth/dynamic-oidc/callback.ts
+++ b/webapps/console/pages/api/auth/dynamic-oidc/callback.ts
@@ -11,6 +11,7 @@ import { isSecure } from "../../../../lib/server/origin";
 import { redirectWithOidcError, OidcErrors } from "../../../../lib/server/oidc-error-handler";
 import { getServerEnv } from "../../../../lib/server/serverEnv";
 import { authAuditLog } from "../../../../lib/server/audit-log";
+import { trackAuthEvent } from "../../../../lib/server/telemetry";
 
 const log = getServerLog("api/auth/dynamic-oidc/callback");
 
@@ -265,6 +266,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
       const userEmail = user.email || email;
       await authAuditLog({ internalId: user.id, email: userEmail, name: user.name || userEmail }, "login", "oidc");
+      await trackAuthEvent(
+        { internalId: user.id, email: userEmail, name: user.name || userEmail, externalId: user.externalId },
+        "login",
+        "oidc"
+      );
     } catch (err) {
       log
         .atError()

--- a/webapps/console/pages/api/auth/dynamic-oidc/logout.ts
+++ b/webapps/console/pages/api/auth/dynamic-oidc/logout.ts
@@ -6,6 +6,7 @@ import jwt from "jsonwebtoken";
 import { nextAuthConfig } from "../../../../lib/nextauth.config";
 import { OidcSessionData } from "../../../../lib/server/oidc-types";
 import { authAuditLog } from "../../../../lib/server/audit-log";
+import { trackAuthEvent } from "../../../../lib/server/telemetry";
 
 const log = getServerLog("api/auth/oidc-logout");
 
@@ -26,6 +27,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               internalId: sessionData.userId,
               email: sessionData.email || "",
               name: sessionData.name || sessionData.email || "",
+            },
+            "logout",
+            "oidc"
+          );
+          await trackAuthEvent(
+            {
+              internalId: sessionData.userId,
+              email: sessionData.email || "",
+              name: sessionData.name || sessionData.email || "",
+              externalId: sessionData.externalId,
             },
             "logout",
             "oidc"

--- a/webapps/console/pages/api/fb-auth/audit-login.ts
+++ b/webapps/console/pages/api/fb-auth/audit-login.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { firebase } from "../../../lib/server/firebase-server";
 import { db } from "../../../lib/server/db";
 import { authAuditLog } from "../../../lib/server/audit-log";
+import { trackAuthEvent } from "../../../lib/server/telemetry";
 import { getServerLog } from "../../../lib/server/log";
 
 const log = getServerLog("firebase-audit-login");
@@ -39,6 +40,11 @@ export const api: Api = {
         }
         if (internalId) {
           await authAuditLog({ internalId, email, name: decoded.name || email }, "login", "firebase");
+          await trackAuthEvent(
+            { internalId, email, name: decoded.name || email, externalId: decoded.uid },
+            "login",
+            "firebase"
+          );
         }
       } catch (err) {
         log

--- a/webapps/console/pages/api/fb-auth/revoke-session.ts
+++ b/webapps/console/pages/api/fb-auth/revoke-session.ts
@@ -9,6 +9,7 @@ import { serialize } from "cookie";
 import { getAppEndpoint } from "../../../lib/domains";
 import { getServerLog } from "../../../lib/server/log";
 import { authAuditLog } from "../../../lib/server/audit-log";
+import { trackAuthEvent } from "../../../lib/server/telemetry";
 
 const log = getServerLog("firebase");
 
@@ -18,6 +19,11 @@ export default createRoute()
     await signOut(user.externalId);
     try {
       await authAuditLog({ internalId: user.internalId, email: user.email, name: user.name }, "logout", "firebase");
+      await trackAuthEvent(
+        { internalId: user.internalId, email: user.email, name: user.name, externalId: user.externalId },
+        "logout",
+        "firebase"
+      );
     } catch (err) {
       log
         .atError()

--- a/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/index.ts
+++ b/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/index.ts
@@ -124,15 +124,9 @@ export const route = createRoute()
       );
     }
     if (workspace.slug) {
-      withProductAnalytics(
-        callback =>
-          callback.track("workspace_access", {
-            workspaceId: workspace.id,
-            workspaceName: workspace.name,
-            workspaceSlug: workspace.slug,
-          }),
-        { user, workspace, req }
-      );
+      // workspaceId/workspaceName/workspaceSlug are injected for every event by
+      // withProductAnalytics, so we only need to name the event here.
+      withProductAnalytics(callback => callback.track("workspace_access"), { user, workspace, req });
     }
 
     try {

--- a/webapps/console/pages/api/workspace/index.ts
+++ b/webapps/console/pages/api/workspace/index.ts
@@ -180,7 +180,7 @@ export const route = createRoute()
     body: z.object({ workspaceId: z.string() }),
     result: z.object({ message: z.string(), status: z.number() }),
   })
-  .handler(async ({ body, user }) => {
+  .handler(async ({ req, body, user }) => {
     const workspaceId = body.workspaceId;
     await verifyAccessWithRole(user, workspaceId, "manageUsers");
 
@@ -198,6 +198,7 @@ export const route = createRoute()
     });
 
     await workspaceAuditLog(user, workspaceId, "deleted", { workspaceName: workspace.name });
+    await withProductAnalytics(p => p.track("workspace_deleted"), { user, workspace, req });
 
     return { message: `${workspace.name} deleted successfully`, status: 200 };
   });


### PR DESCRIPTION
## What

Overhauls the console's server-side product-analytics so every event is self-describing and the key user actions are actually tracked.

### 1. Workspace identity on every event
`withProductAnalytics` now injects `workspaceId` / `workspaceName` / `workspaceSlug` into the properties of every workspace-scoped event (previously only `workspace_access` had them), on top of the `groupId` the `group()` call already set. Backward compatible — only adds keys.

### 2. Richer object events + full lifecycle
- `create_object` now carries `objectId`, `objectName`, `objectSubtype` (destination kind / connector package / function kind), `connectorVersion` (connector image version for services), and `cloned`.
- Added symmetric **`update_object`** and **`delete_object`** (previously only `create_object` existed in product analytics).

### 3. Connections (new)
- **`connection_created`** / **`connection_deleted`** at the link upsert/delete choke points — the core source→destination action, previously untracked and *not* covered by `*_object`.
- Props: `connectionId`, `connectionType` (push/sync), `fromId`, `toId`, plus resolved `destinationType` and `connectorPackage`. Endpoint lookups run only when product telemetry is enabled (Cloud), so self-hosted pays nothing.

### 4. Auth: login consolidated server-side + logout added
- New `trackAuthEvent` helper. `login` now fires **server-side** at all three sign-in choke points (nextauth jwt-initial / firebase `audit-login` / oidc callback), and the client-side `track("login")` calls are removed — one consistent event, no double-count.
- **`logout`** added at all three sign-out paths (nextauth signOut / firebase revoke-session / oidc logout) — previously tracked nowhere.
- These are account-level: identify + event, no workspace group, and they fire once per real sign-in/out (not per page).

### 5. `workspace_deleted`
Mirrors `workspace_created`, on the soft-delete in `pages/api/workspace` DELETE.

## Design notes
- All new event props are labels/enums — no secrets. Connection/object props are read from already-loaded configs where possible.
- New events wired at the same deduplicated, server-side points the audit log uses.
- `TrackedUser` relaxed so `externalId`/`loginProvider` are optional (auth sites only have `internalId`/`email`/`name`); `identifyUser` only sends `externalId` when known so it never blanks the trait.

## Verification
- `pnpm typecheck` clean for all touched files (pre-existing Storybook module errors in the untracked `stories/` dir are unrelated).
- Cross-checked event landing against the live `use.jitsu.com` dogfood stream via the Jitsu MCP (confirmed the prior inconsistency this PR fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCifxrCm8mQGTkTwLxbbME