### PR TITLE
JITSU-91: migrate sync/debug/reports HTTP routes onto the shared service classes

### DIFF
--- a/webapps/console/__tests__/integration/reports-service.test.ts
+++ b/webapps/console/__tests__/integration/reports-service.test.ts
@@ -100,6 +100,8 @@ describe("ReportsService", () => {
     const byStatus = Object.fromEntries(res.rows.map((r: any) => [r.status, r]));
     expect(Number(byStatus.success.events)).toBe(12); // 5 + 7 via sumMerge
     expect(Number(byStatus.error.events)).toBe(1);
+    // srcSize (underlying chunk count) is part of the wire shape the UI's Report schema requires
+    expect(Number(byStatus.success.srcSize)).toBeGreaterThan(0);
     expect(byStatus.success.period).toBe("2026-06-10T00:00:00Z");
     expect(byStatus.success.workspaceId).toBe(workspace.id);
   });

--- a/webapps/console/__tests__/integration/sync-service.test.ts
+++ b/webapps/console/__tests__/integration/sync-service.test.ts
@@ -10,19 +10,12 @@ import { MASKED_SECRET } from "../../lib/schema/destinations";
 
 const svc = () => new SyncService({ prisma: deps().prisma, pgPool: deps().pgPool, clickhouse: deps().clickhouse });
 
+const PKG = { package: "airbyte/source-github", version: "1.0.0" };
+
 async function seedSync(workspaceId: string) {
   const prisma = deps().prisma;
   const service = await prisma.configurationObject.create({
-    data: {
-      workspaceId,
-      type: "service",
-      config: {
-        name: "github source",
-        package: "airbyte/source-github",
-        version: "1.0.0",
-        credentials: { token: "secret" },
-      },
-    },
+    data: { workspaceId, type: "service", config: { name: "github source", ...PKG, credentials: { token: "secret" } } },
   });
   const destination = await prisma.configurationObject.create({
     data: { workspaceId, type: "destination", config: { name: "wh", destinationType: "webhook" } },
@@ -31,6 +24,23 @@ async function seedSync(workspaceId: string) {
     data: { workspaceId, fromId: service.id, toId: destination.id, type: "sync", data: {} },
   });
 }
+
+const mkTask = (syncId: string, taskId: string, status: string, startedAt: string) => ({
+  sync_id: syncId,
+  task_id: taskId,
+  ...PKG,
+  status,
+  started_at: new Date(startedAt),
+});
+
+const mkLog = (taskId: string, syncId: string, timestamp: string | Date, message: string) => ({
+  task_id: taskId,
+  sync_id: syncId,
+  timestamp,
+  level: "INFO",
+  logger: "sync",
+  message,
+});
 
 describe("SyncService", () => {
   it("runSync posts to syncctl and records a RUNNING source_task through the prisma singleton", async () => {
@@ -68,33 +78,11 @@ describe("SyncService", () => {
     const { workspace: foreign } = await seedWorkspace();
     const foreignSync = await seedSync(foreign.id);
 
-    const prisma = deps().prisma;
-    await prisma.source_task.createMany({
+    await deps().prisma.source_task.createMany({
       data: [
-        {
-          sync_id: sync.id,
-          task_id: "task-ok",
-          package: "airbyte/source-github",
-          version: "1.0.0",
-          status: "SUCCESS",
-          started_at: new Date("2026-07-01T10:00:00Z"),
-        },
-        {
-          sync_id: sync.id,
-          task_id: "task-running",
-          package: "airbyte/source-github",
-          version: "1.0.0",
-          status: "RUNNING",
-          started_at: new Date("2026-07-01T11:00:00Z"),
-        },
-        {
-          sync_id: foreignSync.id,
-          task_id: "task-foreign",
-          package: "airbyte/source-github",
-          version: "1.0.0",
-          status: "SUCCESS",
-          started_at: new Date("2026-07-01T12:00:00Z"),
-        },
+        mkTask(sync.id, "task-ok", "SUCCESS", "2026-07-01T10:00:00Z"),
+        mkTask(sync.id, "task-running", "RUNNING", "2026-07-01T11:00:00Z"),
+        mkTask(foreignSync.id, "task-foreign", "SUCCESS", "2026-07-01T12:00:00Z"),
       ],
     });
 
@@ -121,21 +109,13 @@ describe("SyncService", () => {
     const { workspace: foreign } = await seedWorkspace();
     const foreignSync = await seedSync(foreign.id);
 
-    const task = (syncId: string, taskId: string, status: string, startedAt: string) => ({
-      sync_id: syncId,
-      task_id: taskId,
-      package: "airbyte/source-github",
-      version: "1.0.0",
-      status,
-      started_at: new Date(startedAt),
-    });
     await deps().prisma.source_task.createMany({
       data: [
-        task(syncA.id, "a-old", "SUCCESS", "2026-07-01T10:00:00Z"),
-        task(syncA.id, "a-new", "FAILED", "2026-07-02T10:00:00Z"),
-        task(syncA.id, "a-skipped", "SKIPPED", "2026-07-03T10:00:00Z"), // newest but skipped
-        task(syncB.id, "b-1", "SUCCESS", "2026-07-01T10:00:00Z"),
-        task(foreignSync.id, "f-1", "SUCCESS", "2026-07-01T10:00:00Z"),
+        mkTask(syncA.id, "a-old", "SUCCESS", "2026-07-01T10:00:00Z"),
+        mkTask(syncA.id, "a-new", "FAILED", "2026-07-02T10:00:00Z"),
+        mkTask(syncA.id, "a-skipped", "SKIPPED", "2026-07-03T10:00:00Z"), // newest but skipped
+        mkTask(syncB.id, "b-1", "SUCCESS", "2026-07-01T10:00:00Z"),
+        mkTask(foreignSync.id, "f-1", "SUCCESS", "2026-07-01T10:00:00Z"),
       ],
     });
 
@@ -150,24 +130,13 @@ describe("SyncService", () => {
   it("triggerSourceCheck with a caller config unmasks secrets from the stored object", async () => {
     const { user, workspace } = await seedWorkspace();
     const stored = await deps().prisma.configurationObject.create({
-      data: {
-        workspaceId: workspace.id,
-        type: "service",
-        config: {
-          name: "github source",
-          package: "airbyte/source-github",
-          version: "1.0.0",
-          credentials: { token: "real-secret" },
-        },
-      },
+      data: { workspaceId: workspace.id, type: "service", config: { ...PKG, credentials: { token: "real-secret" } } },
     });
 
     let posted: any;
-    let syncctlQuery: URLSearchParams | undefined;
     server.use(
       http.post("http://syncctl.test.local/check", async ({ request }) => {
         posted = await request.json();
-        syncctlQuery = new URL(request.url).searchParams;
         return HttpResponse.json({ ok: true });
       })
     );
@@ -176,75 +145,47 @@ describe("SyncService", () => {
     // the possibly-unsaved editor config with masked secrets
     const storageKey = `${workspace.id}_${stored.id}_somehash_query1`;
     const res = await svc().triggerSourceCheck(user, workspace.id, {
-      config: {
-        id: stored.id,
-        package: "airbyte/source-github",
-        version: "1.0.0",
-        credentials: { token: MASKED_SECRET },
-      },
+      config: { id: stored.id, ...PKG, credentials: { token: MASKED_SECRET } },
       storageKey,
     });
     expect(res).toMatchObject({ ok: false, pending: true, storageKey });
     expect(posted.source.credentials.token).toBe("real-secret");
-    expect(syncctlQuery?.get("storageKey")).toBe(storageKey);
   });
 
   it("source check storage keys of a prefix-colliding workspace are rejected", async () => {
     const { user, workspace } = await seedWorkspace();
     // workspace "ws1" must not accept keys of "ws10" — an exact `${workspaceId}_` segment is required
     const foreignKey = `${workspace.id}0_service_hash`;
+    const config = { ...PKG, credentials: {} };
 
-    const check = await svc().triggerSourceCheck(user, workspace.id, {
-      config: { package: "p", version: "1", credentials: {} },
-      storageKey: foreignKey,
-    });
-    expect(check.ok).toBe(false);
-    expect(check.error).toMatch(/doesn't belong/);
+    const check = await svc().triggerSourceCheck(user, workspace.id, { config, storageKey: foreignKey });
+    expect(check).toMatchObject({ ok: false, error: expect.stringMatching(/doesn't belong/) });
 
     const poll = await svc().getSourceCheckResult(user, workspace.id, foreignKey);
-    expect(poll.ok).toBe(false);
-    expect(poll.error).toMatch(/doesn't belong/);
+    expect(poll).toMatchObject({ ok: false, error: expect.stringMatching(/doesn't belong/) });
   });
 
   it("setSyncState upserts a stream cursor and refuses while the sync runs", async () => {
     const { user, workspace } = await seedWorkspace();
     const sync = await seedSync(workspace.id);
-    await deps().prisma.source_state.create({
-      data: { sync_id: sync.id, stream: "issues", state: { cursor: "old" } },
-    });
+    const prisma = deps().prisma;
+    await prisma.source_state.create({ data: { sync_id: sync.id, stream: "issues", state: { cursor: "old" } } });
 
-    const updated = await svc().setSyncState(user, workspace.id, {
-      syncId: sync.id,
-      stream: "issues",
-      state: { cursor: "new" },
-    });
+    const set = (stream: string, cursor: string) =>
+      svc().setSyncState(user, workspace.id, { syncId: sync.id, stream, state: { cursor } });
+
+    const updated = await set("issues", "new");
     expect(updated.ok).toBe(true);
     expect(JSON.parse(updated.state.issues)).toEqual({ cursor: "new" });
 
-    const inserted = await svc().setSyncState(user, workspace.id, {
-      syncId: sync.id,
-      stream: "pulls",
-      state: { cursor: "p1" },
-    });
+    const inserted = await set("pulls", "p1");
     expect(Object.keys(inserted.state).sort()).toEqual(["issues", "pulls"]);
 
-    await deps().prisma.source_task.create({
-      data: {
-        sync_id: sync.id,
-        task_id: "task-running-state-edit",
-        package: "airbyte/source-github",
-        version: "1.0.0",
-        status: "RUNNING",
-        started_at: new Date("2026-07-01T10:00:00Z"),
-      },
+    await prisma.source_task.create({
+      data: mkTask(sync.id, "task-running-state-edit", "RUNNING", "2026-07-01T10:00:00Z"),
     });
-    const blocked = await svc().setSyncState(user, workspace.id, {
-      syncId: sync.id,
-      stream: "issues",
-      state: { cursor: "nope" },
-    });
-    expect(blocked.ok).toBe(false);
-    expect(blocked.error).toMatch(/running/i);
+    const blocked = await set("issues", "nope");
+    expect(blocked).toMatchObject({ ok: false, error: expect.stringMatching(/running/i) });
   });
 
   it("getSyncState reads and resetSyncState deletes source_state rows", async () => {
@@ -284,22 +225,8 @@ describe("SyncService", () => {
       format: "JSONEachRow",
       clickhouse_settings: { wait_end_of_query: 1 },
       values: [
-        {
-          task_id: "task-ch",
-          sync_id: sync.id,
-          timestamp: "2026-07-01 10:00:00.000",
-          level: "INFO",
-          logger: "sync",
-          message: "started",
-        },
-        {
-          task_id: "task-ch",
-          sync_id: sync.id,
-          timestamp: "2026-07-01 10:01:00.000",
-          level: "INFO",
-          logger: "sync",
-          message: "finished",
-        },
+        mkLog("task-ch", sync.id, "2026-07-01 10:00:00.000", "started"),
+        mkLog("task-ch", sync.id, "2026-07-01 10:01:00.000", "finished"),
       ],
     });
     const chLogs = await svc().getSyncLogs(user, workspace.id, { syncId: sync.id, taskId: "task-ch" });
@@ -308,14 +235,7 @@ describe("SyncService", () => {
 
     // Postgres fallback: nothing in ClickHouse for this task
     await deps().prisma.task_log.create({
-      data: {
-        task_id: "task-pg",
-        sync_id: sync.id,
-        level: "INFO",
-        logger: "sync",
-        message: "from postgres",
-        timestamp: new Date("2026-07-01T10:00:00Z"),
-      },
+      data: mkLog("task-pg", sync.id, new Date("2026-07-01T10:00:00Z"), "from postgres"),
     });
     const pgLogs = await svc().getSyncLogs(user, workspace.id, { syncId: sync.id, taskId: "task-pg" });
     expect(pgLogs.ok).toBe(true);

--- a/webapps/console/__tests__/integration/sync-service.test.ts
+++ b/webapps/console/__tests__/integration/sync-service.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "./support/msw";
 import { deps, seedWorkspace } from "./support/harness";
 import { SyncService } from "../../lib/server/sync-service";
+import { MASKED_SECRET } from "../../lib/schema/destinations";
 
 // Happy paths against real Postgres (source_task join, source_state, task_log
 // fallback), real ClickHouse (task_log), and MSW-faked syncctl.
@@ -111,6 +112,139 @@ describe("SyncService", () => {
     // a foreign task id doesn't resolve through this workspace's join
     const foreignById = await svc().listSyncTasks(user, workspace.id, { taskId: "task-foreign" });
     expect(foreignById.ok).toBe(false);
+  });
+
+  it("latestSyncTasks returns the newest non-skipped task per sync, workspace-scoped", async () => {
+    const { user, workspace } = await seedWorkspace();
+    const syncA = await seedSync(workspace.id);
+    const syncB = await seedSync(workspace.id);
+    const { workspace: foreign } = await seedWorkspace();
+    const foreignSync = await seedSync(foreign.id);
+
+    const task = (syncId: string, taskId: string, status: string, startedAt: string) => ({
+      sync_id: syncId,
+      task_id: taskId,
+      package: "airbyte/source-github",
+      version: "1.0.0",
+      status,
+      started_at: new Date(startedAt),
+    });
+    await deps().prisma.source_task.createMany({
+      data: [
+        task(syncA.id, "a-old", "SUCCESS", "2026-07-01T10:00:00Z"),
+        task(syncA.id, "a-new", "FAILED", "2026-07-02T10:00:00Z"),
+        task(syncA.id, "a-skipped", "SKIPPED", "2026-07-03T10:00:00Z"), // newest but skipped
+        task(syncB.id, "b-1", "SUCCESS", "2026-07-01T10:00:00Z"),
+        task(foreignSync.id, "f-1", "SUCCESS", "2026-07-01T10:00:00Z"),
+      ],
+    });
+
+    // the foreign sync id is silently dropped by the workspace scoping
+    const res = await svc().latestSyncTasks(user, workspace.id, [syncA.id, syncB.id, foreignSync.id]);
+    expect(res.ok).toBe(true);
+    expect(Object.keys(res.tasks).sort()).toEqual([syncA.id, syncB.id].sort());
+    expect(res.tasks[syncA.id].task_id).toBe("a-new");
+    expect(res.tasks[syncB.id].task_id).toBe("b-1");
+  });
+
+  it("triggerSourceCheck with a caller config unmasks secrets from the stored object", async () => {
+    const { user, workspace } = await seedWorkspace();
+    const stored = await deps().prisma.configurationObject.create({
+      data: {
+        workspaceId: workspace.id,
+        type: "service",
+        config: {
+          name: "github source",
+          package: "airbyte/source-github",
+          version: "1.0.0",
+          credentials: { token: "real-secret" },
+        },
+      },
+    });
+
+    let posted: any;
+    let syncctlQuery: URLSearchParams | undefined;
+    server.use(
+      http.post("http://syncctl.test.local/check", async ({ request }) => {
+        posted = await request.json();
+        syncctlQuery = new URL(request.url).searchParams;
+        return HttpResponse.json({ ok: true });
+      })
+    );
+
+    // the UI generates its own storage key (with a per-query suffix) and sends
+    // the possibly-unsaved editor config with masked secrets
+    const storageKey = `${workspace.id}_${stored.id}_somehash_query1`;
+    const res = await svc().triggerSourceCheck(user, workspace.id, {
+      config: {
+        id: stored.id,
+        package: "airbyte/source-github",
+        version: "1.0.0",
+        credentials: { token: MASKED_SECRET },
+      },
+      storageKey,
+    });
+    expect(res).toMatchObject({ ok: false, pending: true, storageKey });
+    expect(posted.source.credentials.token).toBe("real-secret");
+    expect(syncctlQuery?.get("storageKey")).toBe(storageKey);
+  });
+
+  it("source check storage keys of a prefix-colliding workspace are rejected", async () => {
+    const { user, workspace } = await seedWorkspace();
+    // workspace "ws1" must not accept keys of "ws10" — an exact `${workspaceId}_` segment is required
+    const foreignKey = `${workspace.id}0_service_hash`;
+
+    const check = await svc().triggerSourceCheck(user, workspace.id, {
+      config: { package: "p", version: "1", credentials: {} },
+      storageKey: foreignKey,
+    });
+    expect(check.ok).toBe(false);
+    expect(check.error).toMatch(/doesn't belong/);
+
+    const poll = await svc().getSourceCheckResult(user, workspace.id, foreignKey);
+    expect(poll.ok).toBe(false);
+    expect(poll.error).toMatch(/doesn't belong/);
+  });
+
+  it("setSyncState upserts a stream cursor and refuses while the sync runs", async () => {
+    const { user, workspace } = await seedWorkspace();
+    const sync = await seedSync(workspace.id);
+    await deps().prisma.source_state.create({
+      data: { sync_id: sync.id, stream: "issues", state: { cursor: "old" } },
+    });
+
+    const updated = await svc().setSyncState(user, workspace.id, {
+      syncId: sync.id,
+      stream: "issues",
+      state: { cursor: "new" },
+    });
+    expect(updated.ok).toBe(true);
+    expect(JSON.parse(updated.state.issues)).toEqual({ cursor: "new" });
+
+    const inserted = await svc().setSyncState(user, workspace.id, {
+      syncId: sync.id,
+      stream: "pulls",
+      state: { cursor: "p1" },
+    });
+    expect(Object.keys(inserted.state).sort()).toEqual(["issues", "pulls"]);
+
+    await deps().prisma.source_task.create({
+      data: {
+        sync_id: sync.id,
+        task_id: "task-running-state-edit",
+        package: "airbyte/source-github",
+        version: "1.0.0",
+        status: "RUNNING",
+        started_at: new Date("2026-07-01T10:00:00Z"),
+      },
+    });
+    const blocked = await svc().setSyncState(user, workspace.id, {
+      syncId: sync.id,
+      stream: "issues",
+      state: { cursor: "nope" },
+    });
+    expect(blocked.ok).toBe(false);
+    expect(blocked.error).toMatch(/running/i);
   });
 
   it("getSyncState reads and resetSyncState deletes source_state rows", async () => {

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -138,7 +138,7 @@ export class ConfigObjectsService {
 
   // ─── Config objects ───────────────────────────────────────────────────────
 
-  /** Mirrors `config/[type]/index.ts` GET. */
+  /** Backs `config/[type]/index.ts` GET. */
   async list(user: SessionUser, workspaceId: string, type: string): Promise<any[]> {
     await verifyAccess(user, workspaceId);
     this.assertKnownType(type);
@@ -157,7 +157,7 @@ export class ConfigObjectsService {
     return await Promise.all(mapped.map(obj => configObjectType.outputFilter(obj)));
   }
 
-  /** Mirrors `config/[type]/[id].ts` GET. */
+  /** Backs `config/[type]/[id].ts` GET. */
   async get(user: SessionUser, workspaceId: string, type: string, id: string): Promise<any> {
     await verifyAccess(user, workspaceId);
     this.assertKnownType(type);
@@ -175,7 +175,7 @@ export class ConfigObjectsService {
     return await configObjectType.outputFilter(preFilter);
   }
 
-  /** Mirrors `config/[type]/index.ts` POST. Returns the created id. */
+  /** Backs `config/[type]/index.ts` POST. Returns the created id. */
   async create(
     user: SessionUser,
     workspaceId: string,
@@ -254,7 +254,7 @@ export class ConfigObjectsService {
     return { id: created.id };
   }
 
-  /** Mirrors `config/[type]/[id].ts` PUT. */
+  /** Backs `config/[type]/[id].ts` PUT. */
   async update(
     user: SessionUser,
     workspaceId: string,
@@ -296,7 +296,7 @@ export class ConfigObjectsService {
     await configObjectAuditLog(user, workspaceId, id, type, "update", { prevVersion, newVersion: filtered });
   }
 
-  /** Mirrors `config/[type]/[id].ts` DELETE (soft delete). Returns the deleted object, or null. */
+  /** Backs `config/[type]/[id].ts` DELETE (soft delete). Returns the deleted object, or null. */
   async delete(
     user: SessionUser,
     workspaceId: string,
@@ -338,7 +338,7 @@ export class ConfigObjectsService {
 
   // ─── Connections (links) ──────────────────────────────────────────────────
 
-  /** Mirrors `config/link.ts` GET. Masks `functionsEnv` secrets for non-editors. */
+  /** Backs `config/link.ts` GET. Masks `functionsEnv` secrets for non-editors. */
   async listLinks(user: SessionUser, workspaceId: string): Promise<any[]> {
     const role = await verifyAccessWithRole(user, workspaceId, "readEntities");
     const links = await this.prisma.configurationObjectLink.findMany({
@@ -399,7 +399,7 @@ export class ConfigObjectsService {
     );
   }
 
-  /** Mirrors `config/link.ts` POST/PUT upsert. */
+  /** Backs `config/link.ts` POST/PUT upsert. */
   async upsertLink(
     user: SessionUser,
     workspaceId: string,
@@ -560,7 +560,7 @@ export class ConfigObjectsService {
     }
   }
 
-  /** Mirrors `config/link.ts` DELETE. Delete by `id`, or by `fromId`+`toId`. */
+  /** Backs `config/link.ts` DELETE. Delete by `id`, or by `fromId`+`toId`. */
   async deleteLink(
     user: SessionUser,
     workspaceId: string,

--- a/webapps/console/lib/server/debug-service.ts
+++ b/webapps/console/lib/server/debug-service.ts
@@ -119,6 +119,7 @@ export class DebugService {
     workspaceId: string,
     opts: {
       functionId: string;
+      functionName?: string;
       code?: string;
       event: any;
       variables?: any;
@@ -128,7 +129,7 @@ export class DebugService {
   ): Promise<FunctionRunResult> {
     await verifyAccessWithRole(user, workspaceId, "editEntities");
     let code = opts.code;
-    let functionName: string | undefined;
+    let functionName = opts.functionName;
     if (code === undefined) {
       const func = await this.prisma.configurationObject.findFirst({
         where: { id: opts.functionId, workspaceId, type: "function", deleted: false },

--- a/webapps/console/lib/server/debug-service.ts
+++ b/webapps/console/lib/server/debug-service.ts
@@ -113,7 +113,7 @@ export class DebugService {
     }
   }
 
-  /** Mirrors `function/run.ts`. `code` omitted → the stored function's draft (falls back to code). */
+  /** Backs `function/run.ts`. `code` omitted → the stored function's draft (falls back to code). */
   async runFunction(
     user: SessionUser,
     workspaceId: string,
@@ -164,7 +164,7 @@ export class DebugService {
   }
 
   /**
-   * Mirrors `profile-builder/run.ts`. `code`/`settings`/`version` omitted → loaded from the
+   * Backs `profile-builder/run.ts`. `code`/`settings`/`version` omitted → loaded from the
    * stored profile builder (its function's draft/code and `connectionOptions`).
    */
   async runProfileBuilder(

--- a/webapps/console/lib/server/mcp-server/tools.ts
+++ b/webapps/console/lib/server/mcp-server/tools.ts
@@ -492,7 +492,7 @@ export function registerTools(sdkServer: SdkMcpServer, deps: ToolDeps) {
     },
     async ({ workspaceId, serviceId }, ctx) =>
       run("check_source_credentials", () =>
-        syncs.triggerSourceCheck(principalFromAuth(ctx.authInfo), workspaceId, serviceId)
+        syncs.triggerSourceCheck(principalFromAuth(ctx.authInfo), workspaceId, { serviceId })
       )
   );
 

--- a/webapps/console/lib/server/reports-service.ts
+++ b/webapps/console/lib/server/reports-service.ts
@@ -67,7 +67,8 @@ export class ReportsService {
             streamId,
             destinationId,
             status,
-            sumMerge(events) as events
+            sumMerge(events) as events,
+            count(*) as "srcSize"
         from mv_metrics
         where
             timestamp >= toDateTime({start:String}, 'UTC') and

--- a/webapps/console/lib/server/route-services.ts
+++ b/webapps/console/lib/server/route-services.ts
@@ -5,6 +5,10 @@ import { SyncService } from "./sync-service";
 import { DebugService } from "./debug-service";
 import { ReportsService } from "./reports-service";
 
+// Response schema owned by SyncService, re-exported so route handlers pull their
+// service surface from one place.
+export { latestSyncTaskSchema } from "./sync-service";
+
 // Lazy per-process instances of the shared service classes, bound to the
 // db/clickhouse singletons — for HTTP route handlers. The MCP server wires
 // its own instances through McpServerDeps.

--- a/webapps/console/lib/server/route-services.ts
+++ b/webapps/console/lib/server/route-services.ts
@@ -1,3 +1,4 @@
+import once from "lodash/once";
 import { db } from "./db";
 import { clickhouse } from "./clickhouse";
 import { SyncService } from "./sync-service";
@@ -8,12 +9,8 @@ import { ReportsService } from "./reports-service";
 // db/clickhouse singletons — for HTTP route handlers. The MCP server wires
 // its own instances through McpServerDeps.
 
-let sync: SyncService | undefined;
-export const syncService = () => (sync ??= new SyncService({ prisma: db.prisma(), pgPool: db.pgPool(), clickhouse }));
+export const syncService = once(() => new SyncService({ prisma: db.prisma(), pgPool: db.pgPool(), clickhouse }));
 
-let debug: DebugService | undefined;
-export const debugService = () => (debug ??= new DebugService({ prisma: db.prisma() }));
+export const debugService = once(() => new DebugService({ prisma: db.prisma() }));
 
-let reports: ReportsService | undefined;
-export const reportsService = () =>
-  (reports ??= new ReportsService({ prisma: db.prisma(), pgPool: db.pgPool(), clickhouse }));
+export const reportsService = once(() => new ReportsService({ prisma: db.prisma(), pgPool: db.pgPool(), clickhouse }));

--- a/webapps/console/lib/server/route-services.ts
+++ b/webapps/console/lib/server/route-services.ts
@@ -1,0 +1,19 @@
+import { db } from "./db";
+import { clickhouse } from "./clickhouse";
+import { SyncService } from "./sync-service";
+import { DebugService } from "./debug-service";
+import { ReportsService } from "./reports-service";
+
+// Lazy per-process instances of the shared service classes, bound to the
+// db/clickhouse singletons — for HTTP route handlers. The MCP server wires
+// its own instances through McpServerDeps.
+
+let sync: SyncService | undefined;
+export const syncService = () => (sync ??= new SyncService({ prisma: db.prisma(), pgPool: db.pgPool(), clickhouse }));
+
+let debug: DebugService | undefined;
+export const debugService = () => (debug ??= new DebugService({ prisma: db.prisma() }));
+
+let reports: ReportsService | undefined;
+export const reportsService = () =>
+  (reports ??= new ReportsService({ prisma: db.prisma(), pgPool: db.pgPool(), clickhouse }));

--- a/webapps/console/lib/server/sync-service.ts
+++ b/webapps/console/lib/server/sync-service.ts
@@ -7,6 +7,7 @@ import utc from "dayjs/plugin/utc";
 import { hash as juavaHash, requireDefined, rpc } from "juava";
 import stableHash from "stable-hash";
 import { SessionUser } from "../schema";
+import { source_taskDbModel } from "../../prisma/schema";
 import { verifyAccess } from "../api";
 import { ApiError } from "../shared/errors";
 import { containsMaskedSecrets, unmaskSecretsFromOriginal } from "../schema/secrets";
@@ -29,6 +30,19 @@ const LOGS_DEFAULT_LIMIT = 200;
 const LOGS_MAX_LIMIT = 5000;
 
 export type SyncOpResult = { ok: boolean; error?: string; pending?: boolean; [key: string]: any };
+
+// Shape of the per-sync "latest task" returned by latestSyncTasks and exposed by
+// POST /sources/tasks. Derived from the canonical task model and used to shape the
+// query result here AND as the route's response schema, so the two can't drift.
+export const latestSyncTaskSchema = source_taskDbModel.pick({
+  sync_id: true,
+  task_id: true,
+  status: true,
+  description: true,
+  error: true,
+  started_at: true,
+  updated_at: true,
+});
 
 /**
  * Source-sync lifecycle operations (run/cancel/tasks/logs), connector introspection
@@ -194,13 +208,15 @@ export class SyncService {
       where: { id: { in: syncIds }, workspaceId, deleted: false, type: "sync" },
     });
     try {
+      // select * and let latestSyncTaskSchema trim to the exposed fields — keeps the
+      // column list out of this string so it can't drift from the schema.
       const rows = await this.pgPool.query(
-        `select DISTINCT ON (sync_id) sync_id, task_id, status, error, description, started_at, updated_at
+        `select DISTINCT ON (sync_id) *
          from newjitsu.source_task where sync_id = ANY($1::text[]) and status != 'SKIPPED'
          order by sync_id, started_at desc`,
         [syncs.map(s => s.id)]
       );
-      return { ok: true, tasks: Object.fromEntries(rows.rows.map(r => [r.sync_id, r])) };
+      return { ok: true, tasks: Object.fromEntries(rows.rows.map(r => [r.sync_id, latestSyncTaskSchema.parse(r)])) };
     } catch (e: any) {
       return syncError(log, `Error loading tasks`, e, false, `sync ids: ${syncIds} workspace: ${workspaceId}`);
     }

--- a/webapps/console/lib/server/sync-service.ts
+++ b/webapps/console/lib/server/sync-service.ts
@@ -85,7 +85,7 @@ export class SyncService {
     return { service, storageKey: `${workspaceId}_${service.id}_${h}` };
   }
 
-  /** Mirrors `sources/run.ts` (manual trigger). Delegates to the shared `scheduleSync`. */
+  /** Backs `sources/run.ts` (manual trigger). Delegates to the shared `scheduleSync`. */
   async runSync(
     user: SessionUser,
     workspaceId: string,
@@ -111,7 +111,7 @@ export class SyncService {
     return this.getSync(workspaceId, syncId);
   }
 
-  /** Mirrors `sources/cancel.ts`. Cancellation is async — poll `listSyncTasks` for CANCELLED. */
+  /** Backs `sources/cancel.ts`. Cancellation is async — poll `listSyncTasks` for CANCELLED. */
   async cancelSync(
     user: SessionUser,
     workspaceId: string,
@@ -146,7 +146,7 @@ export class SyncService {
     }
   }
 
-  /** Mirrors `sources/tasks.ts` GET (without the per-task logs URL — use `getSyncLogs`). */
+  /** Backs `sources/tasks.ts` GET (without the per-task logs URL — use `getSyncLogs`). */
   async listSyncTasks(
     user: SessionUser,
     workspaceId: string,
@@ -187,7 +187,7 @@ export class SyncService {
     }
   }
 
-  /** Mirrors `sources/tasks.ts` POST — the latest non-skipped task per sync, keyed by sync id. */
+  /** Backs `sources/tasks.ts` POST — the latest non-skipped task per sync, keyed by sync id. */
   async latestSyncTasks(user: SessionUser, workspaceId: string, syncIds: string[]): Promise<SyncOpResult> {
     await verifyAccess(user, workspaceId);
     const syncs = await this.prisma.configurationObjectLink.findMany({
@@ -255,7 +255,7 @@ export class SyncService {
     return { ok: true, logs };
   }
 
-  /** Mirrors `sources/spec.ts`. Async: poll until `ok: true` and `specs` is set. */
+  /** Backs `sources/spec.ts`. Async: poll until `ok: true` and `specs` is set. */
   async getConnectorSpec(
     user: SessionUser,
     workspaceId: string,
@@ -304,7 +304,7 @@ export class SyncService {
     }
   }
 
-  /** Mirrors `sources/discover.ts`. Async: poll until `ok: true` and `catalog` is set. */
+  /** Backs `sources/discover.ts`. Async: poll until `ok: true` and `catalog` is set. */
   async discoverStreams(
     user: SessionUser,
     workspaceId: string,
@@ -421,7 +421,7 @@ export class SyncService {
     }
   }
 
-  /** Mirrors `sources/check.ts` GET: SUCCESS → ok, row with error → error, no row yet → pending. */
+  /** Backs `sources/check.ts` GET: SUCCESS → ok, row with error → error, no row yet → pending. */
   async getSourceCheckResult(user: SessionUser, workspaceId: string, storageKey: string): Promise<SyncOpResult> {
     await verifyAccess(user, workspaceId);
     // Exact-segment prefix: a bare startsWith(workspaceId) would let workspace "ws1"
@@ -442,7 +442,7 @@ export class SyncService {
     }
   }
 
-  /** Mirrors `sources/state.ts` GET — saved cursor per stream. */
+  /** Backs `sources/state.ts` GET — saved cursor per stream. */
   async getSyncState(user: SessionUser, workspaceId: string, syncId: string): Promise<SyncOpResult> {
     await verifyAccess(user, workspaceId);
     const sync = await this.getSync(workspaceId, syncId);

--- a/webapps/console/lib/server/sync-service.ts
+++ b/webapps/console/lib/server/sync-service.ts
@@ -9,6 +9,7 @@ import stableHash from "stable-hash";
 import { SessionUser } from "../schema";
 import { verifyAccess } from "../api";
 import { ApiError } from "../shared/errors";
+import { containsMaskedSecrets, unmaskSecretsFromOriginal } from "../schema/secrets";
 import { scheduleSync, ScheduleSyncResult, syncError } from "./sync";
 import { getServerEnv } from "./serverEnv";
 import { getServerLog } from "./log";
@@ -88,7 +89,7 @@ export class SyncService {
   async runSync(
     user: SessionUser,
     workspaceId: string,
-    opts: { syncId: string; fullSync?: boolean; ignoreRunning?: boolean },
+    opts: { syncId: string; fullSync?: boolean; ignoreRunning?: boolean; taskId?: string },
     req: NextApiRequest
   ): Promise<ScheduleSyncResult> {
     await verifyAccess(user, workspaceId);
@@ -100,7 +101,14 @@ export class SyncService {
       syncIdOrModel: opts.syncId,
       fullSync: !!opts.fullSync,
       ignoreRunning: !!opts.ignoreRunning,
+      taskId: opts.taskId,
     });
+  }
+
+  /** Workspace-scoped sync lookup for routes that keep their own transport (e.g. the gzip log streamer). */
+  async findSync(user: SessionUser, workspaceId: string, syncId: string) {
+    await verifyAccess(user, workspaceId);
+    return this.getSync(workspaceId, syncId);
   }
 
   /** Mirrors `sources/cancel.ts`. Cancellation is async — poll `listSyncTasks` for CANCELLED. */
@@ -176,6 +184,25 @@ export class SyncService {
       return { ok: true, tasks };
     } catch (e: any) {
       return syncError(log, `Error loading tasks`, e, false, `sync: ${opts.syncId} workspace: ${workspaceId}`);
+    }
+  }
+
+  /** Mirrors `sources/tasks.ts` POST — the latest non-skipped task per sync, keyed by sync id. */
+  async latestSyncTasks(user: SessionUser, workspaceId: string, syncIds: string[]): Promise<SyncOpResult> {
+    await verifyAccess(user, workspaceId);
+    const syncs = await this.prisma.configurationObjectLink.findMany({
+      where: { id: { in: syncIds }, workspaceId, deleted: false, type: "sync" },
+    });
+    try {
+      const rows = await this.pgPool.query(
+        `select DISTINCT ON (sync_id) sync_id, task_id, status, error, description, started_at, updated_at
+         from newjitsu.source_task where sync_id = ANY($1::text[]) and status != 'SKIPPED'
+         order by sync_id, started_at desc`,
+        [syncs.map(s => s.id)]
+      );
+      return { ok: true, tasks: Object.fromEntries(rows.rows.map(r => [r.sync_id, r])) };
+    } catch (e: any) {
+      return syncError(log, `Error loading tasks`, e, false, `sync ids: ${syncIds} workspace: ${workspaceId}`);
     }
   }
 
@@ -341,27 +368,56 @@ export class SyncService {
   }
 
   /**
-   * Trigger the async credentials check for an existing service (mirrors `sources/check.ts`
-   * POST, but reads the stored — unmasked — config instead of taking one from the caller).
-   * Returns the `storageKey` to poll via `getSourceCheckResult`.
+   * Trigger the async credentials check (mirrors `sources/check.ts` POST). Two modes:
+   * `serviceId` reads the stored — unmasked — config; `config` checks a caller-supplied
+   * (possibly unsaved) config under a caller-generated `storageKey` — masked secrets are
+   * unmasked from the stored object referenced by `config.id`/`config.cloneId`. Returns the
+   * `storageKey` to poll via `getSourceCheckResult`.
    */
-  async triggerSourceCheck(user: SessionUser, workspaceId: string, serviceId: string): Promise<SyncOpResult> {
+  async triggerSourceCheck(
+    user: SessionUser,
+    workspaceId: string,
+    opts: { serviceId?: string; config?: any; storageKey?: string }
+  ): Promise<SyncOpResult> {
     await verifyAccess(user, workspaceId);
     const { url, authHeaders } = this.syncctl();
-    const { service, storageKey } = await this.getServiceWithStorageKey(workspaceId, serviceId);
+    let source: any;
+    let storageKey: string;
+    if (opts.config) {
+      storageKey = requireDefined(opts.storageKey, "`storageKey` is required when `config` is provided");
+      // Exact-segment prefix — see getSourceCheckResult.
+      if (!storageKey.startsWith(`${workspaceId}_`)) {
+        return { ok: false, error: "storageKey doesn't belong to the current workspace" };
+      }
+      source = opts.config;
+      const existingId = source.cloneId || source.id;
+      const existing = existingId
+        ? await this.prisma.configurationObject.findFirst({ where: { id: existingId } })
+        : null;
+      if (existing && existing.workspaceId !== workspaceId) {
+        return { ok: false, error: "invalid service id" };
+      }
+      if (existing && containsMaskedSecrets(source)) {
+        log.atInfo().log(`Unmasking secrets for service check: ${source.id}`);
+        source = unmaskSecretsFromOriginal(source, existing.config as any);
+      }
+    } else {
+      const serviceId = requireDefined(opts.serviceId, "either `config` or `serviceId` must be provided");
+      ({ service: source, storageKey } = await this.getServiceWithStorageKey(workspaceId, serviceId));
+    }
     try {
       const checkRes = await rpc(url + "/check", {
         method: "POST",
-        body: { source: service },
+        body: { source },
         headers: { "Content-Type": "application/json", ...authHeaders },
-        query: { package: service.package, version: service.version, storageKey },
+        query: { package: source.package, version: source.version, storageKey },
       });
       if (!checkRes.ok) {
         return { ok: false, error: checkRes.error ?? "unknown error" };
       }
       return { ok: false, pending: true, storageKey };
     } catch (e: any) {
-      return syncError(log, `Error running connection check`, e, false, `source: ${serviceId}`);
+      return syncError(log, `Error running connection check`, e, false, `source: ${storageKey}`);
     }
   }
 
@@ -427,6 +483,36 @@ export class SyncService {
       } else {
         await this.pgPool.query(`delete from newjitsu.source_state where sync_id = $1`, [opts.syncId]);
       }
+      return { ok: true, state: await this.loadState(opts.syncId) };
+    } catch (e: any) {
+      return { ok: false, error: e.message };
+    }
+  }
+
+  /**
+   * Overwrite the saved cursor of a single stream (mirrors `sources/state.ts` POST with a
+   * non-empty body). Fails while the sync is running, same as `resetSyncState`.
+   */
+  async setSyncState(
+    user: SessionUser,
+    workspaceId: string,
+    opts: { syncId: string; stream: string; state: any }
+  ): Promise<SyncOpResult> {
+    await verifyAccess(user, workspaceId);
+    const sync = await this.getSync(workspaceId, opts.syncId);
+    if (!sync) {
+      return { ok: false, error: "sync not found" };
+    }
+    const running = await this.prisma.source_task.findFirst({ where: { sync_id: opts.syncId, status: "RUNNING" } });
+    if (running) {
+      return { ok: false, error: "Sync is running. Please make sure that sync is stopped before editing state." };
+    }
+    try {
+      await this.pgPool.query(
+        `insert into newjitsu.source_state(sync_id, state, timestamp, stream) values($2, $1, now(), $3)
+         on conflict (sync_id, stream) do update set state = $1, timestamp = now()`,
+        [JSON.stringify(opts.state), opts.syncId, opts.stream]
+      );
       return { ok: true, state: await this.loadState(opts.syncId) };
     } catch (e: any) {
       return { ok: false, error: e.message };

--- a/webapps/console/pages/api/[workspaceId]/config/[type]/test.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/[type]/test.ts
@@ -1,15 +1,6 @@
-import { createRoute, verifyAccess } from "../../../../../lib/api";
+import { createRoute } from "../../../../../lib/api";
 import { z } from "zod";
-import { getServerLog } from "../../../../../lib/server/log";
-import { ApiError } from "../../../../../lib/shared/errors";
-import { getConfigObjectType, parseObject } from "../../../../../lib/schema/config-objects";
-import { httpAgent, httpsAgent } from "../../../../../lib/server/http-agent";
-import { getErrorMessage, requireDefined } from "juava";
-import { db } from "../../../../../lib/server/db";
-import { unmaskSecretsFromOriginal, containsMaskedSecrets } from "../../../../../lib/schema/secrets";
-import { getServerEnv } from "../../../../../lib/server/serverEnv";
-
-const log = getServerLog("test-connection");
+import { debugService } from "../../../../../lib/server/route-services";
 
 export const config = {
   api: {
@@ -29,52 +20,7 @@ export const route = createRoute()
     tags: ["config"],
   })
   .handler(async ({ user, body, query }) => {
-    log.atDebug().log("POST", JSON.stringify({ body, query }, null, 2));
-    const serverEnv = getServerEnv();
-    const bulkerURLEnv = requireDefined(serverEnv.BULKER_URL, "env BULKER_URL is not defined");
-    const bulkerAuthKey = serverEnv.BULKER_AUTH_KEY ?? "";
-    const isHttps = bulkerURLEnv.startsWith("https://");
-    const { workspaceId, type } = query;
-    await verifyAccess(user, workspaceId);
-    const workspace = requireDefined(
-      await db.prisma().workspace.findFirst({ where: { id: workspaceId } }),
-      `Workspace ${workspaceId} not found`
-    );
-    const configObjectTypes = getConfigObjectType(type);
-    let object = parseObject(type, body);
-    if (containsMaskedSecrets(object)) {
-      const existingEntity = await db.prisma().configurationObject.findFirst({
-        where: { id: body.cloneId || body.id, workspaceId },
-      });
-      if (existingEntity?.config) {
-        log.atInfo().log(`Unmasking secrets for ${type} test: ${body.id}`);
-        const dbConfig = existingEntity.config as any;
-        object = unmaskSecretsFromOriginal(object, dbConfig);
-      }
-    }
-    object = await configObjectTypes.inputFilter(object, "create", workspace);
-
-    const payload = JSON.stringify(object);
-    log.atDebug().log("payload", payload);
-    const options = {
-      method: "POST",
-      agent: (isHttps ? httpsAgent : httpAgent)(),
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: payload,
-    };
-    if (bulkerAuthKey) {
-      options.headers["Authorization"] = `Bearer ${bulkerAuthKey}`;
-    }
-    try {
-      const response = await fetch(bulkerURLEnv + "/test", options);
-      const json = await response.json();
-      log.atInfo().log(`StatusCode: ${response.status} Response Body: ${JSON.stringify(json)}`);
-      return json;
-    } catch (e) {
-      throw new ApiError(`failed to fetch bulker API: ${getErrorMessage(e)}`, { status: 500 });
-    }
+    return debugService().testConnection(user, query.workspaceId, query.type, { config: body });
   });
 
 export default route.toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/function/run.ts
+++ b/webapps/console/pages/api/[workspaceId]/function/run.ts
@@ -1,11 +1,6 @@
-import { getServerLog } from "../../../../lib/server/log";
 import { z } from "zod";
-import { Api, inferUrl, nextJsApiHandler, verifyAccessWithRole } from "../../../../lib/api";
-import { requireDefined, rpc } from "juava";
-import { getServerEnv } from "../../../../lib/server/serverEnv";
-import { db } from "../../../../lib/server/db";
-
-const log = getServerLog("function-run");
+import { Api, inferUrl, nextJsApiHandler } from "../../../../lib/api";
+import { debugService } from "../../../../lib/server/route-services";
 
 export const config = {
   api: {
@@ -29,36 +24,6 @@ const resultType = z.object({
 
 export type FunctionRunType = z.infer<typeof resultType>;
 
-// Class priority order: premium > dedicated > free
-const classPriority = ["premium", "dedicated", "free"];
-
-async function getDeploymentId(workspaceId: string): Promise<string | undefined> {
-  const records = await db.prisma().functionsServer.findMany({
-    where: { workspaceId },
-    select: { class: true, deploymentId: true },
-  });
-  if (records.length === 0) {
-    return undefined;
-  }
-  // Select highest priority class
-  for (const cls of classPriority) {
-    const record = records.find(r => r.class === cls);
-    if (record?.deploymentId) {
-      return record.deploymentId;
-    }
-  }
-  return undefined;
-}
-
-function getUdfRunUrl(deploymentId: string, serverEnv: ReturnType<typeof getServerEnv>): string {
-  const template = requireDefined(
-    serverEnv.FUNCTIONS_SERVER_URL_TEMPLATE,
-    "env FUNCTIONS_SERVER_URL_TEMPLATE is not set. Functions server is required to run functions"
-  );
-  const baseUrl = template.replace("${workspaceId}", deploymentId);
-  return baseUrl + "/udfrun";
-}
-
 export const api: Api = {
   url: inferUrl(__filename),
   POST: {
@@ -79,47 +44,15 @@ export const api: Api = {
       result: resultType,
     },
     handle: async ({ user, query, body }) => {
-      const { workspaceId } = query;
-      await verifyAccessWithRole(user, workspaceId, "editEntities");
-      const serverEnv = getServerEnv();
-
-      const deploymentId = await getDeploymentId(workspaceId);
-      if (!deploymentId) {
-        return resultType.parse({
-          error: {
-            name: "FunctionRuntimeNotReady",
-            message:
-              "Function runtime for this workspace is being initialized. Please try again in a few minutes. If this message persists, please contact support.",
-          },
-          store: {},
-          logs: [],
-        });
-      }
-      const url = getUdfRunUrl(deploymentId, serverEnv);
-
-      log
-        .atInfo()
-        .log(
-          `Running function ${body.functionId} for workspace ${workspaceId} via ${url} (deployment: ${deploymentId})`
-        );
-
-      const rotorAuthKey = serverEnv.ROTOR_AUTH_KEY;
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      if (rotorAuthKey) {
-        headers["Authorization"] = `Bearer ${rotorAuthKey}`;
-      }
-
-      const res = await rpc(url, {
-        method: "POST",
-        body: {
-          ...body,
-          workspaceId,
-        },
-        headers,
+      return debugService().runFunction(user, query.workspaceId, {
+        functionId: body.functionId,
+        functionName: body.functionName,
+        code: body.code,
+        event: body.event,
+        variables: body.variables,
+        store: body.store,
+        userAgent: body.userAgent,
       });
-      return resultType.parse(res);
     },
   },
 };

--- a/webapps/console/pages/api/[workspaceId]/profile-builder/run.ts
+++ b/webapps/console/pages/api/[workspaceId]/profile-builder/run.ts
@@ -1,11 +1,6 @@
-import { getServerLog } from "../../../../lib/server/log";
 import { z } from "zod";
-import { Api, inferUrl, nextJsApiHandler, verifyAccessWithRole } from "../../../../lib/api";
-import { requireDefined, rpc } from "juava";
-import { getServerEnv } from "../../../../lib/server/serverEnv";
-import { db } from "../../../../lib/server/db";
-
-const log = getServerLog("profile-builder-run");
+import { Api, inferUrl, nextJsApiHandler } from "../../../../lib/api";
+import { debugService } from "../../../../lib/server/route-services";
 
 export const config = {
   api: {
@@ -29,40 +24,6 @@ const resultType = z.object({
 
 export type FunctionRunType = z.infer<typeof resultType>;
 
-// Class priority order: premium > dedicated > free
-const classPriority = ["premium", "dedicated", "free"];
-
-async function getProfileBuilderDeploymentId(workspaceId: string): Promise<string | undefined> {
-  const records = await db.prisma().functionsServer.findMany({
-    where: { workspaceId },
-    select: { class: true, deploymentId: true, profileBuilders: true },
-  });
-  if (records.length === 0) {
-    return undefined;
-  }
-  // Select highest priority class that has profile builders assigned
-  for (const cls of classPriority) {
-    const record = records.find(r => r.class === cls);
-    if (record?.deploymentId) {
-      return record.deploymentId;
-    }
-  }
-  return undefined;
-}
-
-function getProfileUdfRunUrl(deploymentId: string, serverEnv: ReturnType<typeof getServerEnv>): string {
-  const template = serverEnv.FUNCTIONS_SERVER_URL_TEMPLATE;
-  if (!template) {
-    const rotorURL = requireDefined(
-      serverEnv.ROTOR_URL,
-      `env ROTOR_URL is not set. Rotor is required to run functions`
-    );
-    return rotorURL + "/profileudfrun";
-  }
-  const baseUrl = template.replace("${workspaceId}", deploymentId);
-  return baseUrl + "/profileudfrun";
-}
-
 export const api: Api = {
   url: inferUrl(__filename),
   POST: {
@@ -84,47 +45,15 @@ export const api: Api = {
       result: resultType,
     },
     handle: async ({ user, query, body }) => {
-      const { workspaceId } = query;
-      await verifyAccessWithRole(user, workspaceId, "editEntities");
-      const serverEnv = getServerEnv();
-
-      const deploymentId = await getProfileBuilderDeploymentId(workspaceId);
-      if (!deploymentId) {
-        return resultType.parse({
-          error: {
-            name: "FunctionRuntimeNotReady",
-            message:
-              "Profile builder runtime for this workspace is being initialized. Please try again in a few minutes. If this message persists, please contact support.",
-          },
-          store: {},
-          logs: [],
-        });
-      }
-      const url = getProfileUdfRunUrl(deploymentId, serverEnv);
-
-      log
-        .atInfo()
-        .log(
-          `Running profile builder ${body.id} for workspace ${workspaceId} via ${url} (deployment: ${deploymentId})`
-        );
-
-      const rotorAuthKey = serverEnv.ROTOR_AUTH_KEY;
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      if (rotorAuthKey) {
-        headers["Authorization"] = `Bearer ${rotorAuthKey}`;
-      }
-
-      const res = await rpc(url, {
-        method: "POST",
-        body: {
-          ...body,
-          workspaceId,
-        },
-        headers,
+      return debugService().runProfileBuilder(user, query.workspaceId, {
+        profileBuilderId: body.id,
+        events: body.events,
+        code: body.code,
+        settings: body.settings,
+        version: body.version,
+        store: body.store,
+        userAgent: body.userAgent,
       });
-      return resultType.parse(res);
     },
   },
 };

--- a/webapps/console/pages/api/[workspaceId]/reports/event-stat.ts
+++ b/webapps/console/pages/api/[workspaceId]/reports/event-stat.ts
@@ -1,21 +1,7 @@
 import { z } from "zod";
-import { createRoute, verifyAccess, getWorkspace } from "../../../../lib/api";
-import { clickhouse } from "../../../../lib/server/clickhouse";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import { getServerLog } from "../../../../lib/server/log";
+import { createRoute, getWorkspace } from "../../../../lib/api";
 import { Report } from "../../../../lib/shared/reporting";
-import { getServerEnv } from "../../../../lib/server/serverEnv";
-
-dayjs.extend(utc);
-
-const log = getServerLog("report-query");
-const serverEnv = getServerEnv();
-
-function toISOString(period: string) {
-  const [date, time] = period.split(" ");
-  return `${date}T${time}Z`;
-}
+import { reportsService } from "../../../../lib/server/route-services";
 
 export default createRoute()
   .GET({
@@ -26,59 +12,15 @@ export default createRoute()
       end: z.any().optional(),
       granularity: z.enum(["day", "hour"]).optional().default("day"),
     }),
-    //result: z.any()
     result: Report.and(z.object({ queryMeta: z.any() })),
   })
   .handler(async ({ user, query }) => {
-    const { workspaceId } = query;
-    const workspace = await getWorkspace(workspaceId);
-    await verifyAccess(user, workspace.id);
-    const start = query.start
-      ? new Date(query.start).toISOString()
-      : dayjs().subtract(1, "month").toDate().toISOString();
-    const end = query.end ? new Date(query.end).toISOString() : new Date().toISOString();
-    const sql = `
-        select
-            date_trunc({granularity:String}, timestamp) as period,
-            connectionId,
-            streamId,
-            destinationId,
-            status,
-            sumMerge(events) as events,
-            count(*) as "srcSize"
-        from mv_metrics
-        where 
-            timestamp >= toDateTime({start:String}, 'UTC') and
-            timestamp < toDateTime({end:String}, 'UTC') and 
-            workspaceId = {workspace:String}
-        group by period, connectionId, status, streamId, destinationId
-        order by period desc, events desc;
-    `;
-
-    const chResult = (await (
-      await clickhouse.query({
-        query: sql,
-        query_params: {
-          start: isoDateTOClickhouse(start),
-          end: isoDateTOClickhouse(end),
-          workspace: workspace.id,
-          granularity: query.granularity,
-        },
-        clickhouse_settings: {
-          wait_end_of_query: 1,
-        },
-      })
-    ).json()) as any;
-    return {
-      rows: chResult.data.map(({ period, ...rest }) => ({
-        ...rest,
-        period: toISOString(period),
-        workspaceId: workspace.id,
-      })),
-    };
+    // getWorkspace resolves slugs too — the UI calls this route by workspace slug.
+    const workspace = await getWorkspace(query.workspaceId);
+    return reportsService().eventStat(user, workspace.id, {
+      start: query.start,
+      end: query.end,
+      granularity: query.granularity,
+    });
   })
   .toNextApiHandler();
-
-function isoDateTOClickhouse(date: string): string {
-  return date.replace("T", " ").replace("Z", "").split(".")[0];
-}

--- a/webapps/console/pages/api/[workspaceId]/reports/sync-stat.ts
+++ b/webapps/console/pages/api/[workspaceId]/reports/sync-stat.ts
@@ -1,7 +1,6 @@
-import { createRoute, getWorkspace, verifyAccess } from "../../../../lib/api";
 import { z } from "zod";
-import dayjs from "dayjs";
-import { db } from "../../../../lib/server/db";
+import { createRoute, getWorkspace } from "../../../../lib/api";
+import { reportsService } from "../../../../lib/server/route-services";
 
 export default createRoute()
   .GET({
@@ -15,27 +14,8 @@ export default createRoute()
     result: z.any(),
   })
   .handler(async ({ user, query }) => {
-    const { workspaceId } = query;
-    const workspace = await getWorkspace(workspaceId);
-    await verifyAccess(user, workspace.id);
-    const end = query.end ? query.end.toISOString() : new Date().toISOString();
-    const start = query.start ? query.start.toISOString() : dayjs(end).subtract(1, "month").toDate().toISOString();
-
-    const res = await db.pgPool().query(
-      `select
-                count(distinct sync."fromId" || sync."toId") as "activeSyncs"
-            from newjitsu.source_task task
-                 join newjitsu."ConfigurationObjectLink" sync on task.sync_id = sync."id"
-            where (task.status = 'SUCCESS' OR task.status = 'PARTIAL')
-              and "workspaceId" = $1
-              and started_at >= $2 and started_at < $3`,
-      [workspaceId, start, end]
-    );
-
-    return {
-      activeSyncs: res.rows[0].activeSyncs,
-      start,
-      end,
-    };
+    // getWorkspace resolves slugs too — the UI calls this route by workspace slug.
+    const workspace = await getWorkspace(query.workspaceId);
+    return reportsService().syncStat(user, workspace.id, { start: query.start, end: query.end });
   })
   .toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/sources/cancel.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/cancel.ts
@@ -1,13 +1,6 @@
 import { z } from "zod";
-import { createRoute, verifyAccess } from "../../../../lib/api";
-import { requireDefined, rpc } from "juava";
-import { getServerLog } from "../../../../lib/server/log";
-import { syncError } from "../../../../lib/server/sync";
-import { db } from "../../../../lib/server/db";
-import { getServerEnv } from "../../../../lib/server/serverEnv";
-
-const log = getServerLog("sync-spec");
-const serverEnv = getServerEnv();
+import { createRoute } from "../../../../lib/api";
+import { syncService } from "../../../../lib/server/route-services";
 
 export default createRoute()
   .GET({
@@ -19,52 +12,13 @@ export default createRoute()
       workspaceId: z.string(),
       syncId: z.string(),
       taskId: z.string(),
-      package: z.string(),
+      // Unused: the service resolves the package from the sync itself. Kept so
+      // existing callers that still send it don't fail query validation.
+      package: z.string().optional(),
     }),
     result: z.any(),
   })
   .handler(async ({ user, query }) => {
-    const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-    const syncURL = requireDefined(
-      serverEnv.SYNCCTL_URL,
-      `env SYNCCTL_URL is not set. Sync Controller is required to run sources`
-    );
-    const syncAuthKey = serverEnv.SYNCCTL_AUTH_KEY ?? "";
-    const authHeaders: any = {};
-    if (syncAuthKey) {
-      authHeaders["Authorization"] = `Bearer ${syncAuthKey}`;
-    }
-
-    const existingLink = await db
-      .prisma()
-      .configurationObjectLink.findFirst({ where: { workspaceId: workspaceId, id: query.syncId, deleted: false } });
-    if (!existingLink) {
-      return { ok: false, error: `sync with id ${query.syncId} not found in the workspace` };
-    }
-
-    try {
-      const res = await rpc(syncURL + "/cancel", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          ...authHeaders,
-        },
-        query,
-      });
-      if (!res.ok) {
-        return { ok: false, error: res.error ?? "unknown error" };
-      } else {
-        return { ok: false, pending: true, startedAt: res.startedAt };
-      }
-    } catch (e: any) {
-      return syncError(
-        log,
-        `Error cancelling sync job`,
-        e,
-        false,
-        `syncId: ${query.syncId} taskId: ${query.taskId} package: ${query.package}`
-      );
-    }
+    return syncService().cancelSync(user, query.workspaceId, { syncId: query.syncId, taskId: query.taskId });
   })
   .toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/sources/check.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/check.ts
@@ -1,15 +1,7 @@
-import { db } from "../../../../lib/server/db";
 import { z } from "zod";
-import { createRoute, verifyAccess } from "../../../../lib/api";
+import { createRoute } from "../../../../lib/api";
 import { ServiceConfig } from "../../../../lib/schema";
-import { requireDefined, rpc } from "juava";
-import { getServerLog } from "../../../../lib/server/log";
-import { syncError } from "../../../../lib/server/sync";
-import { unmaskSecretsFromOriginal, containsMaskedSecrets } from "../../../../lib/schema/secrets";
-import { getServerEnv } from "../../../../lib/server/serverEnv";
-
-const log = getServerLog("sync-check");
-const serverEnv = getServerEnv();
+import { syncService } from "../../../../lib/server/route-services";
 
 const resultType = z.object({
   ok: z.boolean(),
@@ -27,70 +19,11 @@ export default createRoute()
     body: ServiceConfig,
     result: resultType,
   })
-  .handler(async ({ user, query, body, req }) => {
-    const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-    const syncURL = requireDefined(
-      serverEnv.SYNCCTL_URL,
-      `env SYNCCTL_URL is not set. Sync Controller is required to run sources`
-    );
-    if (!query.storageKey.startsWith(workspaceId)) {
-      return { ok: false, error: "storageKey doesn't belong to the current workspace" };
-    }
-    const syncAuthKey = serverEnv.SYNCCTL_AUTH_KEY ?? "";
-    const authHeaders: any = {};
-    if (syncAuthKey) {
-      authHeaders["Authorization"] = `Bearer ${syncAuthKey}`;
-    }
-    const serviceConfig = body as ServiceConfig;
-    const existingService = await db.prisma().configurationObject.findFirst({
-      where: { id: serviceConfig.cloneId || serviceConfig.id },
+  .handler(async ({ user, query, body }) => {
+    return syncService().triggerSourceCheck(user, query.workspaceId, {
+      config: body,
+      storageKey: query.storageKey,
     });
-    if (existingService && existingService.workspaceId !== workspaceId) {
-      return { ok: false, error: "invalid service id" };
-    }
-
-    // Unmask secrets for testing if this is an existing service with masked values
-    let configForTesting = serviceConfig;
-    if (existingService && containsMaskedSecrets(serviceConfig)) {
-      log.atInfo().log(`Unmasking secrets for service test: ${serviceConfig.id}`);
-      const dbServiceConfig = existingService.config as ServiceConfig;
-      configForTesting = unmaskSecretsFromOriginal(serviceConfig, dbServiceConfig);
-    }
-
-    // Pass the ServiceConfig wrapper through to syncctl unchanged. The oauth-refresh
-    // init container inside the syncctl Pod handles Nango refresh — console no
-    // longer touches OAuth credentials.
-    try {
-      const checkRes = await rpc(syncURL + "/check", {
-        method: "POST",
-        body: {
-          source: configForTesting,
-        },
-        headers: {
-          "Content-Type": "application/json",
-          ...authHeaders,
-        },
-        query: {
-          package: body.package,
-          version: body.version,
-          storageKey: query.storageKey,
-        },
-      });
-      if (!checkRes.ok) {
-        return { ok: false, error: checkRes.error ?? "unknown error" };
-      } else {
-        return { ok: false, pending: true };
-      }
-    } catch (e: any) {
-      return syncError(
-        log,
-        `Error running connection check`,
-        e,
-        false,
-        `source: ${query.storageKey} workspace: ${workspaceId}`
-      );
-    }
   })
   .GET({
     auth: true,
@@ -100,43 +33,7 @@ export default createRoute()
     }),
     result: resultType,
   })
-  .handler(async ({ user, query, body }) => {
-    const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-    if (!query.storageKey.startsWith(workspaceId)) {
-      return { ok: false, error: "storageKey doesn't belong to the current workspace" };
-    }
-    try {
-      const res = await db
-        .pgPool()
-        .query(`select status, description from newjitsu.source_check where key = $1`, [query.storageKey]);
-      if (res.rowCount === 1) {
-        const status = res.rows[0].status;
-        const description = res.rows[0].description;
-        if (status === "SUCCESS") {
-          return {
-            ok: true,
-          };
-        } else {
-          return {
-            ok: false,
-            error: description,
-          };
-        }
-      } else {
-        return {
-          ok: false,
-          pending: true,
-        };
-      }
-    } catch (e: any) {
-      return syncError(
-        log,
-        `Error running connection check`,
-        e,
-        false,
-        `source: ${query.storageKey} workspace: ${workspaceId}`
-      );
-    }
+  .handler(async ({ user, query }) => {
+    return syncService().getSourceCheckResult(user, query.workspaceId, query.storageKey);
   })
   .toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/sources/discover.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/discover.ts
@@ -1,15 +1,8 @@
-import { db } from "../../../../lib/server/db";
 import { z } from "zod";
-import { createRoute, verifyAccess } from "../../../../lib/api";
-import { hash as juavaHash, isTruish, requireDefined, rpc } from "juava";
-import { getServerLog } from "../../../../lib/server/log";
-
-import { syncError } from "../../../../lib/server/sync";
-import hash from "stable-hash";
-import { getServerEnv } from "../../../../lib/server/serverEnv";
-
-const log = getServerLog("sync-discover");
-const serverEnv = getServerEnv();
+import { createRoute } from "../../../../lib/api";
+import { isTruish } from "juava";
+import { ApiError } from "../../../../lib/shared/errors";
+import { syncService } from "../../../../lib/server/route-services";
 
 const resultType = z.object({
   ok: z.boolean(),
@@ -17,15 +10,6 @@ const resultType = z.object({
   catalog: z.object({}).passthrough().optional(),
   error: z.string().optional(),
 });
-
-const queryType = z.object({
-  workspaceId: z.string(),
-  package: z.string(),
-  version: z.string(),
-  storageKey: z.string(),
-});
-
-type catalogKeyType = z.infer<typeof queryType>;
 
 export const route = createRoute()
   .GET({
@@ -48,105 +32,21 @@ export const route = createRoute()
     }),
     result: resultType,
   })
-  .handler(async ({ user, query, req }) => {
-    const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-
-    const syncURL = requireDefined(
-      serverEnv.SYNCCTL_URL,
-      `env SYNCCTL_URL is not set. Sync Controller is required to run sources`
-    );
-    const syncAuthKey = serverEnv.SYNCCTL_AUTH_KEY ?? "";
-    const authHeaders: any = {};
-    if (syncAuthKey) {
-      authHeaders["Authorization"] = `Bearer ${syncAuthKey}`;
-    }
-
+  .handler(async ({ user, query }) => {
     try {
-      let existingService = (await db.prisma().configurationObject.findFirst({
-        where: { id: query.serviceId },
-      })) as any;
-      if (!existingService || existingService.workspaceId !== workspaceId) {
-        return { ok: false, error: `Service Connector not found for id: ${query.serviceId}` };
-      }
-      existingService = { ...(existingService.config as any), ...existingService } as any;
-      const h = juavaHash("md5", hash(existingService.credentials));
-      const storageKey = `${workspaceId}_${existingService.id}_${h}`;
-
-      if (!isTruish(query.force)) {
-        const discoverDbRes = await catalogFromDb({
-          storageKey,
-          package: existingService.package,
-          version: existingService.version,
-        });
-        if (discoverDbRes) {
-          if (discoverDbRes.pending) {
-            return discoverDbRes;
-          } else if (!isTruish(query.refresh)) {
-            return discoverDbRes;
-          }
-        }
-      }
-      const discoverQueryRes = await rpc(syncURL + "/discover", {
-        method: "POST",
-        // Pass the source-config wrapper through unchanged. syncctl's
-        // oauth-refresh init container handles Nango refresh inside the Pod —
-        // console no longer touches OAuth credentials.
-        body: {
-          source: existingService,
-        },
-        headers: {
-          "Content-Type": "application/json",
-          ...authHeaders,
-        },
-        query: {
-          package: existingService.package,
-          version: existingService.version,
-          storageKey: storageKey,
-        },
+      return await syncService().discoverStreams(user, query.workspaceId, {
+        serviceId: query.serviceId,
+        refresh: isTruish(query.refresh),
+        force: isTruish(query.force),
       });
-      if (!discoverQueryRes.ok) {
-        return { ok: false, error: discoverQueryRes.error ?? "unknown error" };
-      } else {
-        await db.pgPool().query(
-          `INSERT INTO newjitsu.source_catalog (package, version, key, timestamp, status, description)
-                     VALUES ($1, $2, $3, $4, $5, $6)
-                     ON CONFLICT ON CONSTRAINT source_catalog_pkey DO UPDATE SET timestamp = $4,
-                                                                                 status=$5,
-                                                                                 description=$6`,
-          [existingService.package, existingService.version, storageKey, new Date(), "RUNNING", "RUNNING"]
-        );
-        return { ok: false, pending: true };
+    } catch (e) {
+      // The service 404s on an unknown service; this route has always answered
+      // 200 { ok: false, error } and the pollers expect that.
+      if (e instanceof ApiError) {
+        return { ok: false, error: e.message };
       }
-    } catch (e: any) {
-      return syncError(log, `Error running discover`, e, false, `source: ${query.serviceId} workspace: ${workspaceId}`);
+      throw e;
     }
   });
 
 export default route.toNextApiHandler();
-
-async function catalogFromDb(
-  query: Omit<catalogKeyType, "workspaceId">
-): Promise<{ ok: boolean; catalog?: any; error?: string; pending?: boolean } | undefined> {
-  const res = await db.pgPool().query(
-    `select catalog, status, description from newjitsu.source_catalog where key = $1
-               and package = $2
-               and version = $3`,
-    [query.storageKey, query.package, query.version]
-  );
-  if (res.rowCount === 1) {
-    const status = res.rows[0].status;
-    const catalog = res.rows[0].catalog;
-    const description = res.rows[0].description;
-    switch (status) {
-      case "SUCCESS":
-        return { ok: true, catalog: catalog };
-      case "RUNNING":
-        return { ok: false, pending: true };
-      default:
-        return { ok: false, error: description };
-    }
-  } else {
-    return undefined;
-  }
-}

--- a/webapps/console/pages/api/[workspaceId]/sources/logs.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/logs.ts
@@ -1,6 +1,7 @@
 import { db } from "../../../../lib/server/db";
 import { z } from "zod";
-import { createRoute, verifyAccess } from "../../../../lib/api";
+import { createRoute } from "../../../../lib/api";
+import { syncService } from "../../../../lib/server/route-services";
 import { randomId } from "juava";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -37,10 +38,9 @@ export const route = createRoute()
   })
   .handler(async ({ user, query, res }) => {
     const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-    const existingLink = await db
-      .prisma()
-      .configurationObjectLink.findFirst({ where: { workspaceId: workspaceId, id: query.syncId, deleted: false } });
+    // Workspace scoping lives in the service; the gzip streaming below is transport
+    // and stays in the route.
+    const existingLink = await syncService().findSync(user, workspaceId, query.syncId);
     if (!existingLink) {
       res.writeHead(404, {
         "Content-Type": "application/json",

--- a/webapps/console/pages/api/[workspaceId]/sources/run.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/run.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { createRoute, getUser, verifyAccess } from "../../../../lib/api";
+import { createRoute, getUser } from "../../../../lib/api";
 import { SessionUser } from "../../../../lib/schema";
 import { ApiError } from "../../../../lib/shared/errors";
 import { getServerLog } from "../../../../lib/server/log";
 
-import { scheduleSync } from "../../../../lib/server/sync";
+import { syncService } from "../../../../lib/server/route-services";
 import { isTruish } from "juava";
 import { getServerEnv } from "../../../../lib/server/serverEnv";
 
@@ -67,7 +67,6 @@ export const route = createRoute()
       if (!user) {
         throw new ApiError("Authorization Required", { status: 401 });
       }
-      await verifyAccess(user, workspaceId);
     }
     log
       .atInfo()
@@ -87,16 +86,17 @@ export const route = createRoute()
         );
       return { ok: true };
     }
-    const result = await scheduleSync({
-      req,
-      user,
-      trigger,
+    const result = await syncService().runSync(
+      user!,
       workspaceId,
-      fullSync: isTruish(query.fullSync),
-      syncIdOrModel: query.syncId as string,
-      ignoreRunning: !!query.ignoreRunning,
-      taskId: query.taskId,
-    });
+      {
+        syncId: query.syncId,
+        fullSync: isTruish(query.fullSync),
+        ignoreRunning: !!query.ignoreRunning,
+        taskId: query.taskId,
+      },
+      req
+    );
     if (!result.ok) {
       log
         .atWarn()

--- a/webapps/console/pages/api/[workspaceId]/sources/spec.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/spec.ts
@@ -1,13 +1,7 @@
-import { db } from "../../../../lib/server/db";
 import { z } from "zod";
-import { createRoute, verifyAccess } from "../../../../lib/api";
-import { isTruish, requireDefined, rpc } from "juava";
-import { getServerLog } from "../../../../lib/server/log";
-import { syncError } from "../../../../lib/server/sync";
-import { getServerEnv } from "../../../../lib/server/serverEnv";
-
-const log = getServerLog("sync-spec");
-const serverEnv = getServerEnv();
+import { createRoute } from "../../../../lib/api";
+import { isTruish } from "juava";
+import { syncService } from "../../../../lib/server/route-services";
 
 const resultType = z.object({
   ok: z.boolean(),
@@ -39,83 +33,11 @@ export const route = createRoute()
     result: resultType,
   })
   .handler(async ({ user, query }) => {
-    const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-    const syncURL = requireDefined(
-      serverEnv.SYNCCTL_URL,
-      `env SYNCCTL_URL is not set. Sync Controller is required to run sources`
-    );
-    const syncAuthKey = serverEnv.SYNCCTL_AUTH_KEY ?? "";
-    const authHeaders: any = {};
-    if (syncAuthKey) {
-      authHeaders["Authorization"] = `Bearer ${syncAuthKey}`;
-    }
-    try {
-      const res = await db.pgPool().query(
-        `select specs, error
-                        from newjitsu.source_spec
-                        where package = $1
-                          and version = $2`,
-        [query.package, query.version]
-      );
-      let error;
-      // force=true must re-fetch from the controller even when a cached spec
-      // row exists — otherwise a tag rebuilt in place keeps serving stale specs.
-      if (res.rowCount === 1 && !isTruish(query.force)) {
-        const specs = res.rows[0].specs;
-        if (specs) {
-          return {
-            ok: true,
-            specs,
-          };
-        } else {
-          error = res.rows[0].error ?? "unknown error";
-          if (error === "pending") {
-            return { ok: false, pending: true };
-          }
-        }
-      }
-      if (!res.rowCount || isTruish(query.force)) {
-        const checkRes = await rpc(syncURL + "/spec", {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            ...authHeaders,
-          },
-          query: {
-            package: query.package,
-            version: query.version,
-          },
-        });
-        if (!checkRes.ok) {
-          return { ok: false, error: checkRes.error ?? "unknown error" };
-        } else {
-          await db.pgPool().query(
-            `insert into newjitsu.source_spec as s (package, version, specs, timestamp, error)
-                     values ($1, $2, null, $3, $4)
-                     ON CONFLICT ON CONSTRAINT source_spec_pkey DO UPDATE SET specs = null,
-                                                                              timestamp = $3,
-                                                                              error = $4`,
-            [query.package, query.version, new Date(), "pending"]
-          );
-          return { ok: false, pending: true };
-        }
-      } else {
-        if (error) {
-          return { ok: false, error };
-        } else {
-          return { ok: false, pending: true };
-        }
-      }
-    } catch (e: any) {
-      return syncError(
-        log,
-        `Error loading specs`,
-        e,
-        false,
-        `source: ${query.package}:${query.version} workspace: ${workspaceId}`
-      );
-    }
+    return syncService().getConnectorSpec(user, query.workspaceId, {
+      package: query.package,
+      version: query.version,
+      force: isTruish(query.force),
+    });
   });
 
 export default route.toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/sources/state.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/state.ts
@@ -1,10 +1,6 @@
-import { db } from "../../../../lib/server/db";
 import { z } from "zod";
-import { createRoute, verifyAccess } from "../../../../lib/api";
-import { getServerLog } from "../../../../lib/server/log";
-import { syncError } from "../../../../lib/server/sync";
-
-const log = getServerLog("sync-spec");
+import { createRoute } from "../../../../lib/api";
+import { syncService } from "../../../../lib/server/route-services";
 
 const resultType = z.object({
   ok: z.boolean(),
@@ -22,36 +18,7 @@ export default createRoute()
     result: resultType,
   })
   .handler(async ({ user, query }) => {
-    const { workspaceId, syncId } = query;
-    await verifyAccess(user, workspaceId);
-    try {
-      const sync = await db.prisma().configurationObjectLink.findFirst({
-        where: {
-          workspaceId,
-          type: "sync",
-          id: syncId,
-          deleted: false,
-        },
-      });
-      if (!sync) {
-        return { ok: false, error: "sync not found" };
-      }
-
-      const res = await db.pgPool().query(
-        `select stream, state
-                        from newjitsu.source_state
-                        where sync_id = $1`,
-        [syncId]
-      );
-      const rows = res.rows;
-      if (rows.length === 0) {
-        return { ok: true, state: {} };
-      }
-      const state = Object.fromEntries(rows.map((a, b) => [a.stream, JSON.stringify(a.state, null, 2)]));
-      return { ok: true, state };
-    } catch (e: any) {
-      return syncError(log, `Error loading state`, e, false, `source: ${syncId} workspace: ${workspaceId}`);
-    }
+    return syncService().getSyncState(user, query.workspaceId, query.syncId);
   })
   .POST({
     auth: true,
@@ -65,58 +32,9 @@ export default createRoute()
   })
   .handler(async ({ user, query, body }) => {
     const { workspaceId, syncId, stream } = query;
-    await verifyAccess(user, workspaceId);
-    try {
-      const sync = await db.prisma().configurationObjectLink.findFirst({
-        where: {
-          workspaceId,
-          type: "sync",
-          id: syncId,
-          deleted: false,
-        },
-      });
-      if (!sync) {
-        return { ok: false, error: "sync not found" };
-      }
-      const running = await db.prisma().source_task.findFirst({
-        where: {
-          sync_id: syncId,
-          status: "RUNNING",
-        },
-      });
-      if (running) {
-        return { ok: false, error: "Sync is running. Please make sure that sync is stopped before editing state." };
-      }
-
-      if (!body || Object.keys(body).length === 0) {
-        await db.pgPool().query(
-          `delete from newjitsu.source_state
-                        where sync_id = $1 and stream = $2`,
-          [syncId, stream]
-        );
-      } else {
-        await db.pgPool().query(
-          `insert into newjitsu.source_state(sync_id, state, timestamp, stream) values($2, $1, now(), $3)
-                        on conflict (sync_id, stream) do update
-           set state = $1, timestamp = now()`,
-          [JSON.stringify(body), syncId, stream]
-        );
-      }
-
-      const res = await db.pgPool().query(
-        `select stream, state
-                        from newjitsu.source_state
-                        where sync_id = $1`,
-        [syncId]
-      );
-      const rows = res.rows;
-      if (rows.length === 0) {
-        return { ok: true, state: {} };
-      }
-      const state = Object.fromEntries(rows.map((a, b) => [a.stream, JSON.stringify(a.state, null, 2)]));
-      return { ok: true, state };
-    } catch (e: any) {
-      return { ok: false, error: e.message };
+    if (!body || Object.keys(body).length === 0) {
+      return syncService().resetSyncState(user, workspaceId, { syncId, stream });
     }
+    return syncService().setSyncState(user, workspaceId, { syncId, stream, state: body });
   })
   .toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/sources/tasks.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/tasks.ts
@@ -1,15 +1,8 @@
-import { db } from "../../../../lib/server/db";
 import { z } from "zod";
-import { createRoute, verifyAccess } from "../../../../lib/api";
+import { createRoute } from "../../../../lib/api";
 import { source_taskDbModel } from "../../../../prisma/schema";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
-import { getServerLog } from "../../../../lib/server/log";
 import { getAppEndpoint } from "../../../../lib/domains";
-import { syncError } from "../../../../lib/server/sync";
-
-const log = getServerLog("sync-tasks");
+import { syncService } from "../../../../lib/server/route-services";
 
 const aggregatedResultType = z.object({
   ok: z.boolean(),
@@ -30,9 +23,6 @@ const aggregatedResultType = z.object({
     )
     .optional(),
 });
-
-type aggregatedResultType = z.infer<typeof aggregatedResultType>;
-type source_task = z.infer<typeof source_taskDbModel>;
 
 //fix the type of started_by and metrics from weird prism type to any
 const adjustedSourceTaskDBModel = source_taskDbModel
@@ -65,46 +55,7 @@ export const route = createRoute()
     result: aggregatedResultType,
   })
   .handler(async ({ user, query, body }) => {
-    const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-    const syncs = await db.prisma().configurationObjectLink.findMany({
-      where: {
-        id: {
-          in: body,
-        },
-        workspaceId: workspaceId,
-        deleted: false,
-        type: "sync",
-      },
-    });
-    const syncsId = syncs.map(s => s.id);
-    try {
-      //get latest source_tasks from db for provided sync ids grouped by sync id
-      const rows = await db.pgPool().query(
-        `select DISTINCT ON (sync_id) sync_id, task_id, status, error, description, started_at, updated_at
-         from newjitsu.source_task where sync_id = ANY($1::text[]) and status != 'SKIPPED'
-         order by sync_id, started_at desc`,
-        [syncsId]
-      );
-      const tasksRecord = rows.rows.reduce((acc, r) => {
-        acc[r.sync_id] = {
-          sync_id: r.sync_id,
-          task_id: r.task_id,
-          status: r.status,
-          description: r.description,
-          error: r.error,
-          started_at: r.started_at,
-          updated_at: r.updated_at,
-        };
-        return acc;
-      }, {} as aggregatedResultType["tasks"]);
-      return {
-        ok: true,
-        tasks: tasksRecord,
-      };
-    } catch (e: any) {
-      return syncError(log, `Error loading tasks`, e, false, `sync ids: ${body} workspace: ${workspaceId}`);
-    }
+    return syncService().latestSyncTasks(user, query.workspaceId, body);
   })
   .GET({
     auth: true,
@@ -124,75 +75,21 @@ export const route = createRoute()
     }),
     result: tasksResultType,
   })
-  .handler(async ({ user, query, req, res }) => {
+  .handler(async ({ user, query, req }) => {
     const { workspaceId } = query;
-    await verifyAccess(user, workspaceId);
-    const sync = await db.prisma().configurationObjectLink.findFirst({
-      where: {
-        id: query.syncId,
-        workspaceId: workspaceId,
-        deleted: false,
-        type: "sync",
-      },
+    const result = await syncService().listSyncTasks(user, workspaceId, {
+      syncId: query.syncId,
+      taskId: query.taskId,
+      status: query.status,
+      from: query.from,
+      to: query.to,
     });
-    if (!sync) {
-      return {
-        ok: false,
-        error: `Sync ${query.syncId} not found`,
-      };
+    if (result.ok && result.task) {
+      result.logs = `${getAppEndpoint(req).baseUrl}/api/${workspaceId}/sources/logs?taskId=${query.taskId}&syncId=${
+        query.syncId
+      }`;
     }
-    try {
-      let i = 1;
-      let sql: string =
-        'select st.* from newjitsu.source_task st join newjitsu."ConfigurationObjectLink" link on st.sync_id = link.id where link."workspaceId" = $1';
-      sql += query.syncId ? ` and st.sync_id = $${++i}` : "";
-      sql += query.taskId ? ` and st.task_id = $${++i}` : "";
-      sql += query.status ? ` and st.status = $${++i}` : "";
-      sql += query.from ? ` and st.started_at >= $${++i}` : "";
-      sql += query.to ? ` and st.started_at < $${++i}` : "";
-      sql += " order by st.started_at desc limit 50";
-      log.atDebug().log(`sql: ${sql}`);
-      const args: any[] = [workspaceId];
-      if (query.syncId) {
-        args.push(query.syncId);
-      }
-      if (query.taskId) {
-        args.push(query.taskId);
-      }
-      if (query.status) {
-        args.push(query.status);
-      }
-      if (query.from) {
-        args.push(dayjs(query.from).utc().toDate());
-      }
-      if (query.to) {
-        args.push(dayjs(query.to).utc().toDate());
-      }
-      const tasks = await db.prisma().$queryRawUnsafe<source_task[]>(sql, ...args);
-      if (query.taskId) {
-        if (tasks.length == 0) {
-          return {
-            ok: false,
-            error: `Task ${query.taskId} not found`,
-          };
-        } else {
-          return {
-            ok: true,
-            task: tasks[0],
-            logs: `${getAppEndpoint(req).baseUrl}/api/${workspaceId}/sources/logs?taskId=${query.taskId}&syncId=${
-              query.syncId
-            }`,
-          };
-        }
-      } else {
-        return {
-          ok: true,
-          tasks: tasks,
-        };
-      }
-    } catch (e: any) {
-      return syncError(log, `Error loading tasks`, e, false, `sync ids: ${query.syncId} workspace: ${workspaceId}`);
-    }
+    return result;
   });
 
 export default route.toNextApiHandler();

--- a/webapps/console/pages/api/[workspaceId]/sources/tasks.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/tasks.ts
@@ -72,8 +72,10 @@ export const route = createRoute()
       to: query.to,
     });
     if (result.ok && result.task) {
+      // Use the task's own sync_id, not query.syncId — a taskId-only lookup omits syncId,
+      // and the logs endpoint requires a real one.
       result.logs = `${getAppEndpoint(req).baseUrl}/api/${workspaceId}/sources/logs?taskId=${query.taskId}&syncId=${
-        query.syncId
+        result.task.sync_id
       }`;
     }
     return result;

--- a/webapps/console/pages/api/[workspaceId]/sources/tasks.ts
+++ b/webapps/console/pages/api/[workspaceId]/sources/tasks.ts
@@ -2,26 +2,13 @@ import { z } from "zod";
 import { createRoute } from "../../../../lib/api";
 import { source_taskDbModel } from "../../../../prisma/schema";
 import { getAppEndpoint } from "../../../../lib/domains";
-import { syncService } from "../../../../lib/server/route-services";
+import { syncService, latestSyncTaskSchema } from "../../../../lib/server/route-services";
 
 const aggregatedResultType = z.object({
   ok: z.boolean(),
   error: z.string().optional(),
-  tasks: z
-    .record(
-      z.object({
-        sync_id: z.string(),
-        task_id: z.string(),
-        status: z.string(),
-        description: z.string().nullish(),
-        error: z.string().nullish(),
-        started_by: z.any().optional(),
-        started_at: z.date(),
-        updated_at: z.date(),
-        metrics: z.any().optional(),
-      })
-    )
-    .optional(),
+  // value shape is owned by the service (latestSyncTaskSchema) so it can't drift from the query
+  tasks: z.record(latestSyncTaskSchema).optional(),
 });
 
 //fix the type of started_by and metrics from weird prism type to any


### PR DESCRIPTION
## What

Migrate the sync/debug/reports route handlers onto the shared service classes extracted for the MCP server in #1385, so HTTP and MCP share one implementation of workspace scoping, secret unmasking, and syncctl/bulker/functions dispatch instead of two paths that drift. Same play as `JITSU-67` (config routes → `ConfigObjectsService`).

| Route | Delegates to |
|---|---|
| `sources/run` | `SyncService.runSync` (scheduler-bearer special case + logging stay in the route) |
| `sources/cancel` | `cancelSync` |
| `sources/tasks` GET/POST | `listSyncTasks` / `latestSyncTasks` (route adds the `logs` URL) |
| `sources/spec` | `getConnectorSpec` |
| `sources/discover` | `discoverStreams` |
| `sources/check` POST/GET | `triggerSourceCheck` / `getSourceCheckResult` |
| `sources/state` GET/POST | `getSyncState` / `resetSyncState` + `setSyncState` |
| `sources/logs` | `findSync` (only the ownership lookup moves; gzip streaming stays) |
| `config/[type]/test` | `DebugService.testConnection` |
| `function/run` | `DebugService.runFunction` |
| `profile-builder/run` | `DebugService.runProfileBuilder` |
| `reports/event-stat` | `ReportsService.eventStat` (route keeps `getWorkspace` slug resolution) |
| `reports/sync-stat` | `ReportsService.syncStat` (same) |

`profile-builder/stats.ts` from the issue no longer exists — removed in #1195; `ReportsService.profileBuilderStats` mirrors the dead route, nothing to migrate.

Transport stays in the routes (`createRoute` schemas, OpenAPI `expand` metadata, 20mb `bodyParser` configs, `maxDuration`). `lib/server/route-services.ts` provides lazy per-process service instances bound to the db/clickhouse singletons so route files don't repeat the wiring. Net −613 lines.

## Service gaps closed for parity

The routes had capabilities the services lacked:

- `SyncService.latestSyncTasks` — the `tasks` POST aggregation (latest non-skipped task per sync)
- `SyncService.setSyncState` — the state-editor upsert (`state` POST with a non-empty body)
- `SyncService.triggerSourceCheck` also accepts a caller-supplied unsaved `config` + client-generated `storageKey` (service-editor test flow), with secret unmasking; MCP call site updated
- `SyncService.runSync` passes `taskId`; `DebugService.runFunction` passes `functionName`
- `ReportsService.eventStat` returns `srcSize` (the client-side `Report.parse` requires it)

## Behavior changes

- **Security:** `sources/check` GET/POST now require the exact `${workspaceId}_` storage-key segment — a bare `startsWith(workspaceId)` let workspace `ws1` poll keys of `ws10` (hardened in the service in a1e95e6db; the route gets it by delegating). `sync-stat` counts distinct `(fromId, toId)` tuples instead of collision-prone string concatenation.
- `sources/cancel` returns the service's `{ ok: true, status }` instead of `{ ok: false, pending: true, startedAt }` — the UI only reads `.error`.
- `sources/discover` keeps its historical `200 { ok: false, error }` for unknown services via an `ApiError` adapter in the route (the service 404s).
- `sources/tasks` GET without `syncId` no longer fails spuriously in a workspace with no syncs.
- `sources/tasks` GET with `taskId` builds the `logs` URL from the returned task's own `sync_id`, not the request's `syncId` — a task-only lookup omits `syncId`, so the old link carried `syncId=undefined` and the logs endpoint (which requires a real `syncId`) 404'd. Pre-existing latent bug, hardened here.
- `profile-builder/run` now 404s on an unknown profile builder (previously forwarded blindly) and defaults `settings`/`version` from the stored builder.
- `reports/event-stat`: when `end` is given without `start`, `start` defaults to `end − 1 month` (was `now − 1 month`), matching `sync-stat`.

## Testing

New integration tests (testcontainers Postgres/ClickHouse + MSW syncctl): aggregated-tasks scoping, config-mode source check with unmasking, the `ws1`/`ws10` prefix hardening, state upsert, and `srcSize` in the event-stat wire shape.

`JITSU-91`

