### PR TITLE
JITSU-116 fix(destinations): flush posthog explicitly to stop flush-error log spam

### DIFF
--- a/libs/destination-functions/__tests__/posthog.test.ts
+++ b/libs/destination-functions/__tests__/posthog.test.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { eventsSequence } from "./lib/test-data";
 import { testJitsuFunction, TestOptions } from "./lib/testing-lib";
 import PosthogDestination from "../src/functions/posthog-destination";
@@ -36,6 +37,10 @@ const trackEvent: AnalyticsServerEvent = {
 const nodeStyleBody = { destroy: () => {} } as any;
 
 test("posthog-destination-delivery-error", async () => {
+  // posthog's logFlushError console.error's failures (with the full response
+  // body) from shutdown()'s internal flush; the destination flushes explicitly
+  // beforehand precisely so that path stays silent.
+  const consoleError = vi.spyOn(console, "error");
   // posthog-node only enqueues events in capture(); delivery happens on
   // shutdown(), which swallows fetch errors and emits them on the "error"
   // event. The destination must surface them as RetryError. 413 is used
@@ -54,6 +59,9 @@ test("posthog-destination-delivery-error", async () => {
       chainCtx: { fetch: failingFetch } as any,
     })
   ).rejects.toThrow(RetryError);
+  const flushSpam = consoleError.mock.calls.filter(args => String(args[0]).includes("Error while flushing PostHog"));
+  expect(flushSpam).toEqual([]);
+  consoleError.mockRestore();
 });
 
 test("posthog-destination-delivery-success", async () => {

--- a/libs/destination-functions/src/functions/posthog-destination.ts
+++ b/libs/destination-functions/src/functions/posthog-destination.ts
@@ -192,7 +192,15 @@ const PosthogDestination: JitsuFunction<AnalyticsServerEvent, PosthogDestination
     // synchronous enqueue-time errors; the finally below still flushes the queue
     throw new RetryError(e?.message || String(e));
   } finally {
-    // this is where the queued events are actually sent
+    // This is where the queued events are actually sent. Flush explicitly first:
+    // flush() rejects with the delivery error without logging anything, while
+    // shutdown()'s internal flush console.error's every failure with the full
+    // response body ("Error while flushing PostHog: ...") - and that call is
+    // hardwired to console, so no client option can silence it. After flush()
+    // the queue is empty (posthog drops the batch on HTTP errors), leaving
+    // shutdown() nothing to re-send; it still runs to release timers and
+    // pending work.
+    await client.flush().catch(e => (deliveryError = deliveryError ?? e));
     await client.shutdown().catch(e => (deliveryError = deliveryError ?? e));
   }
   if (deliveryError) {


### PR DESCRIPTION
JITSU-116 follow-up to #1407.

## Problem

Every failed PostHog delivery spams the logs with:

```
Error while flushing PostHog: message=HTTP error while fetching PostHog: status=403, reqByteLength=5560, response body=<!DOCTYPE html>...
```

The line comes from `@posthog/core`'s `logFlushError`, which calls **`console.error` directly** — not the client's logger — so no client option can disable it. It fires from `shutdown()`'s internal drain flush (and from background flushes, which this destination never triggers: it enqueues 1–2 events, far below `flushAt`).

## Fix

`client.flush()` rejects with the same delivery error **without logging anything**. So the destination now flushes explicitly before `shutdown()`:

- on HTTP errors (like the 403 above) posthog drops the batch after the failed attempt, so `shutdown()` finds an empty queue — nothing to re-send, nothing to log;
- `shutdown()` still runs to release timers and pending work;
- the error still reaches the `RetryError` path via the same collection variable (both the `error`-event listener and the `flush()` rejection feed it, first one wins).

## Tests

The delivery-error test now spies on `console.error` and asserts no "Error while flushing PostHog" lines are emitted. Verified against the unfixed code: it produces the exact reported spam line and the test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)