### PR TITLE
feat(console): request-origin awareness across audit log and product analytics

### DIFF
--- a/webapps/console/components/AuditLog/AuditLog.tsx
+++ b/webapps/console/components/AuditLog/AuditLog.tsx
@@ -8,7 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useDebounce } from "use-debounce";
 import Link from "next/link";
 import { AuditLogDiff } from "../AuditLogDiff/AuditLogDiff";
-import { inferTokenTypeFromId } from "../../lib/schema";
+import { originFromAuth } from "../../lib/schema";
 import { FaTerminal } from "react-icons/fa";
 import { FaCloudArrowUp, FaRobot, FaWindowMaximize } from "react-icons/fa6";
 
@@ -77,12 +77,10 @@ function severityTag(s?: string | null) {
 }
 
 /**
- * authType values written by the auth/audit code:
- *   "next-auth", "oidc", "firebase", "credentials" → UI session
- *   "mcp" → MCP tool call (see mcp-server/tools.ts principalFromAuth)
- *   "bearer" → API token; the row also carries a tokenType ("api" | "cli" | …)
- * Origin renders as one of four flat labels: UI / API / CLI / MCP. Other token
- * types fall through to their raw label so we don't quietly silo them.
+ * Origin renders as one of four flat labels: UI / API / CLI / MCP. The mapping
+ * from authType/token to origin lives in `originFromAuth` (lib/schema) so the
+ * audit-log display, the origin filter, and product analytics stay in sync.
+ * A row with no authType has no known origin and renders as "—".
  */
 type Origin = { label: string; color: string; icon: React.ReactNode };
 
@@ -91,15 +89,13 @@ const ORIGIN_API: Origin = { label: "API", color: "purple", icon: <FaCloudArrowU
 const ORIGIN_CLI: Origin = { label: "CLI", color: "blue", icon: <FaTerminal /> };
 const ORIGIN_MCP: Origin = { label: "MCP", color: "magenta", icon: <FaRobot /> };
 
+const ORIGIN_BY_KIND = { ui: ORIGIN_UI, api: ORIGIN_API, cli: ORIGIN_CLI, mcp: ORIGIN_MCP } as const;
+
 function resolveOrigin(item: AuditLogItem): Origin | null {
   if (!item.authType) return null;
-  if (item.authType === "mcp") return ORIGIN_MCP;
-  if (item.authType !== "bearer") return ORIGIN_UI;
-  const tokenType = item.token?.type || (item.tokenId ? inferTokenTypeFromId(item.tokenId) : "api");
-  if (tokenType === "cli") return ORIGIN_CLI;
-  if (tokenType === "api") return ORIGIN_API;
-  // Unknown bearer subtype — surface it verbatim rather than collapsing to API.
-  return { label: tokenType.toUpperCase(), color: "default", icon: <FaCloudArrowUp /> };
+  return ORIGIN_BY_KIND[
+    originFromAuth({ authType: item.authType, tokenId: item.tokenId, tokenType: item.token?.type })
+  ];
 }
 
 function originTag(item: AuditLogItem) {

--- a/webapps/console/components/AuditLog/AuditLog.tsx
+++ b/webapps/console/components/AuditLog/AuditLog.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import { AuditLogDiff } from "../AuditLogDiff/AuditLogDiff";
 import { inferTokenTypeFromId } from "../../lib/schema";
 import { FaTerminal } from "react-icons/fa";
-import { FaCloudArrowUp, FaWindowMaximize } from "react-icons/fa6";
+import { FaCloudArrowUp, FaRobot, FaWindowMaximize } from "react-icons/fa6";
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
@@ -63,6 +63,13 @@ const severityOptions = [
   { value: "security", label: "Security" },
 ];
 
+const originOptions = [
+  { value: "ui", label: "UI" },
+  { value: "api", label: "API" },
+  { value: "cli", label: "CLI" },
+  { value: "mcp", label: "MCP" },
+];
+
 function severityTag(s?: string | null) {
   if (!s) return null;
   const color = s === "security" ? "red" : s === "warning" ? "orange" : "default";
@@ -72,8 +79,9 @@ function severityTag(s?: string | null) {
 /**
  * authType values written by the auth/audit code:
  *   "next-auth", "oidc", "firebase", "credentials" → UI session
+ *   "mcp" → MCP tool call (see mcp-server/tools.ts principalFromAuth)
  *   "bearer" → API token; the row also carries a tokenType ("api" | "cli" | …)
- * Origin renders as one of three flat labels: UI / API / CLI. Other token
+ * Origin renders as one of four flat labels: UI / API / CLI / MCP. Other token
  * types fall through to their raw label so we don't quietly silo them.
  */
 type Origin = { label: string; color: string; icon: React.ReactNode };
@@ -81,9 +89,11 @@ type Origin = { label: string; color: string; icon: React.ReactNode };
 const ORIGIN_UI: Origin = { label: "UI", color: "geekblue", icon: <FaWindowMaximize /> };
 const ORIGIN_API: Origin = { label: "API", color: "purple", icon: <FaCloudArrowUp /> };
 const ORIGIN_CLI: Origin = { label: "CLI", color: "blue", icon: <FaTerminal /> };
+const ORIGIN_MCP: Origin = { label: "MCP", color: "magenta", icon: <FaRobot /> };
 
 function resolveOrigin(item: AuditLogItem): Origin | null {
   if (!item.authType) return null;
+  if (item.authType === "mcp") return ORIGIN_MCP;
   if (item.authType !== "bearer") return ORIGIN_UI;
   const tokenType = item.token?.type || (item.tokenId ? inferTokenTypeFromId(item.tokenId) : "api");
   if (tokenType === "cli") return ORIGIN_CLI;
@@ -233,6 +243,7 @@ export const AuditLog: React.FC<AuditLogProps> = ({ workspaceId, workspaceSlug, 
   const adminView = !workspaceId;
   const [types, setTypes] = useState<string[]>([]);
   const [severities, setSeverities] = useState<string[]>([]);
+  const [origins, setOrigins] = useState<string[]>([]);
   const [range, setRange] = useState<[Dayjs | null, Dayjs | null] | null>(null);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const [pages, setPages] = useState<AuditLogItem[][]>([]);
@@ -262,11 +273,12 @@ export const AuditLog: React.FC<AuditLogProps> = ({ workspaceId, workspaceSlug, 
       JSON.stringify({
         types,
         severities,
+        origins,
         ws: wsFilter?.value,
         from: range?.[0]?.toISOString(),
         to: range?.[1]?.toISOString(),
       }),
-    [types, severities, wsFilter, range]
+    [types, severities, origins, wsFilter, range]
   );
 
   const query = useQuery<AuditLogPage, Error>(
@@ -276,6 +288,7 @@ export const AuditLog: React.FC<AuditLogProps> = ({ workspaceId, workspaceSlug, 
       if (effectiveWorkspaceId) params.workspaceId = effectiveWorkspaceId;
       if (types.length) params.type = types.join(",");
       if (severities.length) params.severity = severities.join(",");
+      if (origins.length) params.origin = origins.join(",");
       if (range?.[0]) params.from = range[0].toISOString();
       if (range?.[1]) params.to = range[1].toISOString();
       if (cursor) params.cursor = cursor;
@@ -416,6 +429,18 @@ export const AuditLog: React.FC<AuditLogProps> = ({ workspaceId, workspaceSlug, 
           options={severityOptions}
           onChange={v => {
             setSeverities(v);
+            reset();
+          }}
+        />
+        <Select
+          mode="multiple"
+          allowClear
+          placeholder="Origin"
+          style={{ minWidth: 160 }}
+          value={origins}
+          options={originOptions}
+          onChange={v => {
+            setOrigins(v);
             reset();
           }}
         />

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -196,6 +196,35 @@ export function inferTokenTypeFromId(id: string): string {
   return "api";
 }
 
+/** Where an authenticated request originated. */
+export type RequestOrigin = "ui" | "api" | "cli" | "mcp";
+
+/**
+ * Classify the origin of an authenticated request from its auth fields (as carried on
+ * SessionUser, or on an audit-log row). Pure — safe to import from client code.
+ *
+ *   authType "mcp"                        → "mcp"
+ *   authType "bearer" + CLI token         → "cli"  (tokenType "cli", or jitsu-cli- id)
+ *   authType "bearer" + anything else     → "api"
+ *   anything else (session / no authType) → "ui"
+ *
+ * Single source of truth for origin: `resolveOrigin` in
+ * components/AuditLog/AuditLog.tsx and the origin filter predicates in
+ * pages/api/audit-log.ts mirror this mapping — keep them in sync.
+ */
+export function originFromAuth(auth: {
+  authType?: string | null;
+  tokenId?: string | null;
+  tokenType?: string | null;
+}): RequestOrigin {
+  if (auth.authType === "mcp") return "mcp";
+  if (auth.authType === "bearer") {
+    const tokenType = auth.tokenType || (auth.tokenId ? inferTokenTypeFromId(auth.tokenId) : "api");
+    return tokenType === "cli" ? "cli" : "api";
+  }
+  return "ui";
+}
+
 export const StreamConfig = ConfigEntityBase.merge(
   z
     .object({

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -241,16 +241,16 @@ export class ConfigObjectsService {
     }
 
     await trackTelemetryEvent("config-object-create", { objectType: type });
-    if (opts.req) {
-      await withProductAnalytics(
-        p =>
-          p.track("create_object", {
-            ...objectAnalyticsProps(type, id, object),
-            ...(incoming.cloneId ? { cloned: true } : {}),
-          }),
-        { user, workspace, req: opts.req }
-      );
-    }
+    // Emit regardless of caller (HTTP or MCP) so MCP-authored changes are tracked too.
+    // The event carries the request origin (ui/api/cli/mcp) via withProductAnalytics.
+    await withProductAnalytics(
+      p =>
+        p.track("create_object", {
+          ...objectAnalyticsProps(type, id, object),
+          ...(incoming.cloneId ? { cloned: true } : {}),
+        }),
+      { user, workspace, req: opts.req }
+    );
     await configObjectAuditLog(user, workspaceId, created.id, type, "create", { newVersion: object });
     return { id: created.id };
   }
@@ -288,13 +288,12 @@ export class ConfigObjectsService {
     delete filtered.workspaceId;
     await this.prisma.configurationObject.update({ where: { id }, data: { config: filtered } });
     await trackTelemetryEvent("config-object-update", { objectType: type });
-    if (opts.req) {
-      await withProductAnalytics(p => p.track("update_object", objectAnalyticsProps(type, id, filtered)), {
-        user,
-        workspace,
-        req: opts.req,
-      });
-    }
+    // Emit for HTTP and MCP callers alike; origin (ui/api/cli/mcp) is stamped by withProductAnalytics.
+    await withProductAnalytics(p => p.track("update_object", objectAnalyticsProps(type, id, filtered)), {
+      user,
+      workspace,
+      req: opts.req,
+    });
     await configObjectAuditLog(user, workspaceId, id, type, "update", { prevVersion, newVersion: filtered });
   }
 
@@ -321,9 +320,10 @@ export class ConfigObjectsService {
     }
     await this.prisma.configurationObject.update({ where: { id: object.id }, data: { deleted: true } });
     await trackTelemetryEvent("config-object-delete", { objectType: type });
-    if (opts.req) {
-      // delete() doesn't otherwise load the workspace — fetch it only when we're
-      // actually going to emit the event, so name/slug reach the group traits.
+    // Emit for HTTP and MCP callers alike (origin is stamped by withProductAnalytics).
+    // delete() doesn't otherwise load the workspace — fetch it only when telemetry is on
+    // and we're going to emit, so name/slug reach the group traits.
+    if (productTelemetryEnabled) {
       const workspace = await this.prisma.workspace.findFirst({ where: { id: workspaceId } });
       if (workspace) {
         await withProductAnalytics(p => p.track("delete_object", objectAnalyticsProps(type, id, object.config)), {
@@ -371,7 +371,9 @@ export class ConfigObjectsService {
     event: "connection_created" | "connection_deleted",
     link: { id: string; fromId: string; toId: string; type?: string | null }
   ): Promise<void> {
-    if (!req || !productTelemetryEnabled) {
+    // Emit for HTTP and MCP callers alike; `req` (when present) only adds IP context.
+    // Origin (ui/api/cli/mcp) is stamped by withProductAnalytics.
+    if (!productTelemetryEnabled) {
       return;
     }
     const [workspace, from, to] = await Promise.all([

--- a/webapps/console/lib/server/telemetry.ts
+++ b/webapps/console/lib/server/telemetry.ts
@@ -1,7 +1,7 @@
 import { db } from "./db";
 import { getLog, randomId } from "juava";
 import { AnalyticsInterface, emptyAnalytics, jitsuAnalytics } from "@jitsu/js";
-import { SessionUser } from "../schema";
+import { originFromAuth, RequestOrigin, SessionUser } from "../schema";
 import { Workspace } from "@prisma/client";
 import { NextApiRequest } from "next";
 import { AnalyticsContext } from "@jitsu/protocols/analytics";
@@ -81,10 +81,13 @@ export interface ProductAnalytics extends AnalyticsInterface {
 
 function createProductAnalytics(
   analytics: AnalyticsInterface,
-  opts?: { req?: NextApiRequest; workspace?: Workspace | WorkspaceIdAndProps }
+  opts?: { req?: NextApiRequest; workspace?: Workspace | WorkspaceIdAndProps; origin?: RequestOrigin }
 ): ProductAnalytics {
   const req = opts?.req;
   const ws = opts?.workspace;
+  // Where the request came from (ui / api / cli / mcp). Stamped onto every track
+  // event below so all product-analytics events carry their origin.
+  const origin = opts?.origin;
   // Injected into every track event so all workspace-scoped events carry the same
   // workspace identity in their properties (in addition to the `groupId`). Omitted
   // when the event isn't tied to a workspace (e.g. `user_created`).
@@ -121,13 +124,18 @@ function createProductAnalytics(
         ip: (req?.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() || req?.socket?.remoteAddress,
         //userAgent: req?.headers["user-agent"] as string,
       };
-      return analytics.track(event, { ...(workspaceProps || {}), ...(props || {}), context });
+      return analytics.track(event, {
+        ...(origin ? { origin } : {}),
+        ...(workspaceProps || {}),
+        ...(props || {}),
+        context,
+      });
     },
   };
 }
 
 export type TrackedUser = Pick<SessionUser, "internalId" | "email" | "name"> &
-  Partial<Pick<SessionUser, "externalId" | "loginProvider">>;
+  Partial<Pick<SessionUser, "externalId" | "loginProvider" | "authType" | "tokenId" | "tokenType">>;
 
 /**
  * Server-side login/logout product event. Account-level: fires an identify + the event,
@@ -159,7 +167,12 @@ export function withProductAnalytics(
 ): Promise<any[]> {
   //we create new instance every time since analytics.js saves state in props and not thread safe
   //creating of an instance is cheap operation
-  const instance = createProductAnalytics(createAnalytics(), { req: opts?.req, workspace: opts.workspace });
+  const instance = createProductAnalytics(createAnalytics(), {
+    req: opts?.req,
+    workspace: opts.workspace,
+    // Derived from the acting user's auth fields; guarantees every event carries an origin.
+    origin: originFromAuth(opts.user),
+  });
   const allPromises: Promise<any>[] = [];
   if (opts.user) {
     allPromises.push(instance.identifyUser(opts.user));

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -271,6 +271,10 @@ export default createRoute()
       workspaceId: z.string().optional(),
       type: z.string().optional(),
       severity: z.string().optional(),
+      // Comma-separated subset of "ui" | "api" | "cli" | "mcp". Origin is not a
+      // stored column — it's derived from authType (+ the jitsu-cli- tokenId
+      // prefix), mirroring resolveOrigin() in components/AuditLog/AuditLog.tsx.
+      origin: z.string().optional(),
       from: z.coerce.date().optional(),
       to: z.coerce.date().optional(),
       cursor: z.string().optional(),
@@ -323,6 +327,44 @@ export default createRoute()
     }
     if (query.severity) {
       where.severity = { in: query.severity.split(",").filter(Boolean) };
+    }
+    if (query.origin) {
+      // Translate each requested origin into a DB predicate that mirrors
+      // resolveOrigin() on the client. There is no `origin` column: UI is any
+      // non-bearer/non-mcp authType, CLI/API split on the jitsu-cli- tokenId
+      // prefix (reliable — the CLI is the only minter of that prefix, and it's
+      // stored on AuditLog.tokenId verbatim). We attach the OR of the selected
+      // origins via `where.AND` so it composes with the workspace/cursor `OR`.
+      const CLI_PREFIX = "jitsu-cli-";
+      const originClauses: Prisma.AuditLogWhereInput[] = [];
+      for (const o of query.origin.split(",").filter(Boolean)) {
+        switch (o) {
+          case "mcp":
+            originClauses.push({ authType: "mcp" });
+            break;
+          case "ui":
+            // notIn also excludes NULL authType (SQL IN semantics), which is
+            // correct: those rows render with no origin, not "UI".
+            originClauses.push({ authType: { notIn: ["bearer", "mcp"] } });
+            break;
+          case "cli":
+            originClauses.push({ authType: "bearer", tokenId: { startsWith: CLI_PREFIX } });
+            break;
+          case "api":
+            // Bearer, minus CLI. A bearer row with no tokenId (service-account
+            // token) resolves to "API" on the client, so include tokenId=null.
+            originClauses.push({
+              authType: "bearer",
+              OR: [{ tokenId: null }, { tokenId: { not: { startsWith: CLI_PREFIX } } }],
+            });
+            break;
+        }
+      }
+      if (originClauses.length > 0) {
+        const and = (where.AND as Prisma.AuditLogWhereInput[] | undefined) ?? [];
+        and.push({ OR: originClauses });
+        where.AND = and;
+      }
     }
     if (query.from || query.to) {
       where.timestamp = {};

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -273,7 +273,8 @@ export default createRoute()
       severity: z.string().optional(),
       // Comma-separated subset of "ui" | "api" | "cli" | "mcp". Origin is not a
       // stored column — it's derived from authType (+ the jitsu-cli- tokenId
-      // prefix), mirroring resolveOrigin() in components/AuditLog/AuditLog.tsx.
+      // prefix). These predicates are the inverse of originFromAuth() in
+      // lib/schema; keep them in sync.
       origin: z.string().optional(),
       from: z.coerce.date().optional(),
       to: z.coerce.date().optional(),

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -331,14 +331,39 @@ export default createRoute()
     }
     if (query.origin) {
       // Translate each requested origin into a DB predicate that mirrors
-      // resolveOrigin() on the client. There is no `origin` column: UI is any
-      // non-bearer/non-mcp authType, CLI/API split on the jitsu-cli- tokenId
-      // prefix (reliable — the CLI is the only minter of that prefix, and it's
-      // stored on AuditLog.tokenId verbatim). We attach the OR of the selected
-      // origins via `where.AND` so it composes with the workspace/cursor `OR`.
+      // originFromAuth() (lib/schema). There is no `origin` column: UI is any
+      // non-bearer/non-mcp authType; the CLI/API split follows originFromAuth,
+      // which treats a bearer token as CLI when its UserApiToken.type is "cli"
+      // OR its id has the jitsu-cli- prefix. The prefix is stored on
+      // AuditLog.tokenId, but `type` lives on UserApiToken with no relation to
+      // join — so for cli/api we additionally resolve the (normally empty) set
+      // of type="cli" tokens whose id lacks the prefix, keeping the filter
+      // consistent with how the table classifies/renders those rows. We attach
+      // the OR of the selected origins via `where.AND` so it composes with the
+      // workspace/cursor `OR`.
       const CLI_PREFIX = "jitsu-cli-";
+      const requested = query.origin.split(",").filter(Boolean);
+      // Tokens the console never mints this way (its CLI endpoint sets both the
+      // prefix and type), but /api/user/keys allows type:"cli" with a random id.
+      let unprefixedCliTokenIds: string[] = [];
+      if (requested.includes("cli") || requested.includes("api")) {
+        const rows = await db.prisma().userApiToken.findMany({
+          where: { type: "cli", NOT: { id: { startsWith: CLI_PREFIX } } },
+          select: { id: true },
+        });
+        unprefixedCliTokenIds = rows.map(r => r.id);
+      }
+      // A bearer row is CLI iff its tokenId is prefixed or in the resolved set.
+      const cliTokenMatch: Prisma.AuditLogWhereInput[] = [
+        { tokenId: { startsWith: CLI_PREFIX } },
+        ...(unprefixedCliTokenIds.length ? [{ tokenId: { in: unprefixedCliTokenIds } }] : []),
+      ];
+      const notCliToken: Prisma.AuditLogWhereInput[] = [
+        { tokenId: { not: { startsWith: CLI_PREFIX } } },
+        ...(unprefixedCliTokenIds.length ? [{ tokenId: { notIn: unprefixedCliTokenIds } }] : []),
+      ];
       const originClauses: Prisma.AuditLogWhereInput[] = [];
-      for (const o of query.origin.split(",").filter(Boolean)) {
+      for (const o of requested) {
         switch (o) {
           case "mcp":
             originClauses.push({ authType: "mcp" });
@@ -349,14 +374,14 @@ export default createRoute()
             originClauses.push({ authType: { notIn: ["bearer", "mcp"] } });
             break;
           case "cli":
-            originClauses.push({ authType: "bearer", tokenId: { startsWith: CLI_PREFIX } });
+            originClauses.push({ authType: "bearer", OR: cliTokenMatch });
             break;
           case "api":
             // Bearer, minus CLI. A bearer row with no tokenId (service-account
             // token) resolves to "API" on the client, so include tokenId=null.
             originClauses.push({
               authType: "bearer",
-              OR: [{ tokenId: null }, { tokenId: { not: { startsWith: CLI_PREFIX } } }],
+              OR: [{ tokenId: null }, { AND: notCliToken }],
             });
             break;
         }


### PR DESCRIPTION
Makes the console consistently aware of **where a request came from — UI, API, CLI, or MCP** — across two surfaces: the audit log and product analytics.

## 1. Audit log — MCP origin + origin filter

- **MCP shows as its own Origin.** The Origin column collapsed any non-`bearer`
  `authType` to **UI**, so MCP-authored config changes displayed as "UI" even
  though they were already written with `authType="mcp"`. Added an `ORIGIN_MCP`
  tag (robot icon).
- **Origin filter.** New multi-select filter with **UI / API / CLI / MCP**. The
  API route gains an `origin` query param translated to `authType` predicates
  (CLI/API split on the `jitsu-cli-` `tokenId` prefix), composed with the
  existing workspace/cursor `OR` via `where.AND`. No migration/backfill —
  historical MCP rows already carry `authType="mcp"`.

## 2. Product analytics — origin on every event

Product analytics never recorded origin, and config-object/connection events
were gated on an HTTP `req`, so **MCP-authored changes emitted no event at all**.

- `withProductAnalytics` derives origin from the acting user and
  `createProductAnalytics` stamps `origin` onto **every** `track()` event.
- **Ungated** `create_object` / `update_object` / `delete_object` and
  `connection_created` / `connection_deleted` so MCP (and any non-HTTP caller)
  emit them too. `delete_object` and connection events keep a
  `productTelemetryEnabled` guard so self-hosted pays for no extra query.

## Single source of truth

`originFromAuth()` (in `lib/schema`, pure/isomorphic) is the one mapping from
`authType`/token → `ui|api|cli|mcp`. The audit-log Origin column and product
analytics both consume it; the audit-log filter predicates are its documented
inverse.

## Testing

- `tsc --noEmit` clean for all changed files (pre-existing errors are unrelated
  missing dev-deps: `msw`, `testcontainers`, `@storybook/*`).

Follow-up to `JITSU-89` (workspace filter on admin audit log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeUP6H1fsHsJjo2FLKKqUS