### PR TITLE
fix(helm): run events-log ClickHouse init on console startup

### DIFF
--- a/helm/templates/console.yaml
+++ b/helm/templates/console.yaml
@@ -53,6 +53,16 @@ spec:
                 echo "seed failed (database schema not ready yet?), retrying in 5s..."
                 sleep 5
               done
+              # Create the events-log ClickHouse tables (powers Live Events).
+              # Nothing else runs this in the dev chart — in prod the
+              # admin/events-log-init route does. Best-effort: retry a few times
+              # for a not-yet-ready ClickHouse, then continue so a disabled or
+              # broken ClickHouse can't wedge console startup.
+              for i in $(seq 1 12); do
+                npx tsx scripts/manage.ts events-log-init && break
+                echo "events-log-init failed (clickhouse not ready yet?), retry $i/12 in 5s..."
+                sleep 5
+              done
               exec npx next dev -H 0.0.0.0 -p 3000
           ports:
             - name: http

--- a/webapps/console/scripts/manage.ts
+++ b/webapps/console/scripts/manage.ts
@@ -16,9 +16,10 @@
 
 import minimist from "minimist";
 import { seedDemoConnections, seedUserAndWorkspace } from "../lib/server/seed";
-import { createHash, randomId } from "juava";
+import { createHash, getClickhouseConfig, randomId, requireDefined } from "juava";
 import { getServerLog } from "../lib/server/log";
 import { getServerEnv } from "../lib/server/serverEnv";
+import { initEventsLogTables } from "../lib/server/clickhouse-init";
 
 const log = getServerLog("manage");
 
@@ -37,6 +38,29 @@ const commands: Record<string, Command> = {
       await seedUserAndWorkspace();
       await seedDemoConnections();
       // Note: seedDemoConnections() logs its own status messages
+    },
+  },
+  "events-log-init": {
+    description:
+      "Create the events-log ClickHouse objects (database, events_log/task_log/dead_letter, retention machinery)",
+    usage: "pnpm manage events-log-init",
+    handler: async () => {
+      // Same DDL the admin/events-log-init route runs in prod — idempotent
+      // (CREATE ... IF NOT EXISTS), so it's safe to run on every startup.
+      // Import the ClickHouse client lazily so unrelated commands (e.g. seed)
+      // don't construct it when CLICKHOUSE_URL isn't configured.
+      const { clickhouse } = await import("../lib/server/clickhouse");
+      const serverEnv = getServerEnv();
+      const chConfig = getClickhouseConfig(serverEnv);
+      log.atInfo().log("Initializing events-log ClickHouse tables...");
+      await initEventsLogTables({
+        clickhouse,
+        database: requireDefined(chConfig.database, "ClickHouse database is not configured"),
+        cluster: serverEnv.CLICKHOUSE_METRICS_CLUSTER || serverEnv.CLICKHOUSE_CLUSTER,
+        username: chConfig.username,
+        password: chConfig.password,
+      });
+      log.atInfo().log("events-log ClickHouse tables ready");
     },
   },
   "password-hash": {


### PR DESCRIPTION
## Problem

The dev Helm chart never created the events-log ClickHouse objects (the `events_log` / `task_log` / `dead_letter` tables + retention machinery) that power **Live Events**. That DDL lives in `lib/server/clickhouse-init.ts` (`initEventsLogTables`) and in prod is run by the `GET /api/admin/events-log-init` admin route — but nothing in the dev chart calls it. So against a fresh ClickHouse there are no events_log tables; the dev stack only "worked" when it happened to point at an already-initialized ClickHouse.

## Fix

- **New `events-log-init` command** in the console manage CLI (`scripts/manage.ts`) that runs the exact same `initEventsLogTables` DDL as the prod route. It's idempotent (`CREATE … IF NOT EXISTS`). The ClickHouse client singleton is imported **lazily** inside the handler so unrelated commands (`seed`) don't construct it when `CLICKHOUSE_URL` is unset.
- **Wire it into console pod startup** (`helm/templates/console.yaml`), right after `seed`. Best-effort with a bounded retry loop so a not-yet-ready ClickHouse gets picked up, but a disabled/broken ClickHouse can't wedge console startup (unlike `seed`, which hard-blocks on Postgres).

## Verification

- `tsc --noEmit` clean on the changed files; `helm lint` passes; the rendered `console.yaml` includes the init step.
- Read-only check against the running dev cluster's console pod:
  - `CLICKHOUSE_CLUSTER` / `CLICKHOUSE_METRICS_CLUSTER` are empty → `cluster` is `undefined` → single-node `MergeTree()` path (matches what the command passes). ✓
  - The `events_log` / `task_log` / `dead_letter` tables already existed on that (external, shared) ClickHouse — which is exactly why the missing-init gap was invisible in this deployment, and confirms the command is a safe idempotent no-op where tables already exist.
- I deliberately did **not** run the DDL against the shared external ClickHouse (already initialized; would just be no-ops on shared infra). Full "runs at pod startup" verification will happen on the next dev deploy that points at a fresh ClickHouse.

## Notes / follow-ups

- **Metrics tables not covered:** `initEventsLogTables` creates the events-log objects but **not** the `metrics` / `mv_metrics` tables (connection stats/charts). Those come from `prisma/metrics.sql`, which the integration test recreates manually and is "cluster-only DDL applied in prod." If we want connection metrics to work in the dev chart too, that's a related but separate gap — happy to file/handle as a follow-up.
- **docker-compose** likely shares the same gap (no events-log-init trigger); out of scope here but worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)