### PR TITLE
JITSU-125 Show recent workspaces inline in the workspace switcher

### DIFF
--- a/webapps/console/components/PageLayout/WorkspacePageLayout.tsx
+++ b/webapps/console/components/PageLayout/WorkspacePageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactNode, useEffect, useState } from "react";
+import React, { PropsWithChildren, ReactNode, useEffect, useRef, useState } from "react";
 import { branding } from "../../lib/branding";
 import { HiSelector } from "react-icons/hi";
 import { FaDocker, FaSignOutAlt, FaUserCircle } from "react-icons/fa";
@@ -9,6 +9,8 @@ import styles from "./WorkspacePageLayout.module.css";
 import {
   Activity,
   BellIcon,
+  Building2,
+  Check,
   ChevronDown,
   ChevronUp,
   CreditCard,
@@ -40,6 +42,7 @@ import { NextRouter, useRouter } from "next/router";
 import Link from "next/link";
 import { getDomains, useAppConfig, useUser, useUserSessionControls, useWorkspace } from "../../lib/context";
 import { useApi } from "../../lib/useApi";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { Overlay } from "../Overlay/Overlay";
 import { WorkspaceNameAndSlugEditor } from "../WorkspaceNameAndSlugEditor/WorkspaceNameAndSlugEditor";
@@ -67,10 +70,75 @@ export type WorkspaceSelectorProps = {
   currentTitle: ReactNode;
 };
 
-function WorkspacesMenu(props: { jitsuClassicAvailable: boolean }) {
+type WorkspacesListResponse = {
+  workspaces: { id: string; name: string; slug?: string | null }[];
+  pagination: { totalCount: number; hasMore: boolean };
+};
+
+// The recent-workspaces query URL, shared between the fetch and the post-switch invalidation so the
+// two never drift out of sync.
+const WORKSPACES_LIST_URL = "/api/workspace?page=0&limit=10";
+
+function WorkspacesMenu(props: {
+  jitsuClassicAvailable: boolean;
+  workspacesData?: WorkspacesListResponse;
+  workspacesLoading: boolean;
+}) {
   const router = useRouter();
   const appConfig = useAppConfig();
+  const currentWorkspace = useWorkspace();
   const { data, error } = useApi(`/api/user/properties`);
+
+  // Inline workspace switcher. The server selects WHICH workspaces to show by last-used (the top 10),
+  // so the list is your most-relevant workspaces — but we render them ALPHABETICALLY, so the on-screen
+  // order is stable and never reshuffles when recency changes. "More" links to the full `/workspaces`
+  // page. Data is preloaded by WorkspaceSelector and passed in here, so the dropdown paints instantly.
+  const { workspacesData, workspacesLoading } = props;
+  const recentWorkspaces = [...(workspacesData?.workspaces ?? [])].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+  );
+  const hasMore = !!workspacesData?.pagination?.hasMore;
+  const moreCount = workspacesData ? Math.max(workspacesData.pagination.totalCount - recentWorkspaces.length, 0) : 0;
+
+  const workspaceItems: MenuProps["items"] = [];
+  if (workspacesLoading) {
+    workspaceItems.push({
+      key: "workspaces-loading",
+      disabled: true,
+      label: <span className="text-textDisabled text-sm">Loading workspaces…</span>,
+    });
+  } else {
+    for (const w of recentWorkspaces) {
+      const isCurrent = w.id === currentWorkspace.id;
+      workspaceItems.push({
+        key: `ws-${w.id}`,
+        label: (
+          <Link href={`/${w.slug || w.id}`} className="flex items-center justify-between gap-6">
+            <ButtonLabel iconSize="small" icon={<Building2 className="h-full w-full" />}>
+              {w.name}
+            </ButtonLabel>
+            {isCurrent && <Check className="h-4 w-4 text-primary shrink-0" />}
+          </Link>
+        ),
+      });
+    }
+    if (hasMore) {
+      workspaceItems.push({
+        key: "more-workspaces",
+        label: (
+          <Link href="/workspaces" className="flex items-center">
+            <ButtonLabel iconSize="small" icon={<Folders className="h-full w-full" />}>
+              More ({moreCount})
+            </ButtonLabel>
+          </Link>
+        ),
+      });
+    }
+  }
+  if (workspaceItems.length > 0) {
+    workspaceItems.push({ type: "divider", key: "workspaces-divider" });
+  }
+
   let additionalMenuItems: MenuItemType[] = [];
   if (error) {
     log.atWarn().log("Failed to load user properties", error);
@@ -103,6 +171,7 @@ function WorkspacesMenu(props: { jitsuClassicAvailable: boolean }) {
   return (
     <Menu
       items={[
+        ...workspaceItems,
         {
           key: "all-workspaces",
           label: (
@@ -134,11 +203,38 @@ function WorkspacesMenu(props: { jitsuClassicAvailable: boolean }) {
 
 export const WorkspaceSelector: React.FC<WorkspaceSelectorProps> = props => {
   const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const currentWorkspace = useWorkspace();
+  const firstWorkspaceEffect = useRef(true);
   //const classicProject = useClassicProject();
+
+  // Preload the recent-workspaces list on mount so the switcher paints instantly. Never revalidated
+  // while the dropdown is open (the effect below only fires on a workspace change, when the dropdown
+  // is closed), so the list never moves under the user.
+  const workspaces = useApi<WorkspacesListResponse>(WORKSPACES_LIST_URL);
+
+  // Switching workspaces bumps that workspace's `lastUsed` server-side, which can change WHICH
+  // workspaces fall in the "most recent" set the list is built from. Invalidate on workspace change
+  // so react-query refetches in the background — the dropdown is closed at switch time, so nothing
+  // moves on screen; the fresh set is ready for the next open. Skip the initial mount (the preload
+  // already fetched). Only set membership can change here; display order stays alphabetical.
+  useEffect(() => {
+    if (firstWorkspaceEffect.current) {
+      firstWorkspaceEffect.current = false;
+      return;
+    }
+    queryClient.invalidateQueries({ queryKey: ["GET", WORKSPACES_LIST_URL] });
+  }, [currentWorkspace.id, queryClient]);
 
   return (
     <Dropdown
-      dropdownRender={() => <WorkspacesMenu jitsuClassicAvailable={false} />}
+      dropdownRender={() => (
+        <WorkspacesMenu
+          jitsuClassicAvailable={false}
+          workspacesData={workspaces.data}
+          workspacesLoading={workspaces.isLoading}
+        />
+      )}
       trigger={["click"]}
       open={open}
       onOpenChange={open => setOpen(open)}

--- a/webapps/console/pages/api/workspace/index.ts
+++ b/webapps/console/pages/api/workspace/index.ts
@@ -1,5 +1,6 @@
 import { createRoute, verifyAccessWithRole } from "../../../lib/api";
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 import { db } from "../../../lib/server/db";
 import { requireDefined } from "juava";
 import { withProductAnalytics } from "../../../lib/server/telemetry";
@@ -56,15 +57,11 @@ export const route = createRoute()
       `User ${user.internalId} does not exist`
     );
 
-    const searchCondition = search
-      ? {
-          OR: [
-            { id: { contains: search, mode: "insensitive" as const } },
-            { name: { contains: search, mode: "insensitive" as const } },
-            { slug: { contains: search, mode: "insensitive" as const } },
-          ],
-        }
-      : {};
+    // Search matches workspace id / name / slug, case-insensitively. Kept as a raw fragment so it
+    // can be composed into the ordering query below (see comment there for why raw SQL).
+    const searchClause = search
+      ? Prisma.sql`AND (w.id ILIKE ${`%${search}%`} OR w.name ILIKE ${`%${search}%`} OR w.slug ILIKE ${`%${search}%`})`
+      : Prisma.empty;
 
     const totalCount = userModel.admin
       ? await db.prisma().workspace.count({
@@ -77,45 +74,44 @@ export const route = createRoute()
           },
         });
 
-    const baseList = userModel.admin
-      ? await db.prisma().workspace.findMany({
-          where: { deleted: false, ...searchCondition },
-          include: {
-            workspaceUserProperties: { where: { userId: userModel.id } },
-            _count: {
-              select: { configurationObject: { where: { deleted: false } } },
-            },
-          },
-          orderBy: { createdAt: "asc" },
-          skip: offset,
-          take: limit,
-        })
-      : (
-          await db.prisma().workspaceAccess.findMany({
-            where: {
-              userId: user.internalId,
-              workspace: { deleted: false, ...searchCondition },
-            },
-            include: { workspace: { include: { workspaceUserProperties: true } } },
-            orderBy: { createdAt: "asc" },
-            skip: offset,
-            take: limit,
-          })
-        ).map(({ workspace }) => workspace);
+    // Order by the current user's last-access time (most-recently-used first, never-opened last).
+    // `lastUsed` lives on WorkspaceUserProperties — a per-user, to-many relation on Workspace — so
+    // Prisma's `orderBy` can't express it (it only orders to-many relations by `_count`). Raw SQL
+    // with a LEFT JOIN drives the pagination window by `lastUsed` while keeping never-opened
+    // workspaces (they sort last via NULLS LAST). Non-admins are scoped by WorkspaceAccess; admins
+    // see every workspace plus its configuration-object count.
+    const order = Prisma.sql`ORDER BY wup."lastUsed" DESC NULLS LAST, w."createdAt" ASC LIMIT ${limit} OFFSET ${offset}`;
+    const rows: any[] = userModel.admin
+      ? await db.prisma().$queryRaw`
+          SELECT w.*, wup."lastUsed",
+            (SELECT count(*) FROM newjitsu."ConfigurationObject" co
+               WHERE co."workspaceId" = w.id AND co.deleted = false) AS entities
+          FROM newjitsu."Workspace" w
+          LEFT JOIN newjitsu."WorkspaceUserProperties" wup
+            ON wup."workspaceId" = w.id AND wup."userId" = ${user.internalId}
+          WHERE w.deleted = false ${searchClause}
+          ${order}`
+      : await db.prisma().$queryRaw`
+          SELECT w.*, wup."lastUsed"
+          FROM newjitsu."Workspace" w
+          JOIN newjitsu."WorkspaceAccess" wa
+            ON wa."workspaceId" = w.id AND wa."userId" = ${user.internalId}
+          LEFT JOIN newjitsu."WorkspaceUserProperties" wup
+            ON wup."workspaceId" = w.id AND wup."userId" = ${user.internalId}
+          WHERE w.deleted = false ${searchClause}
+          ${order}`;
 
-    const workspaces = baseList
-      .map(({ workspaceUserProperties, ...workspace }) =>
-        omitDeleted({
-          ...workspace,
-          lastUsed: workspaceUserProperties?.[0]?.lastUsed || undefined,
-          entities: userModel.admin ? workspace["_count"]?.configurationObject : undefined,
-        })
-      )
-      .sort((a, b) => (b.lastUsed?.getTime() || 0) - (a.lastUsed?.getTime() || 0))
-      // Result is validated against ListResultSchema *before* JSON serialization, where
-      // `lastUsed` is `z.string().datetime()`. Convert the Date to ISO here so validation
-      // passes on responses where lastUsed is populated.
-      .map(w => ({ ...w, lastUsed: w.lastUsed ? w.lastUsed.toISOString() : undefined }));
+    const workspaces = rows.map(row =>
+      omitDeleted({
+        ...row,
+        // Result is validated against ListResultSchema *before* JSON serialization, where
+        // `lastUsed` is `z.string().datetime()`. Convert the Date to ISO so validation passes.
+        lastUsed: row.lastUsed ? new Date(row.lastUsed).toISOString() : undefined,
+        // Postgres `count(*)` comes back as BigInt via $queryRaw, which fails `z.number()` and
+        // JSON serialization — coerce to a plain number.
+        entities: userModel.admin && row.entities != null ? Number(row.entities) : undefined,
+      })
+    );
 
     if (typeof page !== "undefined") {
       return {


### PR DESCRIPTION
## What

Switching workspaces took an extra hop: the switcher dropdown only linked to the `/workspaces` page. This lists the user's **most-recently-used workspaces inline** in the dropdown, so the common case is one click.

JITSU-125

## Changes

**Client — `WorkspacePageLayout.tsx` (`WorkspaceSelector` / `WorkspacesMenu`)**
- Renders up to 10 workspaces inline above the existing "All Workspaces" / "Create new" links, current one marked with a check; each links to `/{slug|id}`.
- **Selected by last-used, displayed alphabetically** — the set is your most relevant workspaces, but the on-screen order is stable (case-insensitive), so it never reshuffles under you when recency changes.
- **Preloaded on mount** (not on first click), so the dropdown paints instantly.
- **Refreshed in the background on workspace switch** via `queryClient.invalidateQueries` — the dropdown is closed at switch time, so set-membership updates off-screen with no flicker.
- `More (N)` link to `/workspaces` when there are more than shown.

**Server — `pages/api/workspace/index.ts`**
- `GET /api/workspace` now orders by the current user's **last-used** time at the DB level (raw-SQL `LEFT JOIN` on `WorkspaceUserProperties`, `ORDER BY lastUsed DESC NULLS LAST`), so `?page=0&limit=N` returns the true N most-recent. Previously the DB page was ordered by `createdAt` and only re-sorted in memory, so `?limit=10` returned the 10 oldest-created.
- No query-param or response-shape change; recency ordering is now the default for all callers (a strict improvement). Never-opened workspaces still appear, sorted last.

## Testing

- `pnpm codegen` + `tsc --noEmit` clean.
- Ran the console locally against a real DB: switcher lists workspaces, click routes into a workspace, order is stable alphabetically, "More" appears past 10.