### PR TITLE
JITSU-104 feat(console): log X-Request-ID as request_id on request logs

### DIFF
--- a/libs/juava/src/log.ts
+++ b/libs/juava/src/log.ts
@@ -21,6 +21,17 @@ let globalLogLevel: LogLevel = (process.env.JUAVA_LOG_LEVEL || "info") as LogLev
 let enableServerLogsColoring: boolean = !(process.env.CI === "1" || process.env.CI === "true");
 let enableJsonFormat: boolean = false;
 
+// Optional provider of ambient structured fields merged into every JSON log
+// line — e.g. a per-request `request_id` sourced from AsyncLocalStorage. Kept
+// as a pluggable hook (not a direct async_hooks import) so juava stays free of
+// Node-only APIs and safe to bundle for the browser/edge; the request-scoped
+// storage lives in the consumer (see webapps/console/lib/server/request-context.ts).
+let logContextProvider: (() => Record<string, any> | undefined) | undefined = undefined;
+
+export function setLogContextProvider(provider: (() => Record<string, any> | undefined) | undefined) {
+  logContextProvider = provider;
+}
+
 export function setGlobalLogLevel(level: LogLevel) {
   globalLogLevel = level;
 }
@@ -155,7 +166,10 @@ function dispatch(msg: LogMessage) {
       }
     }
     if (enableJsonFormat) {
-      writeln(JSON.stringify({ time: msg.date, level: msg.level, msg: lines.join("\n") }));
+      // Ambient fields (e.g. request_id) go top-level so Datadog parses them as
+      // attributes (@request_id, …). The reserved keys always win over context.
+      const context = logContextProvider ? logContextProvider() : undefined;
+      writeln(JSON.stringify({ ...context, time: msg.date, level: msg.level, msg: lines.join("\n") }));
     } else {
       const border = ""; // = "｜";
       const messageFormatted = lines.join(`\n${border} `);

--- a/webapps/console/lib/api.ts
+++ b/webapps/console/lib/api.ts
@@ -525,7 +525,10 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
     // context so every log line for this request carries request_id → @request_id
     // in Datadog, enabling an exact edge-5xx ↔ app-stack join (JITSU-104).
     const rawRequestId = req.headers["x-request-id"];
-    const requestId = (Array.isArray(rawRequestId) ? rawRequestId[0] : rawRequestId) || randomUUID();
+    const headerRequestId = Array.isArray(rawRequestId) ? rawRequestId[0] : rawRequestId;
+    // trim() so a blank/whitespace header falls back to a real id instead of
+    // collapsing distinct requests under an empty-ish @request_id.
+    const requestId = headerRequestId?.trim() || randomUUID();
     return runWithRequestContext({ request_id: requestId }, () => handleRequest(req, res));
   };
 }

--- a/webapps/console/lib/api.ts
+++ b/webapps/console/lib/api.ts
@@ -13,7 +13,9 @@ import { isMaintenanceActive } from "./server/maintenance";
 import { prepareZodObjectForDeserialization, safeParseWithDate } from "./zod";
 import { ApiError } from "./shared/errors";
 import { getServerLog } from "./server/log";
+import { runWithRequestContext } from "./server/request-context";
 import { getFirebaseUser, isFirebaseEnabled } from "./server/firebase-server";
+import { randomUUID } from "crypto";
 import jwt from "jsonwebtoken";
 import { serialize } from "cookie";
 import {
@@ -341,7 +343,7 @@ export async function getUser(
 }
 
 export function nextJsApiHandler(api: Api): NextApiHandler {
-  return async (req: NextApiRequest, res: NextApiResponse) => {
+  const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
     const method = req.method as HttpMethodType;
     const handler = api[method];
     if (!handler) {
@@ -517,6 +519,14 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
           .send({ error: tryJson(getErrorMessage(e)), details: e?.stack, stackArray: stackToArray(e?.stack) });
       }
     }
+  };
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    // Bind the inbound nginx X-Request-ID (or a generated fallback) to the async
+    // context so every log line for this request carries request_id → @request_id
+    // in Datadog, enabling an exact edge-5xx ↔ app-stack join (JITSU-104).
+    const rawRequestId = req.headers["x-request-id"];
+    const requestId = (Array.isArray(rawRequestId) ? rawRequestId[0] : rawRequestId) || randomUUID();
+    return runWithRequestContext({ request_id: requestId }, () => handleRequest(req, res));
   };
 }
 

--- a/webapps/console/lib/server/log.ts
+++ b/webapps/console/lib/server/log.ts
@@ -1,11 +1,22 @@
-import { getLog, LoggerOpts, LogLevel, setGlobalLogLevel, setServerJsonFormat, setServerLogColoring } from "juava";
+import {
+  getLog,
+  LoggerOpts,
+  LogLevel,
+  setGlobalLogLevel,
+  setLogContextProvider,
+  setServerJsonFormat,
+  setServerLogColoring,
+} from "juava";
 import { getServerEnv } from "./serverEnv";
+import { getRequestContext } from "./request-context";
 
 const serverEnv = getServerEnv();
 
 setGlobalLogLevel((serverEnv.LOG_LEVEL || "info") as LogLevel);
 setServerLogColoring(!serverEnv.DISABLE_SERVER_LOGS_ANSI_COLORING);
 setServerJsonFormat(serverEnv.LOG_FORMAT === "json");
+// Merge request-scoped fields (request_id, …) into every JSON log line.
+setLogContextProvider(getRequestContext);
 
 export function getServerLog(_opts?: LoggerOpts | string) {
   return getLog(_opts);

--- a/webapps/console/lib/server/request-context.ts
+++ b/webapps/console/lib/server/request-context.ts
@@ -23,7 +23,10 @@ const storage = new AsyncLocalStorage<RequestContext>();
  */
 export function runWithRequestContext<T>(context: RequestContext, fn: () => T): T {
   const parent = storage.getStore();
-  return storage.run({ ...parent, ...context }, fn);
+  // Freeze the stored context so a stray `getRequestContext().x = …` can't alter
+  // it mid-request. Fields are primitives (request_id), so a shallow freeze is
+  // enough; extend a scope via a nested runWithRequestContext, not by mutation.
+  return storage.run(Object.freeze({ ...parent, ...context }), fn);
 }
 
 export function getRequestContext(): RequestContext | undefined {

--- a/webapps/console/lib/server/request-context.ts
+++ b/webapps/console/lib/server/request-context.ts
@@ -1,0 +1,31 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+/**
+ * Request-scoped context propagated to every log line emitted while handling a
+ * request. Primarily carries `request_id` (the inbound nginx `X-Request-ID`) so
+ * an edge 5xx in the ingress access log can be joined to the exact app-side
+ * error/stack in Datadog via `@request_id`.
+ *
+ * This lives in the console (not juava) because `async_hooks` is Node-only and
+ * juava is also bundled for the browser. juava exposes `setLogContextProvider`
+ * and calls back into `getRequestContext` for JSON log lines.
+ */
+export type RequestContext = {
+  request_id?: string;
+  [key: string]: any;
+};
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Run `fn` with the given context bound to the async execution. Merges with any
+ * parent context so nested `runWithRequestContext` calls don't drop fields.
+ */
+export function runWithRequestContext<T>(context: RequestContext, fn: () => T): T {
+  const parent = storage.getStore();
+  return storage.run({ ...parent, ...context }, fn);
+}
+
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore();
+}


### PR DESCRIPTION
Fixes `JITSU-104` (enabler for `JITSU-103` agentic alert triage).

## Problem

nginx-ingress logs `@http.request_id` (`$req_id`) and forwards it upstream as `X-Request-ID`, but the console never logged it. So an edge 5xx could only be joined to the app-side stack trace by *fuzzy* correlation (same upstream + route + ±5s). A live check searching two 5xx request-ids across all Datadog logs returned only the nginx access logs — nothing app-side.

## What

- **`nextJsApiHandler`** (the central choke point for both `createRoute` and legacy `Api` routes) now binds the inbound `X-Request-ID` — or a generated `randomUUID()` fallback when absent — to an `AsyncLocalStorage` context for the whole request.
- **juava's JSON log emitter** merges request-scoped fields as **top-level keys**, so `request_id` is emitted alongside `time`/`level`/`msg` and Datadog auto-parses it as `@request_id`. Every log line during the request — including the 500 `error + stack` lines in the catch block — carries it.
- juava stays free of Node-only `async_hooks`: it exposes a pluggable `setLogContextProvider` hook (safe for the browser/edge bundles it's part of), and the request-scoped storage lives in `webapps/console/lib/server/request-context.ts` (server-only).

Triage step 3 can flip from window-match to exact:
```
kube_namespace:jitsu-platform @request_id:<id> status:error   →  the actual stack trace
```

## Datadog field

`request_id` is a top-level JSON key, so Datadog's JSON parsing exposes it as `@request_id` with no pipeline remapper needed. Worth a quick confirm on the pipeline that nothing strips/renames it.

## Verification

- Ran the real juava `log.ts` through `tsx` with a mock ALS context:
  - **inside** a request → JSON line includes `"request_id":"…"` as a top-level key on the same line as the error + full stack;
  - **outside** any request → no `request_id` key (no spurious field on startup/background logs);
  - reserved `time`/`level`/`msg` preserved and never clobbered by context.
- `tsc --noEmit` on the console: no type errors in the changed files. (One unrelated pre-existing error, `jsondiffpatch` in `libs/jitsu-js`, is a workspace-link quirk, not touched here.)

## Scope note

Covers all routes flowing through `nextJsApiHandler` — i.e. the vast majority (per the issue's "at minimum on error/500 paths"). Raw Next API routes / NextAuth `[...nextauth]` handlers don't use this wrapper and are out of scope; can follow up if we want auth-path 5xx joined too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)