### PR TITLE
ci(release): CLI on 1.11 line + auto-dispatch on .cli.version.json bump

### DIFF
--- a/.cli.version.json
+++ b/.cli.version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.15",
+  "version": "1.11",
   "tag_prefix": "jitsu-cli",
   "stable_branch": "stable-cli",
   "beta_branch": "newjitsu"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -271,6 +271,7 @@ jobs:
             version_bump:
               - .services.version.json
               - .jsclient.version.json
+              - .cli.version.json
 
       - name: 🚀 Trigger publish workflow
         if: steps.changes.outputs.version_bump == 'true'


### PR DESCRIPTION
Follow-up to the jitsu-cli release-train split (#1391). Two changes:

1. **lint.yml** — the dispatch-publish job only watched `.services.version.json`
   and `.jsclient.version.json`, so a `.cli.version.json` bump never triggered
   `publish.yml`. Added it to the `version_bump` filter.
2. **.cli.version.json** — set base to **1.11**. The CLI historically tracked the
   1.x line; keep it there rather than inheriting the services stream's 2.x.

Merging this bumps `.cli.version.json`, which (via change 1) auto-dispatches a
stable CLI publish → `jitsu-cli@1.11.0`, no microservices.