### PR TITLE
JITSU-125 Dedupe switcher footer: single "All Workspaces (N)" link

### DIFF
--- a/webapps/console/components/PageLayout/WorkspacePageLayout.tsx
+++ b/webapps/console/components/PageLayout/WorkspacePageLayout.tsx
@@ -12,6 +12,7 @@ import {
   Building2,
   Check,
   ChevronDown,
+  ChevronRight,
   ChevronUp,
   CreditCard,
   FilePlus,
@@ -97,8 +98,10 @@ function WorkspacesMenu(props: {
   const recentWorkspaces = [...(workspacesData?.workspaces ?? [])].sort((a, b) =>
     a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
   );
-  const hasMore = !!workspacesData?.pagination?.hasMore;
-  const moreCount = workspacesData ? Math.max(workspacesData.pagination.totalCount - recentWorkspaces.length, 0) : 0;
+  // When the user has more workspaces than we list inline, a single "View all workspaces" action
+  // (with the total) links to the full page. When they all fit, we just show them — no extra link.
+  const totalCount = workspacesData?.pagination?.totalCount ?? 0;
+  const hasMore = totalCount > recentWorkspaces.length;
 
   const workspaceItems: MenuProps["items"] = [];
   if (workspacesLoading) {
@@ -118,18 +121,6 @@ function WorkspacesMenu(props: {
               {w.name}
             </ButtonLabel>
             {isCurrent && <Check className="h-4 w-4 text-primary shrink-0" />}
-          </Link>
-        ),
-      });
-    }
-    if (hasMore) {
-      workspaceItems.push({
-        key: "more-workspaces",
-        label: (
-          <Link href="/workspaces" className="flex items-center">
-            <ButtonLabel iconSize="small" icon={<Folders className="h-full w-full" />}>
-              More ({moreCount})
-            </ButtonLabel>
           </Link>
         ),
       });
@@ -172,16 +163,24 @@ function WorkspacesMenu(props: {
     <Menu
       items={[
         ...workspaceItems,
-        {
-          key: "all-workspaces",
-          label: (
-            <Link href="/workspaces" className="flex items-center">
-              <ButtonLabel iconSize="small" icon={<Folders className="w-full h-full" />}>
-                All Workspaces
-              </ButtonLabel>
-            </Link>
-          ),
-        },
+        ...(hasMore
+          ? [
+              {
+                key: "view-all-workspaces",
+                label: (
+                  <Link href="/workspaces" className="flex items-center justify-between gap-6">
+                    <ButtonLabel iconSize="small" icon={<Folders className="h-full w-full" />}>
+                      View all workspaces
+                    </ButtonLabel>
+                    <span className="flex items-center gap-1 text-textLight text-xs shrink-0">
+                      {totalCount.toLocaleString("en-US")}
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    </span>
+                  </Link>
+                ),
+              },
+            ]
+          : []),
         {
           key: "new-workspace",
           label: (


### PR DESCRIPTION
Follow-up to #1421 (that PR merged before this commit synced into it, so this change was left behind).

The switcher dropdown showed **two** links to `/workspaces` — a "More (N)" item **and** "All Workspaces". This removes the duplicate "More" item and folds the count into the single "All Workspaces" link, formatted with a thousands separator and shown only when there are more workspaces than listed inline:

- Before: `More (5738)` + `All Workspaces`
- After: `All Workspaces (5,748)`

JITSU-125