### PR TITLE
feat(cli): deploy by workspace slug + project config; drop @types/node from protocols

### DIFF
--- a/.cli.version.json
+++ b/.cli.version.json
@@ -1,0 +1,6 @@
+{
+  "version": "2.15",
+  "tag_prefix": "jitsu-cli",
+  "stable_branch": "stable-cli",
+  "beta_branch": "newjitsu"
+}

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -1,0 +1,242 @@
+name: 🛠️ CLI Build
+
+on:
+  # No push trigger: this workflow is invoked by publish.yml (workflow_call) or
+  # manually via the Actions UI (workflow_dispatch). All trigger logic lives in
+  # publish.yml.
+  #
+  # jitsu-cli has its own release train (.cli.version.json) so a CLI release
+  # doesn't drag along a stable rebuild of every microservice. The published
+  # package bundles its @jitsu/* deps at build time (they are devDependencies),
+  # so it is self-contained on npm — nothing here depends on the services or
+  # client-libraries streams.
+  workflow_call:
+    inputs:
+      channel:
+        description: "Release channel: canary, beta, stable"
+        required: true
+        type: string
+      version:
+        description: "Manual version override (e.g., 2.15.0-canary.1)"
+        required: false
+        type: string
+      skip_install:
+        description: "Skip dependency installation (already done in calling workflow)"
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel"
+        type: choice
+        options: [canary, beta, stable]
+        default: canary
+      version:
+        description: "Manual version override (e.g., 2.15.0-canary.1)"
+        required: false
+        type: string
+
+concurrency:
+  group: cli-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version:
+    name: 🏷️ Generate Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.manual.outputs.version || steps.generated.outputs.version }}
+      channel: ${{ inputs.channel }}
+      tag: ${{ steps.manual.outputs.tag || steps.generated.outputs.tag }}
+    steps:
+      - name: 📥 Checkout code
+        if: ${{ !inputs.version }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 🏷️ Generate version
+        if: ${{ !inputs.version }}
+        id: generated
+        uses: ./.github/actions/version
+        with:
+          version_file: .cli.version.json
+          channel: ${{ inputs.channel }}
+
+      - name: 📝 Use manual version
+        if: ${{ inputs.version }}
+        id: manual
+        run: |
+          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
+
+  build:
+    needs: [version]
+    name: 🚀 Build and Publish CLI
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      packages: read
+      id-token: write
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 🔍 Validate OIDC token and npm access
+        run: |
+          OIDC_TOKEN=$(curl -sf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org" | jq -r '.value')
+          if [ -z "${OIDC_TOKEN}" ] || [ "${OIDC_TOKEN}" = "null" ]; then
+            echo "ERROR: Could not obtain OIDC token - check that id-token: write permission is set on this job"
+            exit 1
+          fi
+          echo "OIDC token obtained"
+          FAILED=0
+          for PKG in "jitsu-cli"; do
+            ENCODED=$(printf '%s' "$PKG" | sed 's/@/%40/g; s|/|%2F|g')
+            HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
+            if [ "${HTTP}" != "201" ]; then
+              echo "ERROR: npm OIDC exchange failed (HTTP ${HTTP}) for ${PKG} - check trusted publisher config on npmjs.com"
+              FAILED=1
+            else
+              echo "OK: ${PKG}"
+            fi
+          done
+          [ "${FAILED}" = "0" ] || exit 1
+
+      - name: 🐳 Pull and start builder container
+        run: |
+          docker pull jitsucom/jitsu-builder:latest
+          docker run -d --name builder -v ${{ github.workspace }}:/workspace -w /workspace \
+            -e CI=true \
+            -e GITHUB_ACTIONS=true \
+            -e ACTIONS_ID_TOKEN_REQUEST_URL \
+            -e ACTIONS_ID_TOKEN_REQUEST_TOKEN \
+            -e GITHUB_REF \
+            -e GITHUB_SHA \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_REPOSITORY_ID \
+            -e GITHUB_REPOSITORY_OWNER_ID \
+            -e GITHUB_SERVER_URL \
+            -e GITHUB_EVENT_NAME \
+            -e GITHUB_RUN_ID \
+            -e GITHUB_RUN_ATTEMPT \
+            -e GITHUB_WORKFLOW_REF \
+            -e RUNNER_ENVIRONMENT \
+            jitsucom/jitsu-builder:latest tail -f /dev/null
+
+      - name: 📦 Fetch dependencies from store
+        run: |
+          docker exec builder sh -c 'echo "pnpm store path: $(pnpm store path)"'
+          docker exec builder pnpm fetch
+
+      - name: 📦 Install dependencies
+        if: ${{ !inputs.skip_install }}
+        run: docker exec builder pnpm install --frozen-lockfile --offline
+
+      - name: 📝 Update package version
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          echo "Updating jitsu-cli package.json to version ${VERSION}"
+          docker exec builder sh -c "cd cli/jitsu-cli && jq --arg version \"${VERSION}\" '.version = \$version' package.json > package.json.tmp && mv package.json.tmp package.json"
+          docker exec builder sh -c "cd cli/jitsu-cli && cat package.json | grep version"
+
+      - name: 🏗️ Build CLI
+        # `...` pulls in jitsu-cli's workspace deps (@jitsu/protocols,
+        # @jitsu/functions-lib) so they are built before the bundle step.
+        run: docker exec builder pnpm --filter jitsu-cli... build
+
+      - name: 📤 Publish to NPM
+        env:
+          CHANNEL: ${{ needs.version.outputs.channel }}
+        run: |
+          if [ "${CHANNEL}" = "stable" ]; then
+            NPM_TAG="latest"
+          else
+            NPM_TAG="${CHANNEL}"
+          fi
+
+          echo "Publishing jitsu-cli to NPM with tag: ${NPM_TAG}"
+          docker exec builder sh -c "cd cli/jitsu-cli && pnpm publish --tag ${NPM_TAG} --access public --provenance --no-git-checks"
+
+      - name: 🧹 Cleanup container
+        if: always()
+        run: docker stop builder && docker rm builder
+
+      - name: 🏷️ Create and push git tag
+        if: needs.version.outputs.channel != 'canary'
+        run: |
+          TAG="${{ needs.version.outputs.tag }}"
+          VERSION="${{ needs.version.outputs.version }}"
+
+          # Configure git user
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create annotated tag
+          git tag -a "$TAG" -m "Release $VERSION"
+
+          # Push tag using GITHUB_TOKEN
+          git push origin "$TAG"
+
+          echo "Created and pushed tag: $TAG"
+
+      - name: 📝 Create GitHub release
+        if: needs.version.outputs.channel != 'canary'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.version.outputs.tag }}"
+          VERSION="${{ needs.version.outputs.version }}"
+          CHANNEL="${{ needs.version.outputs.channel }}"
+
+          # Determine if prerelease
+          PRERELEASE_FLAG=""
+          if [ "$CHANNEL" = "beta" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          # Create release without notes
+          gh release create "$TAG" --notes "$VERSION ($CHANNEL)" --title "Jitsu CLI Release $VERSION" $PRERELEASE_FLAG
+
+          echo "Created GitHub release: $TAG"
+
+      - name: 📝 Get short SHA
+        if: always()
+        id: short-sha
+        run: echo "sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: 💬 Send notification to Slack
+        if: always()
+        uses: ./.github/actions/slack-notify
+        with:
+          slack_webhook_url: ${{ secrets.CI_SLACK_WEBHOOK }}
+          color: ${{ job.status == 'success' && '#36a64f' || '#ff0000' }}
+          header: "${{ job.status == 'success' && '✅' || '❌' }} 🛠️ jitsu-cli `${{ needs.version.outputs.channel || 'unknown' }}` build ${{ job.status == 'success' && 'SUCCEEDED' || 'FAILED' }}"
+          blocks: |
+            - title: Branch
+              value: ${{ github.ref_name }}
+            - title: Version
+              value: ${{ needs.version.outputs.version || 'N/A' }}
+            - title: NPM Tag
+              value: ${{ needs.version.outputs.channel == 'stable' && 'latest' || needs.version.outputs.channel }}
+            - title: Commit
+              value: ${{ steps.short-sha.outputs.sha }}
+              url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+            - title: Commit message
+              value: ${{ github.event.head_commit.message && toJSON(github.event.head_commit.message) || 'N/A' }}
+              is_code: true
+            - title: Workflow run
+              value: ${{ job.status == 'success' && 'View workflow run' || 'View failed run' }}
+              url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - title: Triggered by
+              value: ${{ github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
       scope:
         description: "What to publish (auto = detect from the change range)"
         type: choice
-        options: [auto, both, services, client-libraries]
+        options: [auto, both, services, client-libraries, cli]
         default: auto
       channel:
         description: "Release channel (auto = stable if version file bumped, else beta)"
@@ -38,6 +38,10 @@ on:
         type: string
       client_libraries_version:
         description: "Optional version override for client libraries (e.g. 1.11.5)"
+        required: false
+        type: string
+      cli_version:
+        description: "Optional version override for jitsu-cli (e.g. 2.15.5)"
         required: false
         type: string
       from_sha:
@@ -64,8 +68,10 @@ jobs:
     outputs:
       services_run: ${{ steps.resolve.outputs.services_run }}
       client_libs_run: ${{ steps.resolve.outputs.client_libs_run }}
+      cli_run: ${{ steps.resolve.outputs.cli_run }}
       services_channel: ${{ steps.resolve.outputs.services_channel }}
       client_libs_channel: ${{ steps.resolve.outputs.client_libs_channel }}
+      cli_channel: ${{ steps.resolve.outputs.cli_channel }}
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v6
@@ -108,19 +114,26 @@ jobs:
           echo "$CHANGED" | sed 's/^/  /'
 
           # Path patterns mirror what the previous lint.yml deploy jobs filtered on.
-          SERVICES_PATH_RE='^(bulker|services|webapps|libs|cli|types)/|^all\.Dockerfile$|^\.services\.version\.json$|^pnpm-lock\.yaml$|^\.github/workflows/(services\.yaml|publish\.yml)$'
+          # cli/ is deliberately NOT in SERVICES_PATH_RE: jitsu-cli has its own
+          # release train (.cli.version.json / cli.yaml) so a CLI change no
+          # longer drags a stable rebuild of every microservice with it.
+          SERVICES_PATH_RE='^(bulker|services|webapps|libs|types)/|^all\.Dockerfile$|^\.services\.version\.json$|^pnpm-lock\.yaml$|^\.github/workflows/(services\.yaml|publish\.yml)$'
           CLIENT_PATH_RE='^libs/(jitsu-js|jitsu-react|common-config)/|^types/|^\.jsclient\.version\.json$|^pnpm-lock\.yaml$|^\.github/workflows/(client-libraries\.yaml|publish\.yml)$'
+          CLI_PATH_RE='^cli/|^\.cli\.version\.json$|^pnpm-lock\.yaml$|^\.github/workflows/(cli\.yaml|publish\.yml)$'
 
           case "$INPUT_SCOPE" in
             auto)
               SERVICES_RUN=false
               CLIENT_LIBS_RUN=false
+              CLI_RUN=false
               if echo "$CHANGED" | grep -qE "$SERVICES_PATH_RE"; then SERVICES_RUN=true;    fi
               if echo "$CHANGED" | grep -qE "$CLIENT_PATH_RE";   then CLIENT_LIBS_RUN=true; fi
+              if echo "$CHANGED" | grep -qE "$CLI_PATH_RE";      then CLI_RUN=true;         fi
               ;;
-            both)             SERVICES_RUN=true;  CLIENT_LIBS_RUN=true  ;;
-            services)         SERVICES_RUN=true;  CLIENT_LIBS_RUN=false ;;
-            client-libraries) SERVICES_RUN=false; CLIENT_LIBS_RUN=true  ;;
+            both)             SERVICES_RUN=true;  CLIENT_LIBS_RUN=true;  CLI_RUN=false ;;
+            services)         SERVICES_RUN=true;  CLIENT_LIBS_RUN=false; CLI_RUN=false ;;
+            client-libraries) SERVICES_RUN=false; CLIENT_LIBS_RUN=true;  CLI_RUN=false ;;
+            cli)              SERVICES_RUN=false; CLIENT_LIBS_RUN=false; CLI_RUN=true  ;;
           esac
 
           if [ "$INPUT_CHANNEL" = "auto" ]; then
@@ -129,6 +142,7 @@ jobs:
             if [ "${GITHUB_REF_NAME}" != "newjitsu" ]; then
               SERVICES_CHANNEL=canary
               CLIENT_LIBS_CHANNEL=canary
+              CLI_CHANNEL=canary
             else
               if echo "$CHANGED" | grep -q '^\.services\.version\.json$'; then
                 SERVICES_CHANNEL=stable
@@ -140,10 +154,16 @@ jobs:
               else
                 CLIENT_LIBS_CHANNEL=beta
               fi
+              if echo "$CHANGED" | grep -q '^\.cli\.version\.json$'; then
+                CLI_CHANNEL=stable
+              else
+                CLI_CHANNEL=beta
+              fi
             fi
           else
             SERVICES_CHANNEL="$INPUT_CHANNEL"
             CLIENT_LIBS_CHANNEL="$INPUT_CHANNEL"
+            CLI_CHANNEL="$INPUT_CHANNEL"
           fi
 
           echo ""
@@ -152,12 +172,15 @@ jobs:
           echo "  channel input:       $INPUT_CHANNEL"
           echo "  services_run:        $SERVICES_RUN ($SERVICES_CHANNEL)"
           echo "  client_libs_run:     $CLIENT_LIBS_RUN ($CLIENT_LIBS_CHANNEL)"
+          echo "  cli_run:             $CLI_RUN ($CLI_CHANNEL)"
 
           {
             echo "services_run=$SERVICES_RUN"
             echo "client_libs_run=$CLIENT_LIBS_RUN"
+            echo "cli_run=$CLI_RUN"
             echo "services_channel=$SERVICES_CHANNEL"
             echo "client_libs_channel=$CLIENT_LIBS_CHANNEL"
+            echo "cli_channel=$CLI_CHANNEL"
           } >> "$GITHUB_OUTPUT"
 
   services:
@@ -178,3 +201,12 @@ jobs:
     with:
       channel: ${{ needs.detect.outputs.client_libs_channel }}
       version: ${{ inputs.client_libraries_version }}
+
+  cli:
+    needs: [detect]
+    if: ${{ needs.detect.outputs.cli_run == 'true' }}
+    uses: ./.github/workflows/cli.yaml
+    secrets: inherit
+    with:
+      channel: ${{ needs.detect.outputs.cli_channel }}
+      version: ${{ inputs.cli_version }}

--- a/.github/workflows/services.yaml
+++ b/.github/workflows/services.yaml
@@ -492,7 +492,7 @@ jobs:
           fi
           echo "OIDC token obtained"
           FAILED=0
-          for PKG in "jitsu-cli" "@jitsu/functions-lib"; do
+          for PKG in "@jitsu/functions-lib"; do
             ENCODED=$(printf '%s' "$PKG" | sed 's/@/%40/g; s|/|%2F|g')
             HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer ${OIDC_TOKEN}" "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${ENCODED}")
             if [ "${HTTP}" != "201" ]; then
@@ -540,9 +540,6 @@ jobs:
         run: |
           echo "Updating package.json files to version ${VERSION}"
 
-          # Update CLI
-          docker exec builder sh -c "cd cli/jitsu-cli && jq --arg version \"${VERSION}\" '.version = \$version' package.json > package.json.tmp && mv package.json.tmp package.json"
-          
           # Update Types
           docker exec builder sh -c "cd types/protocols && jq --arg version \"${VERSION}\" '.version = \$version' package.json > package.json.tmp && mv package.json.tmp package.json"
 
@@ -550,12 +547,13 @@ jobs:
           docker exec builder sh -c "cd libs/functions && jq --arg version \"${VERSION}\" '.version = \$version' package.json > package.json.tmp && mv package.json.tmp package.json"
 
           echo "Updated versions:"
-          docker exec builder sh -c "cd cli/jitsu-cli && cat package.json | grep version"
           docker exec builder sh -c "cd types/protocols && cat package.json | grep version"
           docker exec builder sh -c "cd libs/functions && cat package.json | grep version"
 
       - name: 🏗️ Build packages
-        run: docker exec builder pnpm --filter jitsu-cli --filter @jitsu/functions-lib build
+        # jitsu-cli is published by cli.yaml (its own .cli.version.json train),
+        # not here — this stream only ships the server-side @jitsu/functions-lib.
+        run: docker exec builder pnpm --filter @jitsu/functions-lib build
 
 
       - name: 📤 Publish to NPM
@@ -577,7 +575,6 @@ jobs:
             echo "Publishing packages to NPM with tag: ${NPM_TAG}"
           fi
 
-          docker exec builder sh -c "cd cli/jitsu-cli && pnpm publish --tag ${NPM_TAG} --access public --provenance --no-git-checks ${DRY_RUN_FLAG}"
           docker exec builder sh -c "cd libs/functions && pnpm publish --tag ${NPM_TAG} --access public --provenance --no-git-checks ${DRY_RUN_FLAG}"
 
       - name: 🧹 Cleanup container

--- a/cli/jitsu-cli/src/commands/deploy.ts
+++ b/cli/jitsu-cli/src/commands/deploy.ts
@@ -61,40 +61,53 @@ export async function deploy({ dir, workspace, name: names, ...params }: Args) {
   //   -w/--workspace flag  →  project config (jitsu.json / package.json "jitsu")
   //   →  default workspace in ~/.jitsu/jitsu-cli.json  →  interactive prompt.
   // The reference may be an id or a slug — both are matched against the list.
+  const findWorkspace = (ref?: string) => (ref ? workspaces.find(w => w.id === ref || w.slug === ref) : undefined);
   const projectConfig = loadProjectConfig(projectDir, packageJson);
-  const workspaceRef = workspace ?? projectConfig.workspace ?? readDefaultWorkspace();
 
   let workspaceObj: Workspace | undefined;
-  if (workspaceRef) {
-    workspaceObj = workspaces.find(w => w.id === workspaceRef || w.slug === workspaceRef);
+  if (workspace) {
+    // Explicit -w/--workspace expresses clear intent: fail hard if it doesn't resolve.
+    workspaceObj = findWorkspace(workspace);
     if (!workspaceObj) {
-      console.error(red(`Workspace '${b(workspaceRef)}' not found (or you don't have access)`));
+      console.error(red(`Workspace '${b(workspace)}' not found (or you don't have access)`));
       process.exit(1);
     }
-  } else if (workspaces.length === 0) {
-    console.error(`${red("No workspaces found")}`);
-    process.exit(1);
-  } else if (workspaces.length === 1) {
-    workspaceObj = workspaces[0];
   } else {
-    const workspaceId = (
-      await inquirer.prompt([
-        {
-          type: "list",
-          name: "workspaceId",
-          message: `Select workspace:`,
-          choices: workspaces.map(w => ({
-            name: `${w.name} (${w.id})`,
-            value: w.id,
-          })),
-        },
-      ])
-    ).workspaceId;
-    workspaceObj = workspaces.find(w => w.id === workspaceId);
+    // "Soft" default from project config or ~/.jitsu. If it doesn't resolve (stale,
+    // deleted, wrong account), fall back to auto-select / interactive prompt instead
+    // of hard-failing — preserving the pre-config behavior of `deploy` with no -w.
+    const softRef = projectConfig.workspace ?? readDefaultWorkspace();
+    workspaceObj = findWorkspace(softRef);
+    if (!workspaceObj) {
+      if (softRef) {
+        console.warn(`Configured workspace ${b(softRef)} not found or not accessible. Selecting manually.`);
+      }
+      if (workspaces.length === 0) {
+        console.error(`${red("No workspaces found")}`);
+        process.exit(1);
+      } else if (workspaces.length === 1) {
+        workspaceObj = workspaces[0];
+      } else {
+        const workspaceId = (
+          await inquirer.prompt([
+            {
+              type: "list",
+              name: "workspaceId",
+              message: `Select workspace:`,
+              choices: workspaces.map(w => ({
+                name: `${w.name} (${w.id})`,
+                value: w.id,
+              })),
+            },
+          ])
+        ).workspaceId;
+        workspaceObj = findWorkspace(workspaceId);
+      }
+    }
   }
 
   if (!workspaceObj?.id || !workspaceObj?.name) {
-    console.error(red(`Workspace '${b(String(workspaceRef))}' not found`));
+    console.error(red(`Workspace not found`));
     process.exit(1);
   }
   await deployFunctions({ ...params, host, apikey, name: names }, projectDir, packageJson, workspaceObj, "function");

--- a/cli/jitsu-cli/src/commands/deploy.ts
+++ b/cli/jitsu-cli/src/commands/deploy.ts
@@ -6,6 +6,8 @@ import { loadPackageJson } from "./shared";
 import cuid from "cuid";
 import { b, green, red } from "../lib/chalk-code-highlight";
 import { getFunctionFromFilePath } from "../lib/compiled-function";
+import { loadProjectConfig } from "../lib/project-config";
+import { readDefaultWorkspace } from "../lib/auth-file";
 
 function readLoginFile() {
   const configFile = `${homedir()}/.jitsu/jitsu-cli.json`;
@@ -55,34 +57,44 @@ export async function deploy({ dir, workspace, name: names, ...params }: Args) {
   }
   const workspaces = (await res.json()) as any[];
 
-  let workspaceId = workspace;
-  if (!workspace) {
-    if (workspaces.length === 0) {
-      console.error(`${red("No workspaces found")}`);
+  // Which workspace to deploy to. Precedence:
+  //   -w/--workspace flag  →  project config (jitsu.json / package.json "jitsu")
+  //   →  default workspace in ~/.jitsu/jitsu-cli.json  →  interactive prompt.
+  // The reference may be an id or a slug — both are matched against the list.
+  const projectConfig = loadProjectConfig(projectDir, packageJson);
+  const workspaceRef = workspace ?? projectConfig.workspace ?? readDefaultWorkspace();
+
+  let workspaceObj: Workspace | undefined;
+  if (workspaceRef) {
+    workspaceObj = workspaces.find(w => w.id === workspaceRef || w.slug === workspaceRef);
+    if (!workspaceObj) {
+      console.error(red(`Workspace '${b(workspaceRef)}' not found (or you don't have access)`));
       process.exit(1);
-    } else if (workspaces.length === 1) {
-      workspaceId = workspaces[0].id;
-    } else {
-      workspaceId = (
-        await inquirer.prompt([
-          {
-            type: "list",
-            name: "workspaceId",
-            message: `Select workspace:`,
-            choices: workspaces.map(w => ({
-              name: `${w.name} (${w.id})`,
-              value: w.id,
-            })),
-          },
-        ])
-      ).workspaceId;
     }
+  } else if (workspaces.length === 0) {
+    console.error(`${red("No workspaces found")}`);
+    process.exit(1);
+  } else if (workspaces.length === 1) {
+    workspaceObj = workspaces[0];
+  } else {
+    const workspaceId = (
+      await inquirer.prompt([
+        {
+          type: "list",
+          name: "workspaceId",
+          message: `Select workspace:`,
+          choices: workspaces.map(w => ({
+            name: `${w.name} (${w.id})`,
+            value: w.id,
+          })),
+        },
+      ])
+    ).workspaceId;
+    workspaceObj = workspaces.find(w => w.id === workspaceId);
   }
 
-  const workspaceObj = workspaces.find(w => w.id === workspaceId);
-  const workspaceName = workspaceObj?.name;
-  if (!workspaceId || !workspaceName) {
-    console.error(red(`Workspace with id ${workspaceId} not found`));
+  if (!workspaceObj?.id || !workspaceObj?.name) {
+    console.error(red(`Workspace '${b(String(workspaceRef))}' not found`));
     process.exit(1);
   }
   await deployFunctions({ ...params, host, apikey, name: names }, projectDir, packageJson, workspaceObj, "function");

--- a/cli/jitsu-cli/src/index.ts
+++ b/cli/jitsu-cli/src/index.ts
@@ -71,8 +71,8 @@ p.command("deploy")
   )
   .option("-k, --apikey <api-key>", "(Optional) Jitsu user's Api Key.")
   .option(
-    "-w, --workspace <workspace-id>",
-    "Id of workspace where to deploy function (Optional). By default, interactive prompt is shown to select workspace"
+    "-w, --workspace <id-or-slug>",
+    "Workspace id or slug to deploy to (Optional). Falls back to jitsu.json / package.json \"jitsu\" config, then the default workspace, then an interactive prompt"
   )
   .option("-t, --type <type>", "entity type to deploy", "function")
   .option("-n, --name <name...>", "limit deploy to provided entities only. (Optional)")

--- a/cli/jitsu-cli/src/index.ts
+++ b/cli/jitsu-cli/src/index.ts
@@ -72,7 +72,7 @@ p.command("deploy")
   .option("-k, --apikey <api-key>", "(Optional) Jitsu user's Api Key.")
   .option(
     "-w, --workspace <id-or-slug>",
-    "Workspace id or slug to deploy to (Optional). Falls back to jitsu.json / package.json \"jitsu\" config, then the default workspace, then an interactive prompt"
+    'Workspace id or slug to deploy to (Optional). Falls back to jitsu.json / package.json "jitsu" config, then the default workspace, then an interactive prompt'
   )
   .option("-t, --type <type>", "entity type to deploy", "function")
   .option("-n, --name <name...>", "limit deploy to provided entities only. (Optional)")

--- a/cli/jitsu-cli/src/lib/project-config.ts
+++ b/cli/jitsu-cli/src/lib/project-config.ts
@@ -1,0 +1,32 @@
+import path from "path";
+import { existsSync, readFileSync } from "fs";
+import { b } from "./chalk-code-highlight";
+
+// Per-project Jitsu configuration, committed alongside the project so a deploy
+// doesn't need machine-global state or CLI flags. Vercel-style (jitsu.json).
+export type ProjectConfig = {
+  // Workspace id or slug to deploy to. Overridden by the -w/--workspace flag.
+  workspace?: string;
+};
+
+// Reads per-project config. Precedence:
+//   1. jitsu.json at the project root
+//   2. "jitsu" key in package.json
+// Returns {} when neither is present. `packageJson` is passed in to avoid a
+// second read of a file the caller already parsed.
+export function loadProjectConfig(projectDir: string, packageJson?: any): ProjectConfig {
+  const jitsuJsonPath = path.resolve(projectDir, "jitsu.json");
+  if (existsSync(jitsuJsonPath)) {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(readFileSync(jitsuJsonPath, "utf-8"));
+    } catch (e) {
+      throw new Error(`Failed to parse ${b(jitsuJsonPath)}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return parsed ?? {};
+  }
+  if (packageJson?.jitsu && typeof packageJson.jitsu === "object") {
+    return packageJson.jitsu as ProjectConfig;
+  }
+  return {};
+}

--- a/types/protocols/functions.d.ts
+++ b/types/protocols/functions.d.ts
@@ -64,7 +64,9 @@ export type FetchType = (url: string, opts?: FetchOpts, extras?: any) => Promise
 export type FetchOpts = {
   method?: string;
   headers?: Record<string, string>;
-  body?: string | Buffer;
+  // Uint8Array instead of Buffer so the type is usable without @types/node.
+  // Buffer extends Uint8Array, so passing a Buffer remains valid.
+  body?: string | Uint8Array;
 };
 export type FunctionLogger<Sync extends boolean = false> = {
   info: (message: string, ...args: any[]) => void | Promise<void>;


### PR DESCRIPTION
## Summary

Two independent CLI/protocols improvements, motivated by dogfooding a 3-year-old
functions project that failed to build and deploy on current Node.

### `fix(protocols)`: drop `@types/node` requirement from `FetchOpts`

`FetchOpts.body` was typed `string | Buffer`. `Buffer` is a Node global, so any
project consuming `@jitsu/protocols` had to install `@types/node` just to typecheck
— otherwise `tsc` fails with `Cannot find name 'Buffer'`.

Changed to `string | Uint8Array`. `Buffer` extends `Uint8Array`, so callers passing
a `Buffer` still typecheck, and the only consumers of `body` in this repo
(`core-functions-lib`) just forward it to native `fetch` (which accepts
`Uint8Array`) — nothing reads it as a `Buffer`. Net effect: same runtime behavior,
one fewer required dependency for extension authors.

### `feat(cli)`: deploy by workspace slug and project config file

- `jitsu-cli deploy -w <ref>` now accepts a workspace **slug**, not just an id.
  Previously a slug failed with *"Workspace with id … not found"*. This matches
  the behavior the `config` commands already have.
- When `-w` is omitted, the target workspace is resolved from, in order:
  1. a project config file — `jitsu.json`, or a `"jitsu"` key in `package.json`
  2. the default workspace in `~/.jitsu/jitsu-cli.json`
  3. an interactive prompt

This lets a project commit its target workspace and drop `--workspace <id>` from
the deploy script:

```jsonc
// jitsu.json
{ "workspace": "my-workspace-slug" }
```

```json
"scripts": { "deploy": "jitsu-cli build && jitsu-cli deploy" }
```

## Testing

- `pnpm typecheck` passes for `cli/jitsu-cli`.
- `loadProjectConfig` verified: `jitsu.json` wins over the `package.json` `"jitsu"`
  key; falls back to the key when no `jitsu.json`; returns `{}` when neither exists.
- Workspace resolution matches by both id and slug; unknown ref errors clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
