### PR TITLE
Record request IP + headers on audit-log rows and use them for origin detection

### DIFF
--- a/cli/jitsu-cli/src/commands/deploy.ts
+++ b/cli/jitsu-cli/src/commands/deploy.ts
@@ -8,6 +8,7 @@ import { b, green, red } from "../lib/chalk-code-highlight";
 import { getFunctionFromFilePath } from "../lib/compiled-function";
 import { loadProjectConfig } from "../lib/project-config";
 import { readDefaultWorkspace } from "../lib/auth-file";
+import { jitsuClientId } from "../lib/version";
 
 function readLoginFile() {
   const configFile = `${homedir()}/.jitsu/jitsu-cli.json`;
@@ -49,6 +50,7 @@ export async function deploy({ dir, workspace, name: names, ...params }: Args) {
     method: "GET",
     headers: {
       Authorization: `Bearer ${apikey}`,
+      "X-Jitsu-Client": jitsuClientId,
     },
   });
   if (!res.ok) {
@@ -161,6 +163,7 @@ async function deployFunctions(
       method: "GET",
       headers: {
         Authorization: `Bearer ${apikey}`,
+        "X-Jitsu-Client": jitsuClientId,
       },
     });
     if (!res.ok) {
@@ -213,7 +216,7 @@ async function fetchExistingFunctions({
   workspaceId?: string;
 }): Promise<ExistingFunctionsCache> {
   const res = await fetch(`${host}/api/${workspaceId}/config/function`, {
-    headers: { Authorization: `Bearer ${apikey}` },
+    headers: { Authorization: `Bearer ${apikey}`, "X-Jitsu-Client": jitsuClientId },
   });
   if (!res.ok) {
     console.error(red(`Cannot list existing functions:\n${b(await res.text())}`));
@@ -303,6 +306,7 @@ async function deployFunction(
       method: "POST",
       headers: {
         Authorization: `Bearer ${apikey}`,
+        "X-Jitsu-Client": jitsuClientId,
       },
       body: JSON.stringify({
         id,
@@ -335,6 +339,7 @@ async function deployFunction(
       method: "PUT",
       headers: {
         Authorization: `Bearer ${apikey}`,
+        "X-Jitsu-Client": jitsuClientId,
       },
       body: JSON.stringify({
         id: id,

--- a/cli/jitsu-cli/src/lib/api-client.ts
+++ b/cli/jitsu-cli/src/lib/api-client.ts
@@ -1,4 +1,5 @@
 import { AuthInfo } from "./auth-file";
+import { jitsuClientId } from "./version";
 
 export type ApiRequest = {
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
@@ -36,6 +37,7 @@ export class ApiClient {
     const headers: Record<string, string> = {
       Accept: "application/json",
       Authorization: `Bearer ${this.auth.apikey}`,
+      "X-Jitsu-Client": jitsuClientId,
     };
     let body: string | undefined;
     if (req.body !== undefined) {

--- a/cli/jitsu-cli/src/lib/version.ts
+++ b/cli/jitsu-cli/src/lib/version.ts
@@ -6,6 +6,15 @@ const fetch = require("cross-fetch");
 
 export const jitsuCliVersion = pkg.version;
 export const jitsuCliPackageName = pkg.name;
+
+/**
+ * Value sent in the `X-Jitsu-Client` header on every request the CLI makes.
+ * The console records it on audit-log rows and uses it to attribute changes to
+ * the CLI/SDK even when the request authenticated with a plain API key (which
+ * carries no CLI marker of its own).
+ */
+export const jitsuClientId = `jitsu-cli/${jitsuCliVersion}`;
+
 let newVersion = undefined;
 
 export function getUpgradeMessage(newVersion: string, oldVersion: string) {

--- a/webapps/console/__tests__/unit/audit-provenance.test.ts
+++ b/webapps/console/__tests__/unit/audit-provenance.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { NextApiRequest } from "next";
+import { extractRequestProvenance } from "../../lib/server/origin";
+import { originFromAuth } from "../../lib/schema";
+
+// The fragile, non-obvious rule: an X-Jitsu-Client "jitsu-cli/…" header overrides
+// the token-based origin (recovering CLI provenance from a plain API key),
+// case-insensitively, and ONLY for a jitsu-cli value — anything else falls
+// through to the existing authType/token logic. The read-API SQL filter mirrors
+// this precedence, so this is the shared contract both sides must agree on.
+describe("originFromAuth — X-Jitsu-Client precedence", () => {
+  const apiKey = { authType: "bearer", tokenId: "PpdX1lrYXvqFTFocW1xYLcX9UPbkTvxv" };
+  it.each([
+    ["plain API key, no header → api", apiKey, undefined, "api"],
+    ["API key + jitsu-cli header → cli", apiKey, "jitsu-cli/0.9.1", "cli"],
+    ["header match is case-insensitive", apiKey, "JITSU-CLI/1.0.0", "cli"],
+    ["unrelated client falls through to token → api", apiKey, "some-tool/1.0", "api"],
+    ["header wins over authType (mcp) → cli", { authType: "mcp" }, "jitsu-cli/1.0.0", "cli"],
+  ] as const)("%s", (_label, auth, client, expected) => {
+    expect(originFromAuth({ ...auth, headers: client ? { "x-jitsu-client": client } : null })).toBe(expected);
+  });
+});
+
+// IP resolution is delegated to the existing getClientIp; the only new logic is
+// the header allowlist, which must never persist credential-bearing headers.
+describe("extractRequestProvenance", () => {
+  it("keeps allowlisted headers and drops credentials", () => {
+    const { ip, headers } = extractRequestProvenance({
+      headers: { "x-jitsu-client": "jitsu-cli/9", authorization: "Bearer s", cookie: "a=b" },
+      socket: { remoteAddress: "192.0.2.9" },
+    } as unknown as NextApiRequest);
+    expect(ip).toBe("192.0.2.9");
+    expect(headers).toEqual({ "x-jitsu-client": "jitsu-cli/9" });
+  });
+});

--- a/webapps/console/__tests__/unit/audit-provenance.test.ts
+++ b/webapps/console/__tests__/unit/audit-provenance.test.ts
@@ -33,4 +33,12 @@ describe("extractRequestProvenance", () => {
     expect(ip).toBe("192.0.2.9");
     expect(headers).toEqual({ "x-jitsu-client": "jitsu-cli/9" });
   });
+
+  it("strips query/fragment from referer so URL secrets aren't persisted", () => {
+    const { headers } = extractRequestProvenance({
+      headers: { referer: "https://use.jitsu.com/accept?invite=SECRET#frag", origin: "https://use.jitsu.com" },
+      socket: {},
+    } as unknown as NextApiRequest);
+    expect(headers).toEqual({ referer: "https://use.jitsu.com/accept", origin: "https://use.jitsu.com" });
+  });
 });

--- a/webapps/console/__tests__/unit/audit-provenance.test.ts
+++ b/webapps/console/__tests__/unit/audit-provenance.test.ts
@@ -15,6 +15,7 @@ describe("originFromAuth — X-Jitsu-Client precedence", () => {
     ["API key + jitsu-cli header → cli", apiKey, "jitsu-cli/0.9.1", "cli"],
     ["header match is case-insensitive", apiKey, "JITSU-CLI/1.0.0", "cli"],
     ["unrelated client falls through to token → api", apiKey, "some-tool/1.0", "api"],
+    ["jitsu-client is not jitsu-cli (delimiter guards) → api", apiKey, "jitsu-client/1.0", "api"],
     ["header wins over authType (mcp) → cli", { authType: "mcp" }, "jitsu-cli/1.0.0", "cli"],
   ] as const)("%s", (_label, auth, client, expected) => {
     expect(originFromAuth({ ...auth, headers: client ? { "x-jitsu-client": client } : null })).toBe(expected);

--- a/webapps/console/components/AuditLog/AuditLog.tsx
+++ b/webapps/console/components/AuditLog/AuditLog.tsx
@@ -36,6 +36,8 @@ export type AuditLogItem = {
   objectId?: string | null;
   authType?: string | null;
   tokenId?: string | null;
+  ip?: string | null;
+  requestHeaders?: Record<string, string> | null;
   token?: { id: string; type?: string | null; name?: string | null } | null;
   changes?: any;
   diff?: DiffEntry[];
@@ -93,9 +95,15 @@ const ORIGIN_MCP: Origin = { label: "MCP", color: "magenta", icon: <FaRobot /> }
 const ORIGIN_BY_KIND = { ui: ORIGIN_UI, api: ORIGIN_API, cli: ORIGIN_CLI, mcp: ORIGIN_MCP } as const;
 
 function resolveOrigin(item: AuditLogItem): Origin | null {
-  if (!item.authType) return null;
+  // No authType and no explicit client header → unknown origin (legacy rows).
+  if (!item.authType && !item.requestHeaders?.["x-jitsu-client"]) return null;
   return ORIGIN_BY_KIND[
-    originFromAuth({ authType: item.authType, tokenId: item.tokenId, tokenType: item.token?.type })
+    originFromAuth({
+      authType: item.authType,
+      tokenId: item.tokenId,
+      tokenType: item.token?.type,
+      headers: item.requestHeaders,
+    })
   ];
 }
 
@@ -117,6 +125,40 @@ function originTag(item: AuditLogItem) {
     </Tooltip>
   );
 }
+
+/**
+ * Renders the request provenance captured on a row — client IP and the
+ * allowlisted request headers (user-agent, x-jitsu-client, …). Both are
+ * best-effort/nullable; renders nothing when neither is present.
+ */
+const RequestProvenanceView: React.FC<{
+  ip?: string | null;
+  headers?: Record<string, string> | null;
+}> = ({ ip, headers }) => {
+  const headerEntries = headers ? Object.entries(headers) : [];
+  if (!ip && headerEntries.length === 0) return null;
+  return (
+    <div className="text-xs">
+      <div className="font-semibold text-text-light mb-1">Request</div>
+      <table className="font-mono">
+        <tbody>
+          {ip && (
+            <tr>
+              <td className="pr-3 align-top text-text-light whitespace-nowrap">ip</td>
+              <td className="break-all">{ip}</td>
+            </tr>
+          )}
+          {headerEntries.map(([k, v]) => (
+            <tr key={k}>
+              <td className="pr-3 align-top text-text-light whitespace-nowrap">{k}</td>
+              <td className="break-all">{v}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
 
 function entityHref(objectType: string | undefined, objectId?: string | null): string | null {
   if (!objectType || !objectId) return null;
@@ -519,10 +561,12 @@ export const AuditLog: React.FC<AuditLogProps> = ({ workspaceId, workspaceSlug, 
         loading={query.isLoading}
         pagination={false}
         expandable={{
-          rowExpandable: (item: AuditLogItem) => Array.isArray(item.diff) && item.diff.length > 0,
+          rowExpandable: (item: AuditLogItem) =>
+            (Array.isArray(item.diff) && item.diff.length > 0) || !!item.ip || !!item.requestHeaders,
           expandedRowRender: (item: AuditLogItem) => (
-            <div className="pl-12 pr-4 py-2 bg-neutral-50">
-              <AuditLogDiff diff={item.diff || []} />
+            <div className="pl-12 pr-4 py-2 bg-neutral-50 flex flex-col gap-3">
+              {Array.isArray(item.diff) && item.diff.length > 0 && <AuditLogDiff diff={item.diff} />}
+              <RequestProvenanceView ip={item.ip} headers={item.requestHeaders} />
             </div>
           ),
         }}

--- a/webapps/console/lib/nextauth.config.ts
+++ b/webapps/console/lib/nextauth.config.ts
@@ -170,89 +170,111 @@ const sharedCookieOptions = authCookieDomain
     }
   : {};
 
-export const nextAuthConfig: NextAuthOptions = {
-  // Configure one or more authentication providers
-  providers: [githubProvider, oidcProvider, credentialsProvider].filter(provider => !!provider) as any,
-  pages: {
-    error: "/error/auth", // Error code passed in query string as ?error=
-    signIn: "/signin", // Displays signin buttons
-  },
-  ...sharedCookieOptions,
+// Built as a factory so the NextAuth handler can pass the current request in
+// (via NextAuth(req, res, options)); the signOut/jwt events then attribute
+// their login/logout audit rows to the request's ip + headers. `req` is
+// optional: the static export below (used by getServerSession and `.secret`
+// consumers) builds it without one, which is fine since those paths never fire
+// the login/logout events.
+function buildNextAuthConfig(req?: NextApiRequest): NextAuthOptions {
+  return {
+    // Configure one or more authentication providers
+    providers: [githubProvider, oidcProvider, credentialsProvider].filter(provider => !!provider) as any,
+    pages: {
+      error: "/error/auth", // Error code passed in query string as ?error=
+      signIn: "/signin", // Displays signin buttons
+    },
+    ...sharedCookieOptions,
 
-  secret:
-    serverEnv.JWT_SECRET ||
-    //if there's no explicit JWT_SECRET, we need to generate a secret based on some values that are unique for an installation
-    generateSecret(["v2", serverEnv.GITHUB_CLIENT_ID, serverEnv.GOOGLE_CLIENT_ID, serverEnv.DATABASE_URL]),
-  events: {
-    signOut: async ({ token }) => {
-      try {
-        const internalId = token?.internalId as string | undefined;
-        const email = (token?.email as string | undefined) || "";
-        const name = (token?.name as string | undefined) || email;
-        const loginProvider = (token?.loginProvider as string | undefined) || "credentials";
-        if (internalId) {
-          await authAuditLog({ internalId, email, name }, "logout", `nextauth-${loginProvider}`);
-          await trackAuthEvent(
-            // Read the persisted externalId (what the jwt/session callbacks treat as
-            // canonical), not token.sub — for some providers sub diverges from the
-            // stored external id, which would overwrite the identify trait with the wrong value.
-            { internalId, email, name, externalId: token?.externalId as string | undefined },
-            "logout",
-            `nextauth-${loginProvider}`
-          );
-        }
-      } catch (err) {
-        log.atError().withCause(err).log("Failed to record logout audit event");
-      }
-    },
-  },
-  callbacks: {
-    jwt: async props => {
-      const loginProvider = (props.account?.provider || props.token.loginProvider || "credentials") as string;
-      const externalId = requireDefined(props.token.sub, `JWT token .sub is not defined`);
-      const email = requireDefined(props.token.email, `JWT token .email is not defined`);
-      const user = await getOrCreateUser({
-        externalId,
-        loginProvider,
-        email,
-        name: props.token.name || email,
-      });
-      // Log a successful login only on the initial sign-in call, not on every JWT refresh.
-      // NextAuth populates `user` on first call; subsequent calls only carry `token`.
-      if (props.user) {
+    secret:
+      serverEnv.JWT_SECRET ||
+      //if there's no explicit JWT_SECRET, we need to generate a secret based on some values that are unique for an installation
+      generateSecret(["v2", serverEnv.GITHUB_CLIENT_ID, serverEnv.GOOGLE_CLIENT_ID, serverEnv.DATABASE_URL]),
+    events: {
+      signOut: async ({ token }) => {
         try {
-          await authAuditLog(
-            { internalId: user.id, email: user.email || email, name: user.name || email },
-            "login",
-            `nextauth-${loginProvider}`
-          );
-          await trackAuthEvent(
-            { internalId: user.id, email: user.email || email, name: user.name || email, externalId },
-            "login",
-            `nextauth-${loginProvider}`
-          );
+          const internalId = token?.internalId as string | undefined;
+          const email = (token?.email as string | undefined) || "";
+          const name = (token?.name as string | undefined) || email;
+          const loginProvider = (token?.loginProvider as string | undefined) || "credentials";
+          if (internalId) {
+            await authAuditLog({ internalId, email, name }, "logout", `nextauth-${loginProvider}`, undefined, req);
+            await trackAuthEvent(
+              // Read the persisted externalId (what the jwt/session callbacks treat as
+              // canonical), not token.sub — for some providers sub diverges from the
+              // stored external id, which would overwrite the identify trait with the wrong value.
+              { internalId, email, name, externalId: token?.externalId as string | undefined },
+              "logout",
+              `nextauth-${loginProvider}`
+            );
+          }
         } catch (err) {
-          log.atError().withCause(err).log("Failed to record login audit event");
+          log.atError().withCause(err).log("Failed to record logout audit event");
         }
-      }
-      return {
-        internalId: user.id,
-        externalId: externalId,
-        mustChangePassword: user.mustChangePassword,
-        externalUsername: props.profile?.["login"],
-        loginProvider: loginProvider,
-        ...props.token,
-      };
+      },
     },
-    async session({ session, token }) {
-      return {
-        ...session,
-        mustChangePassword: token.mustChangePassword,
-        internalId: token.internalId,
-        loginProvider: token.loginProvider,
-        externalId: token.externalId,
-        externalUsername: token.externalUsername,
-      };
+    callbacks: {
+      jwt: async props => {
+        const loginProvider = (props.account?.provider || props.token.loginProvider || "credentials") as string;
+        const externalId = requireDefined(props.token.sub, `JWT token .sub is not defined`);
+        const email = requireDefined(props.token.email, `JWT token .email is not defined`);
+        const user = await getOrCreateUser({
+          externalId,
+          loginProvider,
+          email,
+          name: props.token.name || email,
+        });
+        // Log a successful login only on the initial sign-in call, not on every JWT refresh.
+        // NextAuth populates `user` on first call; subsequent calls only carry `token`.
+        if (props.user) {
+          try {
+            await authAuditLog(
+              { internalId: user.id, email: user.email || email, name: user.name || email },
+              "login",
+              `nextauth-${loginProvider}`,
+              undefined,
+              req
+            );
+            await trackAuthEvent(
+              { internalId: user.id, email: user.email || email, name: user.name || email, externalId },
+              "login",
+              `nextauth-${loginProvider}`
+            );
+          } catch (err) {
+            log.atError().withCause(err).log("Failed to record login audit event");
+          }
+        }
+        return {
+          internalId: user.id,
+          externalId: externalId,
+          mustChangePassword: user.mustChangePassword,
+          externalUsername: props.profile?.["login"],
+          loginProvider: loginProvider,
+          ...props.token,
+        };
+      },
+      async session({ session, token }) {
+        return {
+          ...session,
+          mustChangePassword: token.mustChangePassword,
+          internalId: token.internalId,
+          loginProvider: token.loginProvider,
+          externalId: token.externalId,
+          externalUsername: token.externalUsername,
+        };
+      },
     },
-  },
-};
+  };
+}
+
+// Static config for consumers that only need `.secret` or read an existing
+// session via getServerSession — neither fires the login/logout events, so
+// there's no request to carry.
+export const nextAuthConfig: NextAuthOptions = buildNextAuthConfig();
+
+// Per-request config for the NextAuth handler (pages/api/auth/[...nextauth].ts).
+// Carries `req` into the signOut/jwt events so login & logout audit rows get
+// ip + headers instead of NULL.
+export function nextAuthConfigForRequest(req: NextApiRequest): NextAuthOptions {
+  return buildNextAuthConfig(req);
+}

--- a/webapps/console/lib/nextauth.config.ts
+++ b/webapps/console/lib/nextauth.config.ts
@@ -170,6 +170,15 @@ const sharedCookieOptions = authCookieDomain
     }
   : {};
 
+// Computed once at module load. Must NOT live inside buildNextAuthConfig:
+// generateSecret logs the generated key, and the config is now rebuilt per
+// auth request, so computing it there would re-log the signing secret on every
+// /api/auth/* hit (and re-hash needlessly). If JWT_SECRET is unset we derive a
+// stable secret from installation-unique values.
+const nextAuthSecret =
+  serverEnv.JWT_SECRET ||
+  generateSecret(["v2", serverEnv.GITHUB_CLIENT_ID, serverEnv.GOOGLE_CLIENT_ID, serverEnv.DATABASE_URL]);
+
 // Built as a factory so the NextAuth handler can pass the current request in
 // (via NextAuth(req, res, options)); the signOut/jwt events then attribute
 // their login/logout audit rows to the request's ip + headers. `req` is
@@ -186,10 +195,7 @@ function buildNextAuthConfig(req?: NextApiRequest): NextAuthOptions {
     },
     ...sharedCookieOptions,
 
-    secret:
-      serverEnv.JWT_SECRET ||
-      //if there's no explicit JWT_SECRET, we need to generate a secret based on some values that are unique for an installation
-      generateSecret(["v2", serverEnv.GITHUB_CLIENT_ID, serverEnv.GOOGLE_CLIENT_ID, serverEnv.DATABASE_URL]),
+    secret: nextAuthSecret,
     events: {
       signOut: async ({ token }) => {
         try {

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -224,8 +224,12 @@ export function originFromAuth(auth: {
   tokenType?: string | null;
   headers?: Record<string, string> | null;
 }): RequestOrigin {
+  // Case-insensitive prefix match, kept deliberately simple so the read-API
+  // origin filter (a Prisma `string_starts_with` with mode:"insensitive") can
+  // mirror it exactly. Both sides must agree or `origin=cli` filtering drifts
+  // from what the row renders as.
   const client = auth.headers?.["x-jitsu-client"];
-  if (client && /^jitsu-cli\b/i.test(client)) return "cli";
+  if (client && client.toLowerCase().startsWith("jitsu-cli")) return "cli";
   if (auth.authType === "mcp") return "mcp";
   if (auth.authType === "bearer") {
     const tokenType = auth.tokenType || (auth.tokenId ? inferTokenTypeFromId(auth.tokenId) : "api");

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -224,12 +224,14 @@ export function originFromAuth(auth: {
   tokenType?: string | null;
   headers?: Record<string, string> | null;
 }): RequestOrigin {
-  // Case-insensitive prefix match, kept deliberately simple so the read-API
-  // origin filter (a Prisma `string_starts_with` with mode:"insensitive") can
-  // mirror it exactly. Both sides must agree or `origin=cli` filtering drifts
-  // from what the row renders as.
+  // Match the "jitsu-cli/" prefix (with the trailing slash) case-insensitively.
+  // The slash is a deliberate delimiter so we don't false-attribute a client
+  // like "jitsu-client/1.0"; the CLI always sends `jitsu-cli/<version>`. Kept a
+  // plain prefix check so the read-API origin filter (a Prisma
+  // `string_starts_with` with mode:"insensitive") mirrors it exactly — both
+  // sides must agree or `origin=cli` filtering drifts from what the row renders.
   const client = auth.headers?.["x-jitsu-client"];
-  if (client && client.toLowerCase().startsWith("jitsu-cli")) return "cli";
+  if (client && client.toLowerCase().startsWith("jitsu-cli/")) return "cli";
   if (auth.authType === "mcp") return "mcp";
   if (auth.authType === "bearer") {
     const tokenType = auth.tokenType || (auth.tokenId ? inferTokenTypeFromId(auth.tokenId) : "api");

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -203,10 +203,16 @@ export type RequestOrigin = "ui" | "api" | "cli" | "mcp";
  * Classify the origin of an authenticated request from its auth fields (as carried on
  * SessionUser, or on an audit-log row). Pure — safe to import from client code.
  *
+ *   X-Jitsu-Client "jitsu-cli/…" header   → "cli"  (explicit client signal, wins over token)
  *   authType "mcp"                        → "mcp"
  *   authType "bearer" + CLI token         → "cli"  (tokenType "cli", or jitsu-cli- id)
  *   authType "bearer" + anything else     → "api"
  *   anything else (session / no authType) → "ui"
+ *
+ * The `headers` are the allowlisted request headers stored on the audit row
+ * (see extractRequestProvenance). They let us recover CLI/SDK provenance even
+ * when the request authenticated with a plain API key — the token carries no
+ * CLI marker, but the client announces itself via X-Jitsu-Client.
  *
  * Single source of truth for origin: `resolveOrigin` in
  * components/AuditLog/AuditLog.tsx and the origin filter predicates in
@@ -216,7 +222,10 @@ export function originFromAuth(auth: {
   authType?: string | null;
   tokenId?: string | null;
   tokenType?: string | null;
+  headers?: Record<string, string> | null;
 }): RequestOrigin {
+  const client = auth.headers?.["x-jitsu-client"];
+  if (client && /^jitsu-cli\b/i.test(client)) return "cli";
   if (auth.authType === "mcp") return "mcp";
   if (auth.authType === "bearer") {
     const tokenType = auth.tokenType || (auth.tokenId ? inferTokenTypeFromId(auth.tokenId) : "api");

--- a/webapps/console/lib/server/audit-log.ts
+++ b/webapps/console/lib/server/audit-log.ts
@@ -1,6 +1,8 @@
+import type { NextApiRequest } from "next";
 import { db } from "./db";
 import { SessionUser } from "../schema";
 import { getServerEnv } from "./serverEnv";
+import { extractRequestProvenance } from "./origin";
 import { getServerLog } from "./log";
 import { dispatchAccountAlert, AccountAlertEvent } from "./account-alerts";
 import { AccountAlertEventType } from "../../emails/account-alert";
@@ -185,10 +187,12 @@ export async function configObjectAuditLog(
   id: string,
   type: string,
   op: "create" | "update" | "delete",
-  changes: { prevVersion?: any; newVersion?: any }
+  changes: { prevVersion?: any; newVersion?: any },
+  req?: NextApiRequest
 ) {
   if (enableAuditLog) {
     const objectName = pickObjectName(changes.newVersion) ?? pickObjectName(changes.prevVersion);
+    const { ip, headers } = extractRequestProvenance(req);
     const [prevVersion, newVersion] = await Promise.all([
       redactForAudit(type, changes.prevVersion),
       redactForAudit(type, changes.newVersion),
@@ -210,6 +214,8 @@ export async function configObjectAuditLog(
         userId: user.internalId,
         authType: user.authType,
         tokenId: user.tokenId ?? null,
+        ip,
+        requestHeaders: headers ?? undefined,
         changes: {
           _redacted: true,
           objectType: type,
@@ -227,11 +233,13 @@ export async function authAuditLog(
   user: Pick<SessionUser, "internalId" | "email" | "name">,
   op: AuthOp,
   authType: string,
-  workspaceId?: string
+  workspaceId?: string,
+  req?: NextApiRequest
 ): Promise<void> {
   if (!enableAuditLog) {
     return;
   }
+  const { ip, headers } = extractRequestProvenance(req);
   // No dedup here — call sites are expected to fire only on the actual
   // sign-in / sign-out user action. For Firebase that's the explicit
   // `signIn` / `signInWith` flow; the periodic ID-token rotation goes
@@ -244,6 +252,8 @@ export async function authAuditLog(
         workspaceId: workspaceId ?? null,
         userId: user.internalId,
         authType,
+        ip,
+        requestHeaders: headers ?? undefined,
         changes: {
           email: user.email,
           name: user.name,
@@ -268,13 +278,15 @@ export async function membershipAuditLog(
   workspaceId: string,
   op: MembershipOp,
   target: { userId?: string; email?: string },
-  changes?: { prevRole?: string; newRole?: string }
+  changes?: { prevRole?: string; newRole?: string },
+  req?: NextApiRequest
 ): Promise<void> {
   if (!enableAuditLog) {
     return;
   }
   const type = `member-${op}`;
   const occurredAt = new Date();
+  const { ip, headers } = extractRequestProvenance(req);
   try {
     await db.prisma().auditLog.create({
       data: {
@@ -285,6 +297,8 @@ export async function membershipAuditLog(
         objectId: target.userId ?? null,
         authType: actor?.authType ?? null,
         tokenId: actor?.tokenId ?? null,
+        ip,
+        requestHeaders: headers ?? undefined,
         timestamp: occurredAt,
         changes: {
           actorEmail: actor?.email,
@@ -320,7 +334,8 @@ export async function workspaceAuditLog(
   actor: Pick<SessionUser, "internalId" | "email" | "name" | "authType" | "tokenId">,
   workspaceId: string,
   op: "updated" | "deleted",
-  changes?: { prevVersion?: any; newVersion?: any; workspaceName?: string }
+  changes?: { prevVersion?: any; newVersion?: any; workspaceName?: string },
+  req?: NextApiRequest
 ): Promise<void> {
   if (!enableAuditLog) {
     return;
@@ -328,6 +343,7 @@ export async function workspaceAuditLog(
   const type = `workspace-${op}`;
   const severity = op === "deleted" ? "security" : "info";
   const occurredAt = new Date();
+  const { ip, headers } = extractRequestProvenance(req);
   try {
     await db.prisma().auditLog.create({
       data: {
@@ -337,6 +353,8 @@ export async function workspaceAuditLog(
         userId: actor.internalId,
         authType: actor.authType,
         tokenId: actor.tokenId ?? null,
+        ip,
+        requestHeaders: headers ?? undefined,
         timestamp: occurredAt,
         changes: {
           actorEmail: actor.email,

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -250,7 +250,7 @@ export class ConfigObjectsService {
         }),
       { user, workspace, req: opts.req }
     );
-    await configObjectAuditLog(user, workspaceId, created.id, type, "create", { newVersion: object });
+    await configObjectAuditLog(user, workspaceId, created.id, type, "create", { newVersion: object }, opts.req);
     return { id: created.id };
   }
 
@@ -293,7 +293,7 @@ export class ConfigObjectsService {
       workspace,
       req: opts.req,
     });
-    await configObjectAuditLog(user, workspaceId, id, type, "update", { prevVersion, newVersion: filtered });
+    await configObjectAuditLog(user, workspaceId, id, type, "update", { prevVersion, newVersion: filtered }, opts.req);
   }
 
   /** Backs `config/[type]/[id].ts` DELETE (soft delete). Returns the deleted object, or null. */
@@ -332,7 +332,7 @@ export class ConfigObjectsService {
         });
       }
     }
-    await configObjectAuditLog(user, workspaceId, id, type, "delete", { prevVersion: object.config });
+    await configObjectAuditLog(user, workspaceId, id, type, "delete", { prevVersion: object.config }, opts.req);
     return { ...((object.config as any) || {}), workspaceId, id, type };
   }
 
@@ -451,10 +451,15 @@ export class ConfigObjectsService {
         where: { id: existingLink.id },
         data: { data, deleted: false, workspaceId },
       });
-      await configObjectAuditLog(user, workspaceId, createdOrUpdated.id, "link", "update", {
-        prevVersion: existingLink,
-        newVersion: createdOrUpdated,
-      });
+      await configObjectAuditLog(
+        user,
+        workspaceId,
+        createdOrUpdated.id,
+        "link",
+        "update",
+        { prevVersion: existingLink, newVersion: createdOrUpdated },
+        opts.req
+      );
     } else {
       createdOrUpdated = await this.prisma.configurationObjectLink.create({
         data: {
@@ -466,9 +471,15 @@ export class ConfigObjectsService {
           type,
         },
       });
-      await configObjectAuditLog(user, workspaceId, createdOrUpdated.id, "link", "create", {
-        newVersion: createdOrUpdated,
-      });
+      await configObjectAuditLog(
+        user,
+        workspaceId,
+        createdOrUpdated.id,
+        "link",
+        "create",
+        { newVersion: createdOrUpdated },
+        opts.req
+      );
       await this.emitConnectionEvent(user, workspaceId, opts.req, "connection_created", createdOrUpdated);
     }
     if (type === "sync" && opts.runSync && opts.req) {
@@ -487,7 +498,8 @@ export class ConfigObjectsService {
     user: SessionUser,
     workspaceId: string,
     id: string,
-    patch: { fromId?: string; toId?: string; type?: string; data?: any }
+    patch: { fromId?: string; toId?: string; type?: string; data?: any },
+    opts: { req?: NextApiRequest } = {}
   ): Promise<{ id: string; updated: boolean }> {
     await verifyAccessWithRole(user, workspaceId, "editEntities");
     const existing = await this.prisma.configurationObjectLink.findFirst({
@@ -521,10 +533,15 @@ export class ConfigObjectsService {
     }
     await this.validateLinkData(workspaceId, type, existing.toId, data);
     const updated = await this.prisma.configurationObjectLink.update({ where: { id: existing.id }, data: { data } });
-    await configObjectAuditLog(user, workspaceId, updated.id, "link", "update", {
-      prevVersion: existing,
-      newVersion: updated,
-    });
+    await configObjectAuditLog(
+      user,
+      workspaceId,
+      updated.id,
+      "link",
+      "update",
+      { prevVersion: existing, newVersion: updated },
+      opts.req
+    );
     return { id: updated.id, updated: true };
   }
 
@@ -582,7 +599,7 @@ export class ConfigObjectsService {
         return { deleted: false };
       }
       await this.prisma.configurationObjectLink.update({ where: { id: existing.id }, data: { deleted: true } });
-      await configObjectAuditLog(user, workspaceId, existing.id, "link", "delete", { prevVersion: existing });
+      await configObjectAuditLog(user, workspaceId, existing.id, "link", "delete", { prevVersion: existing }, opts.req);
       await this.emitConnectionEvent(user, workspaceId, opts.req, "connection_deleted", existing);
       return { deleted: true };
     } else if (fromId && toId) {
@@ -591,7 +608,15 @@ export class ConfigObjectsService {
         data: { deleted: true },
       });
       for (const updatedLink of updatedLinks) {
-        await configObjectAuditLog(user, workspaceId, updatedLink.id, "link", "delete", { prevVersion: updatedLink });
+        await configObjectAuditLog(
+          user,
+          workspaceId,
+          updatedLink.id,
+          "link",
+          "delete",
+          { prevVersion: updatedLink },
+          opts.req
+        );
         await this.emitConnectionEvent(user, workspaceId, opts.req, "connection_deleted", updatedLink);
       }
       return { deleted: updatedLinks.length > 0 };

--- a/webapps/console/lib/server/origin.ts
+++ b/webapps/console/lib/server/origin.ts
@@ -53,6 +53,44 @@ export function getClientIp(req: NextApiRequest): string {
   return req.socket.remoteAddress ?? "unknown";
 }
 
+export type RequestProvenance = { ip: string | null; headers: Record<string, string> | null };
+
+// Request headers we persist on audit-log rows to help identify the client
+// (SDK/CLI vs browser vs a raw API call) and, secondarily, for humans to
+// inspect. Deliberately excludes anything credential-bearing (authorization,
+// cookie). `x-jitsu-client` is the explicit signal jitsu-cli sends and the one
+// originFromAuth keys on; the rest are for manual inspection.
+const AUDIT_HEADER_ALLOWLIST = [
+  "user-agent",
+  "accept",
+  "content-type",
+  "x-jitsu-client",
+  "referer",
+  "origin",
+  "accept-language",
+] as const;
+
+/**
+ * Best-effort request provenance for an audit-log row: client IP (via
+ * {@link getClientIp}) plus an allowlisted subset of request headers. Everything
+ * is nullable — a missing `req` (internal callers) or absent headers yield
+ * `null`, which the audit column stores as-is. Never throws.
+ */
+export function extractRequestProvenance(req?: NextApiRequest): RequestProvenance {
+  if (!req) return { ip: null, headers: null };
+  const rawIp = getClientIp(req);
+  const ip = rawIp && rawIp !== "unknown" ? rawIp : null;
+
+  const headers: Record<string, string> = {};
+  for (const key of AUDIT_HEADER_ALLOWLIST) {
+    const v = req.headers[key];
+    if (v == null) continue;
+    const value = Array.isArray(v) ? v.join(", ") : v;
+    if (value) headers[key] = value;
+  }
+  return { ip, headers: Object.keys(headers).length > 0 ? headers : null };
+}
+
 export function getTopLevelDomain(requestDomain: string): string {
   const parts = requestDomain.split(".");
   if (parts.length < 2) {

--- a/webapps/console/lib/server/origin.ts
+++ b/webapps/console/lib/server/origin.ts
@@ -70,6 +70,16 @@ const AUDIT_HEADER_ALLOWLIST = [
   "accept-language",
 ] as const;
 
+// `referer` can carry secrets in its query string / fragment — invitation
+// tokens (`/accept?invite=…`), `__unsafe_token=…` URLs, etc. Keep only the
+// scheme+host+path so it stays useful as provenance without persisting those.
+// (`origin` is scheme+host only per spec, so it needs no stripping.)
+function sanitizeHeaderValue(key: string, value: string): string {
+  if (key !== "referer") return value;
+  const cut = value.search(/[?#]/);
+  return cut === -1 ? value : value.slice(0, cut);
+}
+
 /**
  * Best-effort request provenance for an audit-log row: client IP (via
  * {@link getClientIp}) plus an allowlisted subset of request headers. Everything
@@ -86,7 +96,7 @@ export function extractRequestProvenance(req?: NextApiRequest): RequestProvenanc
     const v = req.headers[key];
     if (v == null) continue;
     const value = Array.isArray(v) ? v.join(", ") : v;
-    if (value) headers[key] = value;
+    if (value) headers[key] = sanitizeHeaderValue(key, value);
   }
   return { ip, headers: Object.keys(headers).length > 0 ? headers : null };
 }

--- a/webapps/console/pages/api/[workspaceId]/config/profile-builder.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/profile-builder.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { NextApiRequest } from "next";
 import { createRoute, verifyAccessWithRole } from "../../../../lib/api";
 import { db } from "../../../../lib/server/db";
 import { ProfileBuilderDbModel } from "../../../../prisma/schema";
@@ -8,7 +9,7 @@ import { MASKED_SECRET } from "../../../../lib/schema/destinations";
 import { configObjectAuditLog } from "../../../../lib/server/audit-log";
 import { omitDeletedList } from "../../../../lib/server/omit-deleted";
 
-async function updateFunctionCode(user: any, workspaceId: string, pbId: string, code: string) {
+async function updateFunctionCode(user: any, workspaceId: string, pbId: string, code: string, req?: NextApiRequest) {
   const withFunc = await db.prisma().profileBuilder.findFirst({
     include: { functions: { include: { function: true } } },
     where: { id: pbId, workspaceId: workspaceId, deleted: false },
@@ -26,10 +27,15 @@ async function updateFunctionCode(user: any, workspaceId: string, pbId: string, 
         config: newConfig,
       },
     });
-    await configObjectAuditLog(user, workspaceId, func.functionId, "function", "update", {
-      prevVersion: func.function.config,
-      newVersion: newConfig,
-    });
+    await configObjectAuditLog(
+      user,
+      workspaceId,
+      func.functionId,
+      "function",
+      "update",
+      { prevVersion: func.function.config, newVersion: newConfig },
+      req
+    );
   } else {
     const func = await db.prisma().configurationObject.create({
       data: {
@@ -49,9 +55,7 @@ async function updateFunctionCode(user: any, workspaceId: string, pbId: string, 
         functionId: func.id,
       },
     });
-    await configObjectAuditLog(user, workspaceId, func.id, "function", "create", {
-      newVersion: func.config,
-    });
+    await configObjectAuditLog(user, workspaceId, func.id, "function", "create", { newVersion: func.config }, req);
   }
 }
 
@@ -66,6 +70,7 @@ const upsertHandler = async (ctx: any) => {
   const {
     body,
     user,
+    req,
     query: { workspaceId },
   } = ctx;
   await verifyAccessWithRole(user, workspaceId, "editEntities");
@@ -82,15 +87,20 @@ const upsertHandler = async (ctx: any) => {
 
   let createdOrUpdated;
   if (existingPb) {
-    await updateFunctionCode(user, workspaceId, existingPb.id, body.code);
+    await updateFunctionCode(user, workspaceId, existingPb.id, body.code, req);
     createdOrUpdated = await db.prisma().profileBuilder.update({
       where: { id: existingPb.id },
       data: { ...pb, deleted: false, workspaceId },
     });
-    await configObjectAuditLog(user, workspaceId, createdOrUpdated.id, "profilebuilder", "update", {
-      prevVersion: existingPb,
-      newVersion: createdOrUpdated,
-    });
+    await configObjectAuditLog(
+      user,
+      workspaceId,
+      createdOrUpdated.id,
+      "profilebuilder",
+      "update",
+      { prevVersion: existingPb, newVersion: createdOrUpdated },
+      req
+    );
   } else {
     createdOrUpdated = await db.prisma().profileBuilder.create({
       data: {
@@ -98,10 +108,16 @@ const upsertHandler = async (ctx: any) => {
         workspaceId,
       },
     });
-    await updateFunctionCode(user, workspaceId, createdOrUpdated.id, body.code);
-    await configObjectAuditLog(user, workspaceId, createdOrUpdated.id, "profilebuilder", "create", {
-      newVersion: createdOrUpdated,
-    });
+    await updateFunctionCode(user, workspaceId, createdOrUpdated.id, body.code, req);
+    await configObjectAuditLog(
+      user,
+      workspaceId,
+      createdOrUpdated.id,
+      "profilebuilder",
+      "create",
+      { newVersion: createdOrUpdated },
+      req
+    );
   }
 
   return { id: createdOrUpdated.id, created: !existingPb };
@@ -157,7 +173,7 @@ export const route = createRoute()
     summary: "Delete profile builder",
     tags: ["profile-builder"],
   })
-  .handler(async ({ user, query: { workspaceId, id } }) => {
+  .handler(async ({ user, req, query: { workspaceId, id } }) => {
     await verifyAccessWithRole(user, workspaceId, "deleteEntities");
     const existingPB = await db.prisma().profileBuilder.findFirst({
       where: { workspaceId: workspaceId, id, deleted: false },
@@ -178,15 +194,19 @@ export const route = createRoute()
           where: { id: func.id },
           data: { deleted: true },
         });
-        await configObjectAuditLog(user, workspaceId, func.id, "function", "delete", {
-          prevVersion: func,
-        });
+        await configObjectAuditLog(user, workspaceId, func.id, "function", "delete", { prevVersion: func }, req);
       }
     }
     await db.prisma().profileBuilder.update({ where: { id: existingPB.id }, data: { deleted: true } });
-    await configObjectAuditLog(user, workspaceId, existingPB.id, "profilebuilder", "delete", {
-      prevVersion: existingPB,
-    });
+    await configObjectAuditLog(
+      user,
+      workspaceId,
+      existingPB.id,
+      "profilebuilder",
+      "delete",
+      { prevVersion: existingPB },
+      req
+    );
     return { deleted: true };
   });
 

--- a/webapps/console/pages/api/[workspaceId]/config/profile-builder/init.ts
+++ b/webapps/console/pages/api/[workspaceId]/config/profile-builder/init.ts
@@ -33,7 +33,7 @@ export default createRoute()
     summary: "Initialize a default profile builder if none exists",
     tags: ["profile-builder"],
   })
-  .handler(async ({ user, query: { workspaceId } }) => {
+  .handler(async ({ user, req, query: { workspaceId } }) => {
     await verifyAccessWithRole(user, workspaceId, "editEntities");
 
     // Serialize concurrent /init calls for the same workspace via a
@@ -93,12 +93,24 @@ export default createRoute()
     // failure here doesn't roll back the user-visible bootstrap. Same
     // trade-off as the original code path.
     if (created.created && created.func && created.pb) {
-      await configObjectAuditLog(user, workspaceId, created.func.id, "function", "create", {
-        newVersion: created.func.config,
-      });
-      await configObjectAuditLog(user, workspaceId, created.pb.id, "profilebuilder", "create", {
-        newVersion: created.pb,
-      });
+      await configObjectAuditLog(
+        user,
+        workspaceId,
+        created.func.id,
+        "function",
+        "create",
+        { newVersion: created.func.config },
+        req
+      );
+      await configObjectAuditLog(
+        user,
+        workspaceId,
+        created.pb.id,
+        "profilebuilder",
+        "create",
+        { newVersion: created.pb },
+        req
+      );
     }
     return {
       profileBuilders: omitDeletedList(created.profileBuilders),

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -368,11 +368,11 @@ export default createRoute()
       // it CLI regardless of token type — mirrors originFromAuth, which checks
       // this header first. Legacy rows (requestHeaders NULL) simply don't match,
       // so they keep classifying by token identity.
-      // Case-insensitive to mirror originFromAuth exactly (it lowercases the
-      // header before comparing) — otherwise a `JITSU-CLI/…` row renders as CLI
-      // but this filter would miss it.
+      // Mirror originFromAuth exactly: case-insensitive "jitsu-cli/" prefix (the
+      // trailing slash is the delimiter that keeps "jitsu-client/…" from being
+      // mis-attributed to CLI).
       const cliHeaderMatch: Prisma.AuditLogWhereInput = {
-        requestHeaders: { path: ["x-jitsu-client"], string_starts_with: "jitsu-cli", mode: "insensitive" },
+        requestHeaders: { path: ["x-jitsu-client"], string_starts_with: "jitsu-cli/", mode: "insensitive" },
       };
       const notCliHeader: Prisma.AuditLogWhereInput = { NOT: cliHeaderMatch };
       const originClauses: Prisma.AuditLogWhereInput[] = [];

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -232,6 +232,8 @@ const ItemSchema = z.object({
   objectId: z.string().nullable().optional(),
   authType: z.string().nullable().optional(),
   tokenId: z.string().nullable().optional(),
+  ip: z.string().nullable().optional(),
+  requestHeaders: z.record(z.string()).nullable().optional(),
   token: z
     .object({
       id: z.string(),
@@ -362,26 +364,35 @@ export default createRoute()
         { tokenId: { not: { startsWith: CLI_PREFIX } } },
         ...(unprefixedCliTokenIds.length ? [{ tokenId: { notIn: unprefixedCliTokenIds } }] : []),
       ];
+      // An explicit X-Jitsu-Client: jitsu-cli/… header stored on the row makes
+      // it CLI regardless of token type — mirrors originFromAuth, which checks
+      // this header first. Legacy rows (requestHeaders NULL) simply don't match,
+      // so they keep classifying by token identity.
+      const cliHeaderMatch: Prisma.AuditLogWhereInput = {
+        requestHeaders: { path: ["x-jitsu-client"], string_starts_with: "jitsu-cli" },
+      };
+      const notCliHeader: Prisma.AuditLogWhereInput = { NOT: cliHeaderMatch };
       const originClauses: Prisma.AuditLogWhereInput[] = [];
       for (const o of requested) {
         switch (o) {
           case "mcp":
-            originClauses.push({ authType: "mcp" });
+            originClauses.push({ AND: [{ authType: "mcp" }, notCliHeader] });
             break;
           case "ui":
             // notIn also excludes NULL authType (SQL IN semantics), which is
             // correct: those rows render with no origin, not "UI".
-            originClauses.push({ authType: { notIn: ["bearer", "mcp"] } });
+            originClauses.push({ AND: [{ authType: { notIn: ["bearer", "mcp"] } }, notCliHeader] });
             break;
           case "cli":
-            originClauses.push({ authType: "bearer", OR: cliTokenMatch });
+            // Either the explicit client header, or a bearer request with a CLI token.
+            originClauses.push({ OR: [cliHeaderMatch, { authType: "bearer", OR: cliTokenMatch }] });
             break;
           case "api":
-            // Bearer, minus CLI. A bearer row with no tokenId (service-account
-            // token) resolves to "API" on the client, so include tokenId=null.
+            // Bearer, minus CLI (neither the header nor a CLI token). A bearer
+            // row with no tokenId (service-account token) resolves to "API" on
+            // the client, so include tokenId=null.
             originClauses.push({
-              authType: "bearer",
-              OR: [{ tokenId: null }, { AND: notCliToken }],
+              AND: [{ authType: "bearer" }, notCliHeader, { OR: [{ tokenId: null }, { AND: notCliToken }] }],
             });
             break;
         }
@@ -553,6 +564,8 @@ export default createRoute()
           objectId: r.objectId ?? null,
           authType: r.authType ?? null,
           tokenId: r.tokenId ?? null,
+          ip: r.ip ?? null,
+          requestHeaders: (r.requestHeaders as Record<string, string> | null) ?? null,
           token,
           changes: finalChanges,
           diff,

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -374,7 +374,19 @@ export default createRoute()
       const cliHeaderMatch: Prisma.AuditLogWhereInput = {
         requestHeaders: { path: ["x-jitsu-client"], string_starts_with: "jitsu-cli/", mode: "insensitive" },
       };
-      const notCliHeader: Prisma.AuditLogWhereInput = { NOT: cliHeaderMatch };
+      // NULL-safe negation of cliHeaderMatch. A plain `NOT cliHeaderMatch` is
+      // wrong here: for rows where requestHeaders is SQL NULL, or the
+      // x-jitsu-client key is absent, the JSON-path predicate is SQL NULL, and
+      // `NOT NULL` is NULL (not TRUE) — so those rows would be dropped from the
+      // api/ui/mcp filters. That's every legacy row and every non-CLI request.
+      // Enumerate the "not a CLI-header row" cases explicitly instead:
+      const notCliHeader: Prisma.AuditLogWhereInput = {
+        OR: [
+          { requestHeaders: { equals: Prisma.DbNull } }, // no headers stored (legacy rows)
+          { requestHeaders: { path: ["x-jitsu-client"], equals: Prisma.AnyNull } }, // key absent
+          { NOT: cliHeaderMatch }, // present, but not a jitsu-cli/ value
+        ],
+      };
       const originClauses: Prisma.AuditLogWhereInput[] = [];
       for (const o of requested) {
         switch (o) {

--- a/webapps/console/pages/api/audit-log.ts
+++ b/webapps/console/pages/api/audit-log.ts
@@ -368,8 +368,11 @@ export default createRoute()
       // it CLI regardless of token type — mirrors originFromAuth, which checks
       // this header first. Legacy rows (requestHeaders NULL) simply don't match,
       // so they keep classifying by token identity.
+      // Case-insensitive to mirror originFromAuth exactly (it lowercases the
+      // header before comparing) — otherwise a `JITSU-CLI/…` row renders as CLI
+      // but this filter would miss it.
       const cliHeaderMatch: Prisma.AuditLogWhereInput = {
-        requestHeaders: { path: ["x-jitsu-client"], string_starts_with: "jitsu-cli" },
+        requestHeaders: { path: ["x-jitsu-client"], string_starts_with: "jitsu-cli", mode: "insensitive" },
       };
       const notCliHeader: Prisma.AuditLogWhereInput = { NOT: cliHeaderMatch };
       const originClauses: Prisma.AuditLogWhereInput[] = [];

--- a/webapps/console/pages/api/auth/[...nextauth].ts
+++ b/webapps/console/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,10 @@
-import { nextAuthConfig } from "../../../lib/nextauth.config";
+import { nextAuthConfigForRequest } from "../../../lib/nextauth.config";
 import NextAuth from "next-auth";
+import type { NextApiRequest, NextApiResponse } from "next";
 
-export default NextAuth(nextAuthConfig);
+// Per-request invocation (NextAuth(req, res, options)) so the signOut/jwt
+// events in the config can attribute login/logout audit rows to the request's
+// ip + headers.
+export default async function auth(req: NextApiRequest, res: NextApiResponse) {
+  return NextAuth(req, res, nextAuthConfigForRequest(req));
+}

--- a/webapps/console/pages/api/auth/dynamic-oidc/callback.ts
+++ b/webapps/console/pages/api/auth/dynamic-oidc/callback.ts
@@ -265,7 +265,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     try {
       const userEmail = user.email || email;
-      await authAuditLog({ internalId: user.id, email: userEmail, name: user.name || userEmail }, "login", "oidc");
+      await authAuditLog(
+        { internalId: user.id, email: userEmail, name: user.name || userEmail },
+        "login",
+        "oidc",
+        undefined,
+        req
+      );
       await trackAuthEvent(
         { internalId: user.id, email: userEmail, name: user.name || userEmail, externalId: user.externalId },
         "login",

--- a/webapps/console/pages/api/auth/dynamic-oidc/logout.ts
+++ b/webapps/console/pages/api/auth/dynamic-oidc/logout.ts
@@ -29,7 +29,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               name: sessionData.name || sessionData.email || "",
             },
             "logout",
-            "oidc"
+            "oidc",
+            undefined,
+            req
           );
           await trackAuthEvent(
             {

--- a/webapps/console/pages/api/fb-auth/audit-login.ts
+++ b/webapps/console/pages/api/fb-auth/audit-login.ts
@@ -27,7 +27,7 @@ export const api: Api = {
     types: {
       body: z.object({ idToken: z.string() }),
     },
-    handle: async ({ body }) => {
+    handle: async ({ body, req }) => {
       try {
         const decoded = await firebase().auth().verifyIdToken(body.idToken);
         const email = decoded.email || "";
@@ -39,7 +39,7 @@ export const api: Api = {
           internalId = profile?.id;
         }
         if (internalId) {
-          await authAuditLog({ internalId, email, name: decoded.name || email }, "login", "firebase");
+          await authAuditLog({ internalId, email, name: decoded.name || email }, "login", "firebase", undefined, req);
           await trackAuthEvent(
             { internalId, email, name: decoded.name || email, externalId: decoded.uid },
             "login",

--- a/webapps/console/pages/api/fb-auth/revoke-session.ts
+++ b/webapps/console/pages/api/fb-auth/revoke-session.ts
@@ -18,7 +18,13 @@ export default createRoute()
   .handler(async ({ req, body, res, user }) => {
     await signOut(user.externalId);
     try {
-      await authAuditLog({ internalId: user.internalId, email: user.email, name: user.name }, "logout", "firebase");
+      await authAuditLog(
+        { internalId: user.internalId, email: user.email, name: user.name },
+        "logout",
+        "firebase",
+        undefined,
+        req
+      );
       await trackAuthEvent(
         { internalId: user.internalId, email: user.email, name: user.name, externalId: user.externalId },
         "logout",

--- a/webapps/console/pages/api/user/accept.ts
+++ b/webapps/console/pages/api/user/accept.ts
@@ -15,7 +15,7 @@ export default createRoute()
       workspaceId: z.string().optional(),
     }),
   })
-  .handler(async ({ user, body }) => {
+  .handler(async ({ user, req, body }) => {
     const token = await db.prisma().invitationToken.findFirst({ where: { token: body.invitationToken } });
     if (!token) {
       return { accepted: false, details: `Token ${body.invitationToken} was not found` };
@@ -60,7 +60,8 @@ export default createRoute()
       token.workspaceId,
       "joined",
       { userId: user.internalId, email: user.email },
-      { newRole: token.role || "owner" }
+      { newRole: token.role || "owner" },
+      req
     );
     return { accepted: true, workspaceName: workspace.name, workspaceId: workspace.id };
   })

--- a/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/index.ts
+++ b/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/index.ts
@@ -196,11 +196,17 @@ export const route = createRoute()
         prev.slug !== workspace.slug ||
         !isEqual(prev.featuresEnabled, workspace.featuresEnabled))
     ) {
-      await workspaceAuditLog(user, workspace.id, "updated", {
-        prevVersion: { name: prev.name, slug: prev.slug, featuresEnabled: prev.featuresEnabled },
-        newVersion: { name: workspace.name, slug: workspace.slug, featuresEnabled: workspace.featuresEnabled },
-        workspaceName: workspace.name,
-      });
+      await workspaceAuditLog(
+        user,
+        workspace.id,
+        "updated",
+        {
+          prevVersion: { name: prev.name, slug: prev.slug, featuresEnabled: prev.featuresEnabled },
+          newVersion: { name: workspace.name, slug: workspace.slug, featuresEnabled: workspace.featuresEnabled },
+          workspaceName: workspace.name,
+        },
+        req
+      );
     }
     if (onboarding === "true") {
       await withProductAnalytics(callback => callback.track("workspace_onboarded"), { user, workspace, req });

--- a/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/users/[userId]/role.ts
+++ b/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/users/[userId]/role.ts
@@ -20,7 +20,7 @@ const api: Api = {
       query: z.object({ workspaceIdOrSlug: z.string(), userId: z.string() }),
       body: z.object({ role: WorkspaceRolesZodType }),
     },
-    handle: async ({ user, body, query: { workspaceIdOrSlug, userId } }) => {
+    handle: async ({ user, req, body, query: { workspaceIdOrSlug, userId } }) => {
       const workspace = requireDefined(
         await getWorkspace(workspaceIdOrSlug),
         `Can't find workspace ${workspaceIdOrSlug}`
@@ -69,7 +69,8 @@ const api: Api = {
         workspace.id,
         "role-changed",
         { userId, email: targetUser?.email },
-        { prevRole, newRole: body.role }
+        { prevRole, newRole: body.role },
+        req
       );
 
       return { success: true, role: body.role };

--- a/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/users/index.ts
+++ b/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/users/index.ts
@@ -127,7 +127,8 @@ const api: Api = {
           workspace.id,
           "invited",
           { email: body.email },
-          { newRole: body.role || "owner" }
+          { newRole: body.role || "owner" },
+          req
         );
         return {
           token: token.token,
@@ -142,7 +143,7 @@ const api: Api = {
     types: {
       query: z.object({ email: z.string().optional(), userId: z.string().optional(), workspaceIdOrSlug: z.string() }),
     },
-    handle: async ({ user, query: { workspaceIdOrSlug, email, userId } }) => {
+    handle: async ({ user, req, query: { workspaceIdOrSlug, email, userId } }) => {
       const workspace = requireDefined(
         await getWorkspace(workspaceIdOrSlug),
         `Can't find workspace ${workspaceIdOrSlug}`
@@ -169,7 +170,7 @@ const api: Api = {
       // false `member-removed` security events from idempotent retries or
       // stale invitation cancels.
       if (removedCount > 0) {
-        await membershipAuditLog(user, workspace.id, "removed", { userId, email: targetEmail });
+        await membershipAuditLog(user, workspace.id, "removed", { userId, email: targetEmail }, undefined, req);
       }
       return { success: true };
     },

--- a/webapps/console/pages/api/workspace/index.ts
+++ b/webapps/console/pages/api/workspace/index.ts
@@ -197,7 +197,7 @@ export const route = createRoute()
       data: { deleted: true },
     });
 
-    await workspaceAuditLog(user, workspaceId, "deleted", { workspaceName: workspace.name });
+    await workspaceAuditLog(user, workspaceId, "deleted", { workspaceName: workspace.name }, req);
     await withProductAnalytics(p => p.track("workspace_deleted"), { user, workspace, req });
 
     return { message: `${workspace.name} deleted successfully`, status: 200 };

--- a/webapps/console/prisma/schema.prisma
+++ b/webapps/console/prisma/schema.prisma
@@ -272,16 +272,18 @@ model ConnectorPackage {
 }
 
 model AuditLog {
-  id          String   @id @default(cuid())
-  timestamp   DateTime @default(now()) /// @zod.custom(z.coerce.date())
-  type        String
-  severity    String?  @default("info")
-  userId      String?
-  workspaceId String?
-  objectId    String?
-  changes     Json?
-  authType    String?
-  tokenId     String?
+  id             String   @id @default(cuid())
+  timestamp      DateTime @default(now()) /// @zod.custom(z.coerce.date())
+  type           String
+  severity       String?  @default("info")
+  userId         String?
+  workspaceId    String?
+  objectId       String?
+  changes        Json?
+  authType       String?
+  tokenId        String?
+  ip             String?
+  requestHeaders Json?
 
   @@index(timestamp)
   @@index(type)


### PR DESCRIPTION
## Why

The Admin Audit Log's **Origin** badge (UI / API / CLI / MCP) is derived purely from the auth token's identity (`originFromAuth`). Confirmed against prod, this loses real provenance:

- CI `jitsu-cli deploy` runs authenticated with a **plain personal API key** carry no CLI marker, so they render as **API** even though they come from the SDK/CLI.
- The `AuditLog` table stored **no IP, no User-Agent, no headers** — only `authType` + `tokenId`. Once written, an SDK-via-API-key request was indistinguishable from any other REST call, with nothing to reclassify from.

## What

- **Schema:** two nullable, additive columns on `AuditLog` — `ip` and `requestHeaders` (JSON).
- **Capture:** `extractRequestProvenance(req)` (in `lib/server/origin.ts`, reusing the existing `getClientIp`) records the client IP plus an **allowlisted** set of headers (`user-agent`, `accept`, `content-type`, `x-jitsu-client`, `referer`, `origin`, `accept-language`). Credential headers (`authorization`, `cookie`) are never stored. Wired into all `configObjectAuditLog` / auth / membership / workspace writes via the `req` already threaded to those call sites.
- **Detection:** `originFromAuth` now checks `X-Jitsu-Client` first — a `jitsu-cli/…` value classifies the row as **CLI** regardless of which token authenticated it. Explicit signal only, no fuzzy User-Agent heuristics. The read-API origin filter mirrors the same precedence.
- **CLI:** `jitsu-cli` now sends `X-Jitsu-Client: jitsu-cli/<version>` on its requests (both `ApiClient` and the hand-rolled `deploy` fetches).
- **UI:** the captured IP + headers render in the expanded audit row.

Everything is best-effort/nullable — legacy rows keep classifying by token identity.

## ⚠️ Deploy ordering

The generated Prisma client selects the new columns, so **the DB must get the columns before this code reads them.** Run `prisma db push` (this repo uses `db push`, not migration files) against each environment as part of / before the deploy, otherwise `auditLog.findMany` will error. Columns are additive + nullable → no data loss, no backfill.

The `X-Jitsu-Client` classification only affects new rows once a jitsu-cli release ships the header; the console side works immediately for any client that sends it.

## Testing

Unit tests (`__tests__/unit/audit-provenance.test.ts`) cover the two non-obvious pieces most likely to break:
- `originFromAuth`'s `X-Jitsu-Client` precedence — overrides token-based origin, case-insensitive, only for `jitsu-cli`, else falls through. This is the contract the read-API SQL filter mirrors.
- `extractRequestProvenance`'s header allowlist never persisting credential headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)