### PR TITLE
JITSU-106 fix(console): make ApiError status unambiguous and fix client error codes

### DIFF
--- a/webapps/console/lib/api.ts
+++ b/webapps/console/lib/api.ts
@@ -280,7 +280,7 @@ export async function getUser(
   if (bearerToken) {
     const [keyId, secret] = bearerToken.split(":");
     if (!secret) {
-      throw new ApiError("Bearer token should have a format of keyId:secret");
+      throw new ApiError("Bearer token should have a format of keyId:secret", { status: 401 });
     }
     const serviceAccount = findServiceAccount({ keyId, secret });
     if (serviceAccount) {
@@ -290,18 +290,21 @@ export async function getUser(
       //auth based on an API key
       const token = await db.prisma().userApiToken.findUnique({ where: { id: keyId } });
       if (!token) {
-        throw new ApiError(`Invalid API key id ${keyId}`, { keyId }, { status: 401 });
+        throw new ApiError(`Invalid API key id ${keyId}`, { status: 401, responseObject: { keyId } });
       }
       if (!checkHash(token.hash, secret)) {
-        throw new ApiError(`Invalid API key secret for ${keyId}`, { keyId }, { status: 401 });
+        throw new ApiError(`Invalid API key secret for ${keyId}`, { status: 401, responseObject: { keyId } });
       }
       // MCP refresh tokens are stored in UserApiToken but must not be usable
       // as general Console API bearer keys — they are scoped to MCP only.
       if (token.oauthClientId) {
-        throw new ApiError(`MCP refresh tokens cannot be used as Console API bearer keys`, { keyId }, { status: 401 });
+        throw new ApiError(`MCP refresh tokens cannot be used as Console API bearer keys`, {
+          status: 401,
+          responseObject: { keyId },
+        });
       }
       if (token.expiresAt && token.expiresAt.getTime() < Date.now()) {
-        throw new ApiError(`API key ${keyId} has expired`, { keyId }, { status: 401 });
+        throw new ApiError(`API key ${keyId} has expired`, { status: 401, responseObject: { keyId } });
       }
       const user = requireDefined(
         await db.prisma().userProfile.findUnique({ where: { id: token.userId } }),
@@ -437,8 +440,10 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
 
         if (!parseResult.success) {
           throw new ApiError(`Can't parse request body for ${req.method} ${req.url}`, {
-            zodError: parseResult.error,
-            body: tryJson(req.body),
+            responseObject: {
+              zodError: parseResult.error,
+              body: tryJson(req.body),
+            },
           });
         }
         body = parseResult.data;
@@ -447,7 +452,9 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
           body = parseIfNeeded(req.body);
         } catch (e) {
           throw new ApiError(`Body ${req.method} ${req.url} is not a JSON object: ${getErrorMessage(e)}`, {
-            body: req.body,
+            responseObject: {
+              body: req.body,
+            },
           });
         }
       }
@@ -456,7 +463,9 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
         const parseResult = safeParseWithDate(handler.types?.query, req.query);
         if (!parseResult.success) {
           throw new ApiError(`Can't parse request query for ${req.method} ${req.url}`, {
-            zodError: parseResult.error,
+            responseObject: {
+              zodError: parseResult.error,
+            },
           });
         }
         query = parseResult.data;
@@ -482,7 +491,9 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
               )}. Zod error: ${JSON.stringify(parseResult.error)}`
             );
           throw new ApiError(`Response for ${req.method} ${req.url} doesn't match required schema`, {
-            zodError: parseResult.error,
+            responseObject: {
+              zodError: parseResult.error,
+            },
           });
         }
         //do not set explicit 200 status here. If the status has been set by the handler, we should respect it. There's
@@ -589,11 +600,10 @@ export async function verifyAccess(user: SessionUser, workspaceId: string) {
     if ((await db.prisma().userProfile.findFirst({ where: { id: user.internalId } }))?.admin) {
       return;
     }
-    throw new ApiError(
-      `User ${userId} doesn't have access to workspace ${workspaceId}`,
-      { workspaceId, userId },
-      { status: 403 }
-    );
+    throw new ApiError(`User ${userId} doesn't have access to workspace ${workspaceId}`, {
+      status: 403,
+      responseObject: { workspaceId, userId },
+    });
   }
 }
 
@@ -629,11 +639,10 @@ export async function verifyAccessWithRole(
         ...WorkspaceRolePermissions["owner"],
       };
     }
-    throw new ApiError(
-      `User ${userId} doesn't have access to workspace ${workspaceId}`,
-      { workspaceId, userId },
-      { status: 403 }
-    );
+    throw new ApiError(`User ${userId} doesn't have access to workspace ${workspaceId}`, {
+      status: 403,
+      responseObject: { workspaceId, userId },
+    });
   }
 
   const role = (access.role || "owner") as WorkspaceRoleType;
@@ -641,8 +650,7 @@ export async function verifyAccessWithRole(
   if (!hasPermission(role, requiredPermission)) {
     throw new ApiError(
       `User ${userId} doesn't have permission '${requiredPermission}' in workspace ${workspaceId}. Required role: owner or editor`,
-      { workspaceId, userId, role, requiredPermission },
-      { status: 403 }
+      { status: 403, responseObject: { workspaceId, userId, role, requiredPermission } }
     );
   }
 

--- a/webapps/console/lib/nextauth.config.ts
+++ b/webapps/console/lib/nextauth.config.ts
@@ -87,7 +87,7 @@ export async function getOrCreateUser(opts: {
   });
   if (!user) {
     if (serverEnv.DISABLE_SIGNUP) {
-      throw new ApiError("Sign up is disabled", { code: "signup-disabled" });
+      throw new ApiError("Sign up is disabled", { responseObject: { code: "signup-disabled" } });
     }
     //first user is admin
     const admin = !(await db.prisma().userProfile.count());

--- a/webapps/console/lib/schema/config-objects.ts
+++ b/webapps/console/lib/schema/config-objects.ts
@@ -75,9 +75,9 @@ export async function handleLinkedConnections(
       });
     }
   } else if (options?.strict) {
-    throw new ApiError(
-      `Cannot delete ${objectType} because it has ${linkedConnections.length} linked connections`,
-      {
+    throw new ApiError(`Cannot delete ${objectType} because it has ${linkedConnections.length} linked connections`, {
+      status: 409,
+      responseObject: {
         code: "LINKED_CONNECTIONS_EXIST",
         linkedConnectionsCount: linkedConnections.length,
         linkedConnections: linkedConnections.map(link => ({
@@ -87,8 +87,7 @@ export async function handleLinkedConnections(
           toId: link.toId,
         })),
       },
-      { status: 409 }
-    );
+    });
   }
 }
 
@@ -97,13 +96,17 @@ export function parseObject(type: string, obj: any): any {
   assertDefined(configType, `Unknown config object type ${type}`);
   const parseResult = safeParseWithDate(configType.schema, obj);
   if (!parseResult.success) {
-    throw new ApiError(`Failed to validate schema of ${type}`, { object: obj, error: parseResult.error });
+    throw new ApiError(`Failed to validate schema of ${type}`, {
+      responseObject: { object: obj, error: parseResult.error },
+    });
   }
   const topLevelObject = parseResult.data;
   //we're parsing same object twice here, but it's not a big deal
   const narrowParseResult = configType.narrowSchema(topLevelObject, configType.schema).safeParse(obj);
   if (!narrowParseResult.success) {
-    throw new ApiError(`Failed to validate schema of ${type}`, { object: obj, error: narrowParseResult.error });
+    throw new ApiError(`Failed to validate schema of ${type}`, {
+      responseObject: { object: obj, error: narrowParseResult.error },
+    });
   }
   return narrowParseResult.data;
 }
@@ -293,21 +296,23 @@ const configObjectTypes: Record<string, ConfigObjectType> = {
         throw new ApiError(
           `Cannot delete function because it is being used by ${connectionsUsingFunction.length} connection(s) and ${profileBuildersUsingFunction.length} profile builder(s)`,
           {
-            code: "FUNCTION_IN_USE",
-            connectionsCount: connectionsUsingFunction.length,
-            profileBuildersCount: profileBuildersUsingFunction.length,
-            connections: connectionsUsingFunction.map(link => ({
-              id: link.id,
-              type: link.type || "push",
-              fromId: link.fromId,
-              toId: link.toId,
-            })),
-            profileBuilders: profileBuildersUsingFunction.map(pb => ({
-              id: pb.id,
-              name: pb.name,
-            })),
-          },
-          { status: 409 }
+            status: 409,
+            responseObject: {
+              code: "FUNCTION_IN_USE",
+              connectionsCount: connectionsUsingFunction.length,
+              profileBuildersCount: profileBuildersUsingFunction.length,
+              connections: connectionsUsingFunction.map(link => ({
+                id: link.id,
+                type: link.type || "push",
+                fromId: link.fromId,
+                toId: link.toId,
+              })),
+              profileBuilders: profileBuildersUsingFunction.map(pb => ({
+                id: pb.id,
+                name: pb.name,
+              })),
+            },
+          }
         );
       }
     },

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -129,11 +129,10 @@ export class ConfigObjectsService {
 
   private assertKnownType(type: string) {
     if (!getAllConfigObjectTypeNames().includes(type)) {
-      throw new ApiError(
-        `Unknown resource type '${type}'. Known types: ${getAllConfigObjectTypeNames().join(", ")}`,
-        { type },
-        { status: 400 }
-      );
+      throw new ApiError(`Unknown resource type '${type}'. Known types: ${getAllConfigObjectTypeNames().join(", ")}`, {
+        status: 400,
+        responseObject: { type },
+      });
     }
   }
 
@@ -170,7 +169,7 @@ export class ConfigObjectsService {
       where: { workspaceId, id, type, deleted: false },
     });
     if (!object) {
-      throw new ApiError(`${type} with id ${id} does not exist`, {}, { status: 404 });
+      throw new ApiError(`${type} with id ${id} does not exist`, { status: 404 });
     }
     const preFilter = { ...((object.config as any) || {}), workspaceId, id, type, updatedAt: object.updatedAt };
     return await configObjectType.outputFilter(preFilter);
@@ -277,7 +276,7 @@ export class ConfigObjectsService {
       where: { workspaceId, id, type, deleted: false },
     });
     if (!object) {
-      throw new ApiError(`${type} with id ${id} does not exist`, {}, { status: 404 });
+      throw new ApiError(`${type} with id ${id} does not exist`, { status: 404 });
     }
     // Snapshot before merge — `merge` may mutate `object.config` in place.
     const prevVersion = deepCopy(object.config);
@@ -414,7 +413,7 @@ export class ConfigObjectsService {
       try {
         validateSyncSchedule(data);
       } catch (e: any) {
-        throw new ApiError(e.message, {}, { status: 400 });
+        throw new ApiError(e.message, { status: 400 });
       }
     }
 
@@ -431,23 +430,19 @@ export class ConfigObjectsService {
         : undefined;
 
     if (!id && existingLink) {
-      throw new ApiError(`Link from '${fromId}' to '${toId}' already exists`, {}, { status: 400 });
+      throw new ApiError(`Link from '${fromId}' to '${toId}' already exists`, { status: 400 });
     }
 
     const co = this.prisma.configurationObject;
     if (!(await co.findFirst({ where: { workspaceId, type: fromType, id: fromId, deleted: false } }))) {
-      throw new ApiError(
-        `${fromType} object with id '${fromId}' not found in the workspace '${workspaceId}'`,
-        {},
-        { status: 400 }
-      );
+      throw new ApiError(`${fromType} object with id '${fromId}' not found in the workspace '${workspaceId}'`, {
+        status: 400,
+      });
     }
     if (!(await co.findFirst({ where: { workspaceId, type: "destination", id: toId, deleted: false } }))) {
-      throw new ApiError(
-        `Destination object with id '${toId}' not found in the workspace '${workspaceId}'`,
-        {},
-        { status: 400 }
-      );
+      throw new ApiError(`Destination object with id '${toId}' not found in the workspace '${workspaceId}'`, {
+        status: 400,
+      });
     }
 
     let createdOrUpdated: any;
@@ -499,31 +494,29 @@ export class ConfigObjectsService {
       where: { workspaceId, id, deleted: false },
     });
     if (!existing) {
-      throw new ApiError(`connection with id ${id} does not exist`, {}, { status: 404 });
+      throw new ApiError(`connection with id ${id} does not exist`, { status: 404 });
     }
     if (patch.fromId && patch.fromId !== existing.fromId) {
-      throw new ApiError(`fromId '${patch.fromId}' does not match connection ${id}`, {}, { status: 400 });
+      throw new ApiError(`fromId '${patch.fromId}' does not match connection ${id}`, { status: 400 });
     }
     if (patch.toId && patch.toId !== existing.toId) {
-      throw new ApiError(`toId '${patch.toId}' does not match connection ${id}`, {}, { status: 400 });
+      throw new ApiError(`toId '${patch.toId}' does not match connection ${id}`, { status: 400 });
     }
     // A link's type is immutable (push↔sync changes the from/to semantics — that's a
     // delete + create). Reject a mismatched patch.type rather than validate against one
     // type and persist another.
     const type = existing.type ?? "push";
     if (patch.type && patch.type !== type) {
-      throw new ApiError(
-        `connection ${id} is '${type}'; its type can't be changed to '${patch.type}'`,
-        {},
-        { status: 400 }
-      );
+      throw new ApiError(`connection ${id} is '${type}'; its type can't be changed to '${patch.type}'`, {
+        status: 400,
+      });
     }
     const data = patch.data !== undefined ? patch.data : existing.data;
     if (type === "sync" && data) {
       try {
         validateSyncSchedule(data);
       } catch (e: any) {
-        throw new ApiError(e.message, {}, { status: 400 });
+        throw new ApiError(e.message, { status: 400 });
       }
     }
     await this.validateLinkData(workspaceId, type, existing.toId, data);
@@ -541,11 +534,10 @@ export class ConfigObjectsService {
     if (type === "sync") {
       const parseResult = SyncOptionsType.safeParse(data);
       if (!parseResult.success) {
-        throw new ApiError(
-          `Invalid sync options: ${parseResult.error.message}`,
-          { zodError: parseResult.error },
-          { status: 400 }
-        );
+        throw new ApiError(`Invalid sync options: ${parseResult.error.message}`, {
+          status: 400,
+          responseObject: { zodError: parseResult.error },
+        });
       }
       return;
     }
@@ -561,8 +553,7 @@ export class ConfigObjectsService {
             `Invalid connection options for ${(destination.config as any)?.["destinationType"]}: ${
               parseResult.error.message
             }`,
-            { zodError: parseResult.error },
-            { status: 400 }
+            { status: 400, responseObject: { zodError: parseResult.error } }
           );
         }
       }
@@ -580,7 +571,7 @@ export class ConfigObjectsService {
     await verifyAccessWithRole(user, workspaceId, "deleteEntities");
     if (id) {
       if (fromId || toId) {
-        throw new ApiError("You can't specify 'fromId' or 'toId' with 'id'", {}, { status: 400 });
+        throw new ApiError("You can't specify 'fromId' or 'toId' with 'id'", { status: 400 });
       }
       // Read-then-update: prisma `update` throws when no row matches, so a missing id would
       // error instead of reporting deleted:false. Look it up first.

--- a/webapps/console/lib/server/debug-service.ts
+++ b/webapps/console/lib/server/debug-service.ts
@@ -78,7 +78,7 @@ export class DebugService {
         where: { id, workspaceId, type, deleted: false },
       });
       if (!existing) {
-        throw new ApiError(`${type} with id ${id} does not exist`, {}, { status: 404 });
+        throw new ApiError(`${type} with id ${id} does not exist`, { status: 404 });
       }
       body = { ...(existing.config as any), id };
     }
@@ -109,7 +109,7 @@ export class DebugService {
       const response = await fetch(bulkerURLEnv + "/test", options);
       return await response.json();
     } catch (e) {
-      throw new ApiError(`failed to fetch bulker API: ${getErrorMessage(e)}`, {}, { status: 500 });
+      throw new ApiError(`failed to fetch bulker API: ${getErrorMessage(e)}`, { status: 500 });
     }
   }
 
@@ -134,7 +134,7 @@ export class DebugService {
         where: { id: opts.functionId, workspaceId, type: "function", deleted: false },
       });
       if (!func) {
-        throw new ApiError(`function with id ${opts.functionId} does not exist`, {}, { status: 404 });
+        throw new ApiError(`function with id ${opts.functionId} does not exist`, { status: 404 });
       }
       const cfg = func.config as any;
       code = requireDefined(cfg.draft ?? cfg.code, `function ${opts.functionId} has no code`);
@@ -185,7 +185,7 @@ export class DebugService {
       include: { functions: { include: { function: true } } },
     });
     if (!pb) {
-      throw new ApiError(`profile builder with id ${opts.profileBuilderId} does not exist`, {}, { status: 404 });
+      throw new ApiError(`profile builder with id ${opts.profileBuilderId} does not exist`, { status: 404 });
     }
     let code = opts.code;
     if (code === undefined) {

--- a/webapps/console/lib/server/events-log-service.ts
+++ b/webapps/console/lib/server/events-log-service.ts
@@ -106,8 +106,7 @@ export class EventsLogService {
         `Unknown events-log type '${type}'. Known: ${EVENTS_LOG_TYPES.join(
           ", "
         )} (use the dead-letter tooling for '${DEAD_LETTER}')`,
-        { type },
-        { status: 400 }
+        { status: 400, responseObject: { type } }
       );
     }
     await verifyAccess(user, workspaceId);
@@ -316,7 +315,7 @@ export class EventsLogService {
     mode: "incoming" | "actor" | "deadletter"
   ) {
     const reject = () => {
-      throw new ApiError(`source '${actorId}' doesn't belong to the current workspace`, {}, { status: 403 });
+      throw new ApiError(`source '${actorId}' doesn't belong to the current workspace`, { status: 403 });
     };
     if (mode === "incoming") {
       if (!(await this.prisma.configurationObject.findFirst({ where: { id: actorId, workspaceId } }))) reject();

--- a/webapps/console/lib/server/mcp-server/tools.ts
+++ b/webapps/console/lib/server/mcp-server/tools.ts
@@ -84,7 +84,7 @@ function principalFromAuth(authInfo: AuthInfo | undefined): SessionUser {
   const extra = (authInfo?.extra ?? {}) as Record<string, any>;
   const userId = extra.userId;
   if (!userId) {
-    throw new ApiError("No authenticated user on this MCP session", {}, { status: 401 });
+    throw new ApiError("No authenticated user on this MCP session", { status: 401 });
   }
   return {
     internalId: userId,
@@ -194,7 +194,7 @@ export function registerTools(sdkServer: SdkMcpServer, deps: ToolDeps) {
           const links = await service.listLinks(user, workspaceId);
           const found = links.find((l: any) => l.id === id);
           if (!found) {
-            throw new ApiError(`connection with id ${id} does not exist`, {}, { status: 404 });
+            throw new ApiError(`connection with id ${id} does not exist`, { status: 404 });
           }
           return found;
         }

--- a/webapps/console/lib/server/reports-service.ts
+++ b/webapps/console/lib/server/reports-service.ts
@@ -131,7 +131,7 @@ export class ReportsService {
       where: { id: opts.profileBuilderId, workspaceId },
     });
     if (!pb) {
-      throw new ApiError(`Profile Builder ${opts.profileBuilderId} not found`, {}, { status: 404 });
+      throw new ApiError(`Profile Builder ${opts.profileBuilderId} not found`, { status: 404 });
     }
     const version = opts.version ?? pb.version;
     try {

--- a/webapps/console/lib/server/sync-service.ts
+++ b/webapps/console/lib/server/sync-service.ts
@@ -77,7 +77,7 @@ export class SyncService {
       where: { id: serviceId, workspaceId, type: "service", deleted: false },
     });
     if (!row) {
-      throw new ApiError(`service with id ${serviceId} not found in the workspace`, {}, { status: 404 });
+      throw new ApiError(`service with id ${serviceId} not found in the workspace`, { status: 404 });
     }
     const service = { ...(row.config as any), ...row } as any;
     const h = juavaHash("md5", stableHash(service.credentials));

--- a/webapps/console/lib/shared/errors.ts
+++ b/webapps/console/lib/shared/errors.ts
@@ -1,10 +1,17 @@
 export class ApiError extends Error {
-  status?: number;
+  status: number;
   responseObject: object;
 
-  constructor(message: string, responseObject: object = {}, { status = 500 }: { status?: number } = {}) {
+  /**
+   * `status` and `responseObject` both used to be positional objects, so passing
+   * the status in the payload slot — `new ApiError(msg, { status: 403 })` — type
+   * checked fine but silently answered 500 and leaked `status` into the response
+   * body. Eleven call sites had it wrong. Keep them in one options bag so the
+   * compiler can tell the two apart.
+   */
+  constructor(message: string, opts: { status?: number; responseObject?: object } = {}) {
     super(message);
-    this.status = status;
-    this.responseObject = responseObject;
+    this.status = opts.status ?? 500;
+    this.responseObject = opts.responseObject ?? {};
   }
 }

--- a/webapps/console/pages/api/[workspaceId]/config/[type]/test.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/[type]/test.ts
@@ -73,7 +73,7 @@ export const route = createRoute()
       log.atInfo().log(`StatusCode: ${response.status} Response Body: ${JSON.stringify(json)}`);
       return json;
     } catch (e) {
-      throw new ApiError(`failed to fetch bulker API: ${getErrorMessage(e)}`, {}, { status: 500 });
+      throw new ApiError(`failed to fetch bulker API: ${getErrorMessage(e)}`, { status: 500 });
     }
   });
 

--- a/webapps/console/pages/api/[workspaceId]/config/profile-builder.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/profile-builder.ts
@@ -71,7 +71,9 @@ const upsertHandler = async (ctx: any) => {
   await verifyAccessWithRole(user, workspaceId, "editEntities");
   const parseResult = safeParseWithDate(ProfileBuilderDbModel, body.profileBuilder);
   if (!parseResult.success) {
-    throw new ApiError(`Failed to validate schema of profile-builder`, { object: body, error: parseResult.error });
+    throw new ApiError(`Failed to validate schema of profile-builder`, {
+      responseObject: { object: body, error: parseResult.error },
+    });
   }
   const pb = parseResult.data;
 

--- a/webapps/console/pages/api/[workspaceId]/dead-letter/[actorId].ts
+++ b/webapps/console/pages/api/[workspaceId]/dead-letter/[actorId].ts
@@ -51,7 +51,7 @@ export const api: Api = {
           .profileBuilder.findFirst({ where: { id: query.actorId, workspaceId: query.workspaceId } });
 
         if (!source && !link && !pb) {
-          throw new ApiError(`actor doesn't belong to the current workspace`, {}, { status: 403 });
+          throw new ApiError(`actor doesn't belong to the current workspace`, { status: 403 });
         }
       }
 

--- a/webapps/console/pages/api/[workspaceId]/log/[type]/[actorId].ts
+++ b/webapps/console/pages/api/[workspaceId]/log/[type]/[actorId].ts
@@ -44,7 +44,7 @@ export const api: Api = {
           .prisma()
           .configurationObject.findFirst({ where: { id: query.actorId, workspaceId: query.workspaceId } });
         if (!source) {
-          throw new ApiError(`site doesn't belong to the current workspace`, {}, { status: 403 });
+          throw new ApiError(`site doesn't belong to the current workspace`, { status: 403 });
         }
       } else {
         const link = await db
@@ -57,7 +57,7 @@ export const api: Api = {
           where: { id: query.actorId, workspaceId: query.workspaceId, type: "destination" },
         });
         if (!link && !pb && !dst) {
-          throw new ApiError(`connection doesn't belong to the current workspace`, {}, { status: 403 });
+          throw new ApiError(`connection doesn't belong to the current workspace`, { status: 403 });
         }
       }
       res.writeHead(200, {

--- a/webapps/console/pages/api/[workspaceId]/sources/run.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/run.ts
@@ -65,7 +65,7 @@ export const route = createRoute()
       trigger = "manual";
       user = await getUser(res, req);
       if (!user) {
-        throw new ApiError("Authorization Required", {}, { status: 401 });
+        throw new ApiError("Authorization Required", { status: 401 });
       }
       await verifyAccess(user, workspaceId);
     }

--- a/webapps/console/pages/api/admin/domains.ts
+++ b/webapps/console/pages/api/admin/domains.ts
@@ -18,10 +18,10 @@ export default createRoute()
   })
   .handler(async ({ query: { token, domain }, res }) => {
     if (!dataDomains) {
-      throw new ApiError(`Domain ${domain} not found. Data domains configuration is absent`, {}, { status: 404 });
+      throw new ApiError(`Domain ${domain} not found. Data domains configuration is absent`, { status: 404 });
     }
     if (!token) {
-      throw new ApiError("Unauthorized", {}, { status: 401 });
+      throw new ApiError("Unauthorized", { status: 401 });
     }
     if (domain.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)) {
       res.status(404);
@@ -52,7 +52,7 @@ export default createRoute()
         return { ok: true, details: `Stream ${streamId} found` };
       } else {
         log.atWarn().log(`Stream ${streamId} extracted from ${domain} not found`);
-        throw new ApiError(`Slug ${streamId} for ${domain} not found`, {}, { status: 404 });
+        throw new ApiError(`Slug ${streamId} for ${domain} not found`, { status: 404 });
       }
     } else {
       log.atInfo().log(`Stream not found for ${domain}. Searching by custom domain`);
@@ -68,7 +68,7 @@ export default createRoute()
       });
       if (!streams || streams.length === 0) {
         log.atWarn().log(`Custom domain ${domain} not found`);
-        throw new ApiError(`Domain ${domain} not found`, {}, { status: 404 });
+        throw new ApiError(`Domain ${domain} not found`, { status: 404 });
       } else {
         log
           .atWarn()

--- a/webapps/console/pages/api/fb-auth/create-session.ts
+++ b/webapps/console/pages/api/fb-auth/create-session.ts
@@ -37,13 +37,13 @@ export const api: Api = {
         log
           .atError()
           .log(`CSRF cookie (${csrfCookie}) doesn't match provided token ${csrfToken}`, JSON.stringify(req.cookies));
-        throw new ApiError("CSRF error", {}, { status: 401 });
+        throw new ApiError("CSRF error", { status: 401 });
       }
       // JITSU-018: never mint a session cookie for an unverified email+password
       // account, even if the client-side gate was bypassed.
       const decodedIdToken = await firebase().auth().verifyIdToken(idToken);
       if (isUnverifiedPasswordAccount(decodedIdToken)) {
-        throw new ApiError("Email address is not verified", {}, { status: 403 });
+        throw new ApiError("Email address is not verified", { status: 403 });
       }
       const { cookie, expiresIn } = await createSessionCookie(idToken);
 

--- a/webapps/console/pages/api/init-user.ts
+++ b/webapps/console/pages/api/init-user.ts
@@ -42,12 +42,11 @@ export default createRoute()
         if (isMaintenanceActive()) {
           throw new ApiError(
             "Jitsu is in maintenance mode; account creation is temporarily disabled. Please try again later.",
-            { code: "maintenance" },
-            { status: 503 }
+            { status: 503, responseObject: { code: "maintenance" } }
           );
         }
         if (serverEnv.DISABLE_SIGNUP) {
-          throw new ApiError("Sign up is disabled", { code: "signup-disabled" });
+          throw new ApiError("Sign up is disabled", { responseObject: { code: "signup-disabled" } });
         }
         if (!user.loginProvider && !user.externalId) {
           //double check so we won't pull first of all users from DB
@@ -70,7 +69,10 @@ export default createRoute()
         // genuinely new account is about to be created. The helper deletes the
         // orphaned Firebase account.
         if (await shouldRejectPersonalEmailSignup(user)) {
-          throw new ApiError(WORK_EMAIL_REQUIRED_MESSAGE, { code: "personal-email-rejected" }, { status: 403 });
+          throw new ApiError(WORK_EMAIL_REQUIRED_MESSAGE, {
+            status: 403,
+            responseObject: { code: "personal-email-rejected" },
+          });
         }
 
         const newUser = await db.prisma().userProfile.create({

--- a/webapps/console/pages/api/sources/logo.ts
+++ b/webapps/console/pages/api/sources/logo.ts
@@ -1,11 +1,15 @@
 import { db } from "../../../lib/server/db";
-import { getErrorMessage, getLog, requireDefined } from "juava";
+import { getErrorMessage, getLog } from "juava";
 import { jitsuSources, externalSources } from "./index";
 
 export default async function handler(req, res) {
   try {
     const packageType = (req.query.type as string) || "airbyte";
-    const packageId = requireDefined(req.query.package as string, `GET param package is required`);
+    const packageId = req.query.package as string;
+    if (!packageId) {
+      res.status(400).json({ status: 400, message: `GET param package is required` });
+      return;
+    }
 
     const jitsuSource = jitsuSources[packageId];
     if (jitsuSource) {

--- a/webapps/console/pages/api/user/keys.ts
+++ b/webapps/console/pages/api/user/keys.ts
@@ -89,7 +89,7 @@ const api: Api = {
     handle: async ({ user, query, body }) => {
       const existing = await db.prisma().userApiToken.findUnique({ where: { id: query.id } });
       if (!existing || existing.userId !== user.internalId) {
-        throw new ApiError(`Key not found`, {}, { status: 404 });
+        throw new ApiError(`Key not found`, { status: 404 });
       }
       // `expiresAt` is tri-state on the wire: present-as-Date sets, present-as-null
       // clears, missing leaves the column alone. Same for `name`.
@@ -122,7 +122,7 @@ const api: Api = {
     handle: async ({ user, query }) => {
       const existing = await db.prisma().userApiToken.findUnique({ where: { id: query.id } });
       if (!existing || existing.userId !== user.internalId) {
-        throw new ApiError(`Key not found`, {}, { status: 404 });
+        throw new ApiError(`Key not found`, { status: 404 });
       }
       // MCP-aware delete: if the row has oauthClientId set, also nukes its
       // OAuthAccessToken rows and the OAuthClient itself. For non-MCP keys

--- a/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/index.ts
+++ b/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/index.ts
@@ -115,13 +115,12 @@ export const route = createRoute()
     try {
       await verifyAccess(user, workspace.id);
     } catch (e) {
-      throw new ApiError(
-        `Current user doesn't have an access to workspace`,
-        {
+      throw new ApiError(`Current user doesn't have an access to workspace`, {
+        status: 403,
+        responseObject: {
           noAccessToWorkspace: true,
         },
-        { status: 403 }
-      );
+      });
     }
     if (workspace.slug) {
       // workspaceId/workspaceName/workspaceSlug are injected for every event by


### PR DESCRIPTION
`JITSU-106` — follow-up to `JITSU-103`, found by using the `JITSU-104` `request_id` join to trace a week of nginx-ingress alerts back to app stacks.

Pairs with [jitsu-cloud-billing#24](https://github.com/jitsucom/jitsu-cloud-billing/pull/24), which fixes the same class of bug on billing.

## The bug

`ApiError`'s constructor took **two positional objects**:

```ts
constructor(message: string, responseObject: object = {}, { status = 500 }: { status?: number } = {})
```

So `new ApiError(msg, { status: 403 })` — the form that reads correctly, and that **eleven call sites independently reached for** — type checked fine but silently answered **500**, leaking `status` into the response body:

```
OLD call form -> HTTP status: 500 | body: {"message":"User x is not an admin","status":403}
```

An HTTP 500 whose body claims `"status": 403`. It looks right in review, which is presumably how it survived. Real impact:

| Site | Intended | Actually returned |
| -- | -- | -- |
| `verifyAdmin` — non-admin on any admin endpoint | 403 | 500 |
| `workspace` create/update — invalid name or slug (4 sites) | 400 | 500 |
| `workspace/[id]`, `workspace/[id]/users` — not found (2 sites) | 404 | 500 |
| `users/[userId]/role` — user has no access | 404 | 500 |
| `users/[userId]/role` — removing the last owner | 400 | 500 |
| `[workspaceId]/listen` — missing `If-Modified-Since` | 400 | 500 |

All of it lands in the `[nginx-ingress] 5xx / bad-4xx surge` monitor (304244687) as if it were a server fault. The `listen` one plausibly explains the `/api/.../listen` 500 seen in the logs this week.

## The fix

The argument *order* was never the problem — `status` and `responseObject` are **both plain objects**, so the compiler can't tell them apart. Any signature that keeps them as two positional objects stays silently misusable. Collapsing them into one options bag breaks the ambiguity:

```ts
constructor(message: string, opts: { status?: number; responseObject?: object } = {})
```

Now:
- **The natural form is the correct form.** `new ApiError("Not an admin", { status: 403 })` does what it says — those 11 sites needed no edit at all.
- **Every stale call is a compile error**, not a silent 500: `Expected 1-2 arguments, but got 3.` and `Object literal may only specify known properties, and 'code' does not exist in type '{ status?: ...; responseObject?: ... }'`.

Migrated all **59 call sites across 19 files** via an AST codemod (then prettier), a mechanical transform the compiler validated:

```
(msg, payload, { status: N })  ->  (msg, { status: N, responseObject: payload })
(msg, payload)                 ->  (msg, { responseObject: payload })
```

## Two sites that threw with no status at all

- **`lib/api.ts`** — a malformed bearer token (`Bearer token should have a format of keyId:secret`) → **401**. Every neighbouring auth failure in the same block already passed `{ status: 401 }`; this one was missed. 25 of these 500s in the week, all from a `node` user-agent calling `/api/undefined/config/link`.
- **`/api/sources/logo`** — a missing `package` query param → **400** (was `requireDefined` throwing into a blanket `catch` → 500).

## Verification

- `tsc --noEmit`: **0 errors** (was 59 immediately after the signature change — that count *is* the migration surface, each one enumerated by the compiler).
- `eslint .`: 0 errors (2 pre-existing warnings in untouched files).
- `prettier --check`: clean.
- `vitest --project unit`: 3 files, 22 tests passed.
- Runtime check against the real module:

```
PASS  bare -> default 500              -> status 500 (want 500), body {}
PASS  natural form (the 11 sites)      -> status 403 (want 403), body {}
PASS  status + payload (auth sites)    -> status 401 (want 401), body {"keyId":"k"}
PASS  payload only                     -> status 500 (want 500), body {"code":"signup-disabled"}
```

Note the second line: the body is now clean `{}` — no more `status` leaking into the response.

## Reviewer note

The bulk of the diff is the mechanical 59-site migration. The interesting files are `lib/shared/errors.ts` (the signature) and `lib/api.ts` (the bearer-token 401 + the auth sites' payload migration).

## Not in this PR

The literal `undefined` in `/api/undefined/config/link` and `airbyte/undefined` comes from a caller-side bug — a JS `undefined` interpolated into a URL by a `node` client. Worth tracking down separately; this PR only stops it being reported as a server fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)