### PR TITLE
JITSU-106 fix(console): stop logging /api/me CORS rejections as errors

### DIFF
--- a/webapps/console/pages/api/me.ts
+++ b/webapps/console/pages/api/me.ts
@@ -17,12 +17,12 @@ function getMatcher(mask: string): (test: string) => boolean {
   if (mask.startsWith("*")) {
     const suffix = mask.substring(1);
     return (test: string) => {
-      log.atInfo().log(`Matching ${mask} (suffix: ${suffix}) with ${test} - wildcard`);
+      log.atDebug().log(`Matching ${mask} (suffix: ${suffix}) with ${test} - wildcard`);
       return test.toLowerCase().trim().endsWith(suffix.toLowerCase().trim());
     };
   } else {
     return (test: string) => {
-      log.atInfo().log(`Matching ${mask} with ${test}`);
+      log.atDebug().log(`Matching ${mask} with ${test}`);
       return test.toLowerCase().trim() === mask.toLowerCase().trim();
     };
   }
@@ -39,8 +39,12 @@ function handleCors(requestDomain: string, origin: string | undefined, res: Next
     .split(",")
     .map(mask => mask.replaceAll("[originTopLevelDomain]", topLevelDomain));
   if (!compiledMasks.map(getMatcher).find(matcher => matcher(originHost))) {
+    // Rejecting a disallowed origin is this endpoint working, not a fault: /api/me
+    // answers with credentials, so the allow-list is what stops an arbitrary page
+    // reading a signed-in user's identity. Logged at warn so it stays greppable
+    // without counting towards console's error rate.
     log
-      .atError()
+      .atWarn()
       .log(
         `CORS error - origin ${origin} is not allowed. Masks: ${allowedOrigins} (compiled: ${compiledMasks}), request domain: ${requestDomain}, top level domain: ${topLevelDomain}`
       );


### PR DESCRIPTION
`JITSU-106`. Prompted by this morning's alert: **06:11:47 UTC, warn, 6 events** on the console backend — all six were `/api/me` 403s, all from one origin, `http://localhost:4113`. Someone's local dev server pointed at prod `use.jitsu.com`.

## The 403 is correct and stays correct

`/api/me` returns the signed-in user plus their workspaces and sets `Access-Control-Allow-Credentials: true`. The origin allow-list is what stops an arbitrary page on any localhost reading a logged-in Jitsu user's identity. Rejecting a disallowed origin is the endpoint doing its job.

**This PR changes no status codes.** A disallowed origin still gets a 403. It only stops that decision being *reported* as a server-side error.

## Two changes

**1. CORS rejection: `.atError()` → `.atWarn()`.** It's a routine policy decision, not a fault. At error it inflates console's error rate and shows up in error dashboards as if something were broken.

**2. Per-match origin logging: `.atInfo()` → `.atDebug()`.** `getMatcher` logged a line for every mask it tested, on every `/api/me` request:

```
[me]: Matching *.jitsu.com (suffix: .jitsu.com) with jitsu.com - wildcard
[me]: Matching jitsu.com with jitsu.com
```

That's **~500/day** of pure noise (738 on Jul 14), and it adds nothing the rejection log doesn't already carry — masks, compiled masks, request domain and top-level domain are all in that one line. Relevant given the High Log Usage monitor (275847661) fired on Jul 8.

juava's `globalLogLevel` defaults to `info` and `atDebug()` returns a noop builder below its threshold, so these stop being emitted in prod (verified: `JUAVA_LOG_LEVEL` isn't set anywhere in `jitsu-cloud-infra`). Still available locally with `JUAVA_LOG_LEVEL=debug`.

## What this does *not* fix

The alert itself. The nginx-ingress monitor (304244687) counts 403 in its "bad 4xx" band, so a developer hitting prod from localhost still pages the team. That's a monitor change, not a code one — the band already excludes 401, and 403 is the same class of thing (an authorization decision, not a fault).

Worth noting the interaction with [#1403](https://github.com/jitsucom/jitsu/pull/1403): that PR makes `verifyAdmin` return a real 403 instead of 500, so **403 volume will rise** once it deploys. If the monitor keeps counting 403, the noise moves rather than goes away.

## Verification

`tsc --noEmit` clean; prettier clean. No behavioural change beyond log levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)