### PR TITLE
JITSU-132 Revamp README: lead with Cloud and MCP, refresh Bulker README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,64 @@
+# Repository Layout
+
+This is a monorepo spanning Go and TypeScript.
+
+```
+bulker/            Go services
+  bulkerapp/         Bulker — warehouse ingestion service
+  ingest/            HTTP ingest endpoint
+  sync-controller/   Connector sync orchestration
+  bulkerlib/         Core ingestion library
+  connectors/        Warehouse connectors (ClickHouse, BigQuery, Redshift, Snowflake, S3, GCS, …)
+
+services/
+  rotor/             Event routing, transformation, function execution
+
+webapps/
+  console/           Admin UI (Next.js), Management API, MCP server
+
+libs/
+  jitsu-js/          Browser + Node.js SDK (@jitsu/js)
+  jitsu-react/       React bindings (@jitsu/jitsu-react)
+  functions/         Functions runtime (@jitsu/functions-lib)
+  juava/             Shared TypeScript utilities
+
+cli/jitsu-cli/     Developer CLI (jitsu-cli on npm)
+types/protocols/   Shared TypeScript protocols (@jitsu/protocols)
+helm/              Helm chart
+docker/            Docker Compose setup (deprecated)
+```
+
 # Prerequisites
 
 - `node: >=22`
 - `npx`
 - `pnpm: >= 10`
 - `docker: >= 19.03.0`
+- `go: 1.26` — for the Go services; the repo uses Go workspaces via `go.work`
 
 # Commands
 
 - `pnpm install` - Install dependencies
+- `pnpm codegen` - Generate the Prisma client + zod schemas. Required once after a fresh checkout
+  (or a new worktree) before anything else will build
 - `pnpm build` - Build the project
+  - `pnpm build:turbo` - Same, orchestrated by Turbo
 - `pnpm format` - Apply prettier to the project, only to changed files
   - `pnpm format:check` - Check if prettier needs to be applied, check only changed files
   - `pnpm format:check:all` - Check if prettier needs to be applied. Check all files
   - `pnpm format:all` - Same as `pnpm format`, but check all files, regardless of changes
 - `pnpm typecheck` - Run typecheck
+  - `pnpm typecheck:turbo` - Same, orchestrated by Turbo
 - `pnpm lint` - Run linter
 - `pnpm test` - Run tests
+- `pnpm console:dev` - Run just the console
+
+For the Go services, inside `bulker/`:
+
+```bash
+go build ./...
+go test ./...
+```
 
 # Local Dev Env
 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,14 @@
 ## What is Jitsu?
 
 Jitsu collects event data from your websites, apps and servers, and delivers it to your data
-warehouse and to whatever other tools you use. It covers the same ground as Segment, with a few
-differences that tend to matter.
+warehouse and to whatever other tools you use. It covers the same ground as Segment, but it's
+MIT-licensed and self-hostable, so the whole pipeline can run inside your own infrastructure —
+or on [Jitsu Cloud](https://use.jitsu.com), same software, hosted.
 
-It's open source, MIT-licensed, and you can run it yourself. Self-host Jitsu and the entire pipeline
-— collection, processing, delivery — stays inside your own infrastructure, with no third party in
-the path. If you'd rather not run it, [Jitsu Cloud](https://use.jitsu.com) is the same software,
-hosted.
-
-Data lands in the warehouse in minutes rather than hours. Segment loads warehouses on a schedule —
-once or twice a day on most plans, hourly at the very best. Jitsu lets you set the delivery mode per
-destination: batches as frequent as one minute for warehouses that would rather be written to in
-bulk (most of them), or row-by-row streaming where the destination handles it well.
-
-And you pay per event, not per user. Segment bills by Monthly Tracked User, so the bill scales with
-audience size no matter how much data each person actually generates. Jitsu bills by event volume,
-which is easier to predict and usually cheaper.
+Data lands in minutes, not hours: Segment loads warehouses once or twice a day (hourly at best),
+while Jitsu delivers per destination in batches as frequent as a minute, or row-by-row where that
+suits the destination. And billing is per event rather than per Monthly Tracked User, so it tracks
+data volume instead of audience size.
 
 A typical Jitsu setup gives you:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ A typical Jitsu setup gives you:
   [destination catalog](https://jitsu.com/docs/destinations/catalog).
 - **[Functions](https://jitsu.com/docs/functions)** — JavaScript that runs on every event to filter,
   transform, and enrich it before delivery.
+  - Write them in the browser, or build and deploy them from your own repo with the
+    [Jitsu CLI](https://jitsu.com/docs/jitsu-cli) — `jitsu-cli init` scaffolds a TypeScript project
+    with tests, and `jitsu-cli deploy` ships it to your workspace. Use whatever tooling you like:
+    TypeScript, npm libraries, your own test suite, and your normal CI.
 - **Connector syncs** — pull data *into* your warehouse from third-party sources (Airbyte-compatible
   connectors).
 - **A user identity graph and profile builder**, built automatically from the event stream.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Jitsu is a handful of independently scalable services:
 Backed by Postgres (configuration), Kafka/Redpanda (event bus), ClickHouse (live events and
 metrics), and MongoDB (profiles).
 
-[Bulker](https://github.com/jitsucom/bulker) is also usable standalone if you just want a warehouse
+[Bulker](./bulker) is also usable standalone if you just want a warehouse
 ingestion engine and are comfortable with low-level APIs.
 
 ## Self-hosting

--- a/README.md
+++ b/README.md
@@ -33,9 +33,19 @@
 ## What is Jitsu?
 
 Jitsu collects event data from your websites, apps and servers, and streams it — in real time — to
-your data warehouse and to whatever other tools you use. Think of it as a warehouse-first,
-open-source alternative to Segment: the raw data lands in **your** storage, in your account, with no
-vendor lock-in and no sampling.
+your data warehouse and to whatever other tools you use. It covers the same ground as Segment, with
+three differences that tend to matter:
+
+- **It's open source, and you can run it yourself.** Jitsu is MIT-licensed. Self-host it and the
+  entire pipeline — collection, processing, delivery — runs inside your own infrastructure, with no
+  third party in the path and no per-event vendor to trust. Or use
+  [Jitsu Cloud](https://use.jitsu.com) and skip the ops.
+- **Warehouse delivery is streaming, not batched.** Segment loads warehouses on a schedule — once or
+  twice a day on most plans, hourly at the very best. Jitsu writes events to your warehouse as they
+  arrive, so your tables are seconds behind reality rather than hours.
+- **You pay per event, not per user.** Segment bills by Monthly Tracked User, so cost scales with
+  audience size regardless of how much data each person generates. Jitsu bills by event volume,
+  which is usually much cheaper and always easier to predict.
 
 A typical Jitsu setup gives you:
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ or on [Jitsu Cloud](https://use.jitsu.com), same software, hosted.
 
 Data lands in minutes, not hours: Segment loads warehouses once or twice a day (hourly at best),
 while Jitsu delivers per destination in batches as frequent as a minute, or row-by-row where that
-suits the destination. And billing is per event rather than per Monthly Tracked User, so it tracks
-data volume instead of audience size.
+suits the destination. And where Segment bills by Monthly Tracked User, Jitsu Cloud bills by event
+volume, so the bill tracks data rather than audience size — while self-hosting has no usage billing
+at all.
 
 A typical Jitsu setup gives you:
 

--- a/README.md
+++ b/README.md
@@ -32,27 +32,30 @@
 
 ## What is Jitsu?
 
-Jitsu collects event data from your websites, apps and servers, and streams it — in real time — to
-your data warehouse and to whatever other tools you use. It covers the same ground as Segment, with
-three differences that tend to matter:
+Jitsu collects event data from your websites, apps and servers, and delivers it to your data
+warehouse and to whatever other tools you use. It covers the same ground as Segment, with a few
+differences that tend to matter.
 
-- **It's open source, and you can run it yourself.** Jitsu is MIT-licensed. Self-host it and the
-  entire pipeline — collection, processing, delivery — runs inside your own infrastructure, with no
-  third party in the path and no per-event vendor to trust. Or use
-  [Jitsu Cloud](https://use.jitsu.com) and skip the ops.
-- **Warehouse delivery is streaming, not batched.** Segment loads warehouses on a schedule — once or
-  twice a day on most plans, hourly at the very best. Jitsu writes events to your warehouse as they
-  arrive, so your tables are seconds behind reality rather than hours.
-- **You pay per event, not per user.** Segment bills by Monthly Tracked User, so cost scales with
-  audience size regardless of how much data each person generates. Jitsu bills by event volume,
-  which is usually much cheaper and always easier to predict.
+It's open source, MIT-licensed, and you can run it yourself. Self-host Jitsu and the entire pipeline
+— collection, processing, delivery — stays inside your own infrastructure, with no third party in
+the path. If you'd rather not run it, [Jitsu Cloud](https://use.jitsu.com) is the same software,
+hosted.
+
+Data lands in the warehouse in minutes rather than hours. Segment loads warehouses on a schedule —
+once or twice a day on most plans, hourly at the very best. Jitsu lets you set the delivery mode per
+destination: batches as frequent as one minute for warehouses that would rather be written to in
+bulk (most of them), or row-by-row streaming where the destination handles it well.
+
+And you pay per event, not per user. Segment bills by Monthly Tracked User, so the bill scales with
+audience size no matter how much data each person actually generates. Jitsu bills by event volume,
+which is easier to predict and usually cheaper.
 
 A typical Jitsu setup gives you:
 
 - **Event collection** from the browser, mobile, or the server, via
   [SDKs, an HTTP API, or a drop-in Segment proxy](https://jitsu.com/docs/sending-data).
-- **Real-time streaming to destinations** — ClickHouse, BigQuery, Snowflake, Redshift, Postgres, S3,
-  GCS, and dozens of SaaS tools. See the
+- **Delivery to destinations** — ClickHouse, BigQuery, Snowflake, Redshift, Postgres, S3, GCS, and
+  dozens of SaaS tools, streamed or micro-batched depending on what the destination prefers. See the
   [destination catalog](https://jitsu.com/docs/destinations/catalog).
 - **[Functions](https://jitsu.com/docs/functions)** — JavaScript that runs on every event to filter,
   transform, and enrich it before delivery.

--- a/README.md
+++ b/README.md
@@ -113,33 +113,8 @@ loop, without a human in the middle.
 claude mcp add --transport http jitsu https://use.jitsu.com/mcp
 ```
 
-**Claude Desktop** — Settings → Connectors → *Add custom connector*, name it `Jitsu`, URL
-`https://use.jitsu.com/mcp`, then hit *Connect*.
-
-**Cursor** (`~/.cursor/mcp.json`, or `.cursor/mcp.json` in a project)
-
-```json
-{
-  "mcpServers": {
-    "jitsu": {
-      "url": "https://use.jitsu.com/mcp"
-    }
-  }
-}
-```
-
-**VS Code** (`.vscode/mcp.json`)
-
-```json
-{
-  "servers": {
-    "jitsu": {
-      "type": "http",
-      "url": "https://use.jitsu.com/mcp"
-    }
-  }
-}
-```
+Other clients (Claude Desktop, Cursor, VS Code) take the same URL — see
+[jitsu.com/docs/mcp](https://jitsu.com/docs/mcp) for their setup.
 
 ### Authentication
 
@@ -147,29 +122,21 @@ Interactive clients use **OAuth 2.1** — no API key to manage. The first tool c
 tab asking you to approve the connection; tokens are scoped, listed, and revocable from your account
 settings page.
 
-For headless environments (CI, cron, servers), generate a personal API key on the user settings page
-and pass it as a header:
+Headless environments (CI, cron, servers) use a personal API key instead — generate one on the user
+settings page and pass it as `Authorization: Bearer <keyId>:<keySecret>`:
 
 ```bash
 claude mcp add --transport http jitsu https://use.jitsu.com/mcp \
   --header "Authorization: Bearer $JITSU_API_KEY"
 ```
 
-where `JITSU_API_KEY` is `<keyId>:<keySecret>`.
-
 ### What the agent can do
 
-25 tools, grouped roughly like this:
-
-| Area                     | Tools                                                                                                            |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| Workspaces & config      | `list_workspaces`, `list_resources`, `get_resource`, `get_resource_schema`, `create_resource`, `update_resource`, `delete_resource` |
-| Events & debugging       | `list_event_sources`, `query_events`, `run_function`, `test_connection`                                            |
-| Connector syncs          | `run_sync`, `cancel_sync`, `list_sync_tasks`, `get_sync_logs`, `get_sync_state`, `reset_sync_state`                |
-| Source setup             | `get_connector_spec`, `discover_streams`, `check_source_credentials`, `get_source_check_result`                    |
-| Profiles & stats         | `run_profile_builder`, `get_event_stat`, `get_sync_stat`, `get_profile_builder_stats`                              |
-
-Full reference: **[jitsu.com/docs/mcp](https://jitsu.com/docs/mcp)**.
+25 tools, covering everything the console does: read and write workspace configuration
+(destinations, streams, connections, functions), query Live Events and function logs, run and cancel
+connector syncs, discover source streams and inspect sync state, execute functions and profile
+builders against test data, and pull event and sync statistics. Full reference:
+[jitsu.com/docs/mcp](https://jitsu.com/docs/mcp).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Jitsu 2.0
-
-<p align="center">
-👉<b>Looking for Jitsu Classic? Switch to 
-<a href="https://github.com/jitsucom/jitsu/tree/master">classic branch</a>, and read about <a href="[https://docs.jitsu.com/jitsu-classic](https://jitsu.com/blog/jitsu-next">Jitsu Classic and Jitsu Next differences</a></b>
-</p>
 <p align="center">
 <img src="https://github.com/jitsucom/jitsu/blob/newjitsu/.readme-assets/github-hero-light-mode.png?raw=true#gh-light-mode-only" />
 <img src="https://github.com/jitsucom/jitsu/blob/newjitsu/.readme-assets/github-hero-dark-mode.png?raw=true#gh-dark-mode-only" />
 </p>
+
 <p align="center">
-<b><a href="https://jitsu.com">Learn more »</a></b> 
-</p>
-<p align="center">
-<a href="https://jitsu.com/slack">Slack</a> · <a href="https://jitsu.com/">Website</a> · <a href="https://docs.jitsu.com">Docs</a> · <a href="https://github.com/jitsucom/jitsu/blob/newjitsu/LICENSE">MIT License</a> · <b><a href="https://docs.jitsu.com/self-hosting">Self-hosting</a></b>
+<b>Open-source event data platform. An alternative to Segment.</b>
 </p>
 
----
 <p align="center">
+<a href="https://jitsu.com">Website</a> ·
+<a href="https://jitsu.com/docs">Docs</a> ·
+<a href="https://jitsu.com/docs/mcp">MCP Server</a> ·
+<a href="https://use.jitsu.com">Jitsu Cloud</a> ·
+<a href="https://jitsu.com/docs/self-hosting">Self-hosting</a> ·
+<a href="https://jitsu.com/slack">Slack</a> ·
+<a href="https://github.com/jitsucom/jitsu/blob/newjitsu/LICENSE">MIT License</a>
+</p>
 
+<p align="center">
 <a href="https://news.ycombinator.com/item?id=29106082">
   <img
     style="width: 200px; height: 43px;" width="200" height="43"
@@ -28,78 +28,215 @@
 <a href="https://www.producthunt.com/posts/jitsu-2?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-jitsu&#0045;2" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=297526&theme=neutral" alt="Jitsu - Open&#0045;source&#0032;real&#0045;time&#0032;data&#0032;collection&#0032;platform | Product Hunt" style="width: 200px; height: 43px;" width="200" height="43" /></a>
 </p>
 
-# What is Jitsu?
+---
 
-Jitsu is a tool for collecting event data from your websites, apps and stream them to your data warehouse or other services.
-It is a self-hosted, open-source alternative to Segment.
+## What is Jitsu?
+
+Jitsu collects event data from your websites, apps and servers, and streams it — in real time — to
+your data warehouse and to whatever other tools you use. Think of it as a warehouse-first,
+open-source alternative to Segment: the raw data lands in **your** storage, in your account, with no
+vendor lock-in and no sampling.
+
+A typical Jitsu setup gives you:
+
+- **Event collection** from the browser, mobile, or the server, via
+  [SDKs, an HTTP API, or a drop-in Segment proxy](https://jitsu.com/docs/sending-data).
+- **Real-time streaming to destinations** — ClickHouse, BigQuery, Snowflake, Redshift, Postgres, S3,
+  GCS, and dozens of SaaS tools. See the
+  [destination catalog](https://jitsu.com/docs/destinations/catalog).
+- **[Functions](https://jitsu.com/docs/functions)** — JavaScript that runs on every event to filter,
+  transform, and enrich it before delivery.
+- **Connector syncs** — pull data *into* your warehouse from third-party sources (Airbyte-compatible
+  connectors).
+- **A user identity graph and profile builder**, built automatically from the event stream.
+- **[Live Events](https://jitsu.com/docs/features/live-events)** — see every event, function log and
+  destination write as it happens, which makes debugging a pipeline a matter of seconds rather than
+  days.
+- **An [MCP server](https://jitsu.com/docs/mcp)**, so an AI agent can configure and operate all of
+  the above.
 
 <p align="center">
 <img src="https://github.com/jitsucom/jitsu/blob/newjitsu/.readme-assets/overview-screenshot.png?raw=true">
 </p>
 
-# Quick start
+## Get started with Jitsu Cloud
 
-## 1. Install Jitsu
+The fastest way to run Jitsu is **[Jitsu Cloud](https://use.jitsu.com)** — we host and scale it for
+you.
 
-### Docker Compose
+- **Free tier: 200k events/month**, no credit card required.
+- Unlimited destinations and unlimited captured events on every plan.
+- A **free ClickHouse instance** is included, so you can go from zero to queryable event data
+  without provisioning a warehouse first.
+- Custom domains, events debugger, and the Configuration API on the free tier too.
 
-The fastest way to install jitsu is [docker compose](https://docs.jitsu.com/self-hosting/quick-start):
+See [pricing](https://jitsu.com/pricing) for the full breakdown, or jump straight into the
+[Quick Start guide](https://jitsu.com/docs).
+
+Once you have a workspace:
+
+1. **Create a site** (a stream) and grab your write key.
+2. **Add a destination** — ClickHouse, BigQuery, Snowflake, Postgres, S3, or anything from the
+   [catalog](https://jitsu.com/docs/destinations/catalog).
+3. **Start sending events** using one of the methods below.
+
+### Sending events
+
+| Method                                                                  | Use it for                                        |
+| ----------------------------------------------------------------------- | ------------------------------------------------- |
+| [HTML snippet](https://jitsu.com/docs/sending-data/html)                | Any website, no build step                        |
+| [`@jitsu/js`](https://jitsu.com/docs/sending-data/npm)                  | Isomorphic — works in the browser and in Node.js  |
+| [`@jitsu/jitsu-react`](https://jitsu.com/docs/sending-data/react)       | React and Next.js apps                            |
+| [HTTP API](https://jitsu.com/docs/sending-data/http)                    | Any language, backend services                    |
+| [Segment proxy](https://jitsu.com/docs/sending-data/segment-proxy)      | Migrating off Segment without touching client code |
+
+Everything the UI does is also available through the
+[Management API](https://jitsu.com/docs/management-api) and the
+[Jitsu CLI](https://jitsu.com/docs/jitsu-cli).
+
+## Jitsu MCP Server
+
+Jitsu ships a [Model Context Protocol](https://modelcontextprotocol.io) server, so coding agents and
+AI assistants can build and operate your data pipelines directly — no clicking through the UI.
+
+An agent connected to Jitsu can set up a destination, wire a connection, send a test event, read the
+resulting Live Events, notice that a function threw, fix the function, and re-run it — the full
+loop, without a human in the middle.
+
+**Endpoint:** `https://use.jitsu.com/mcp` (or `<your-console-url>/mcp` when self-hosting).
+
+### Connect your client
+
+**Claude Code**
 
 ```bash
-# Clone the repository
-git clone --depth 1 https://github.com/jitsucom/jitsu
-cd jitsu/docker
-# Optionally, edit .env.local file and set env variables, see README.md in `docker` folder
-touch .env.local
-#
-
+claude mcp add --transport http jitsu https://use.jitsu.com/mcp
 ```
 
-### Deploy at scale
+**Claude Desktop** — Settings → Connectors → *Add custom connector*, name it `Jitsu`, URL
+`https://use.jitsu.com/mcp`, then hit *Connect*.
 
-For productions deployments, [read this guide](https://docs.jitsu.com/self-hosting/production-deployment)
+**Cursor** (`~/.cursor/mcp.json`, or `.cursor/mcp.json` in a project)
 
-### Jitsu Cloud
+```json
+{
+  "mcpServers": {
+    "jitsu": {
+      "url": "https://use.jitsu.com/mcp"
+    }
+  }
+}
+```
 
-**Cloud version is available at [use.jitsu.com](https://use.jitsu.com). It's free up to 200k events per month, and
-comes with a [FREE ClickHouse instance](https://next.jitsu.com/features/clickhouse)**
+**VS Code** (`.vscode/mcp.json`)
 
-## 2. Configure Jitsu
+```json
+{
+  "servers": {
+    "jitsu": {
+      "type": "http",
+      "url": "https://use.jitsu.com/mcp"
+    }
+  }
+}
+```
 
-* Follow [Quick Start Guide](https://docs.jitsu.com/)
-* Get yourself familiar with [Jitsu Concepts](https://docs.jitsu.com/concepts)
-* Browse [Destination Catalog](https://next.jitsu.com/integrations/destinations)
+### Authentication
 
-## 3. Send events
+Interactive clients use **OAuth 2.1** — no API key to manage. The first tool call opens a browser
+tab asking you to approve the connection; tokens are scoped, listed, and revocable from your account
+settings page.
 
-[Send events](https://docs.jitsu.com/sending-data/). Multiple SDKs are available:
+For headless environments (CI, cron, servers), generate a personal API key on the user settings page
+and pass it as a header:
 
-* [HTML Snippet](https://docs.jitsu.com/sending-data/html)
-* [React](https://docs.jitsu.com/sending-data/react) (including Next.js)
-* [NPM Package](https://docs.jitsu.com/sending-data/npm). Yes, it's isomorphic and works in server-side Node.js too!
-* [HTTP API](https://docs.jitsu.com/sending-data/http)
-* [Segment Proxy](https://docs.jitsu.com/sending-data/segment-proxy)
+```bash
+claude mcp add --transport http jitsu https://use.jitsu.com/mcp \
+  --header "Authorization: Bearer $JITSU_API_KEY"
+```
 
-# 🚚 Bulker
+where `JITSU_API_KEY` is `<keyId>:<keySecret>`.
 
-Jitsu is based on [Bulker](https://github.com/jitsucom/bulker), an open-source data warehouse ingestion engine. 
-Bulker can be used as a standalone tool, if you're comfortable working with low-level APIs.
+### What the agent can do
 
-# Contributing
+25 tools, grouped roughly like this:
 
-Please see our [contributing guidelines](CONTRIBUTING.md).
+| Area                     | Tools                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Workspaces & config      | `list_workspaces`, `list_resources`, `get_resource`, `get_resource_schema`, `create_resource`, `update_resource`, `delete_resource` |
+| Events & debugging       | `list_event_sources`, `query_events`, `run_function`, `test_connection`                                            |
+| Connector syncs          | `run_sync`, `cancel_sync`, `list_sync_tasks`, `get_sync_logs`, `get_sync_state`, `reset_sync_state`                |
+| Source setup             | `get_connector_spec`, `discover_streams`, `check_source_credentials`, `get_source_check_result`                    |
+| Profiles & stats         | `run_profile_builder`, `get_event_stat`, `get_sync_stat`, `get_profile_builder_stats`                              |
 
-## Development Notes
+Full reference: **[jitsu.com/docs/mcp](https://jitsu.com/docs/mcp)**.
 
+## Architecture
 
+Jitsu is a handful of independently scalable services:
 
+| Service            | Stack       | What it does                                                              |
+| ------------------ | ----------- | ------------------------------------------------------------------------- |
+| **ingest**         | Go          | HTTP endpoint that accepts events and writes them to Kafka                |
+| **rotor**          | TypeScript  | Routes events, runs Functions, applies destination-specific transforms    |
+| **bulker**         | Go          | High-throughput warehouse ingestion — batching, schema management, retries |
+| **sync-controller**| Go          | Orchestrates connector syncs (pulling data from third-party sources)      |
+| **console**        | Next.js     | Admin UI, Management API, and the MCP server                              |
 
+Backed by Postgres (configuration), Kafka/Redpanda (event bus), ClickHouse (live events and
+metrics), and MongoDB (profiles).
 
+[Bulker](https://github.com/jitsucom/bulker) is also usable standalone if you just want a warehouse
+ingestion engine and are comfortable with low-level APIs.
 
+## Self-hosting
 
+Jitsu is MIT-licensed and fully self-hostable, with no usage limits and no feature gating. Cloud is
+the path of least resistance; self-hosting is for when you need the data to stay inside your own
+infrastructure.
 
+### Quick start (Kubernetes / Minikube)
 
+The development Helm chart is the recommended way to get a complete stack running locally. You'll
+need [Minikube](https://minikube.sigs.k8s.io/docs/start/) (a single-node Kubernetes cluster on your
+machine) and [Helm v3+](https://helm.sh/docs/intro/install/):
 
+```bash
+git clone -b newjitsu --single-branch https://github.com/jitsucom/jitsu
+cd jitsu/helm
 
+minikube start          # give the VM at least 8GB RAM
+./dev-deploy.sh deploy
+./dev-deploy.sh tunnel  # in a second terminal
+```
 
+`./dev-deploy.sh tunnel` runs `minikube tunnel`, which routes the cluster's LoadBalancer services to
+`localhost` so you can reach them from your browser — console on `:3000`, ingest on `:3049`, bulker
+on `:3042`, rotor on `:3401`, plus Postgres, ClickHouse, MongoDB and Kafka. It asks for `sudo` (it
+binds privileged ports) and has to keep running in its own terminal for the whole session.
 
+The console will be at http://localhost:3000. Full instructions:
+[Self-hosting Quick Start](https://jitsu.com/docs/self-hosting/quick-start).
+
+### Production
+
+For real deployments, read the
+[Production Deployment guide](https://jitsu.com/docs/self-hosting/production-deployment) and the
+[Configuration Reference](https://jitsu.com/docs/self-hosting). It covers scaling each service,
+Kafka sizing, and the environment variables every component reads.
+
+## Contributing
+
+Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers the repository layout, how to
+set up a development environment and run the test suites, and the branch, commit and pull request
+conventions.
+
+## Community & support
+
+- **[Slack](https://jitsu.com/slack)** — the fastest way to reach the team and other users
+- **[GitHub Issues](https://github.com/jitsucom/jitsu/issues)** — bugs and feature requests
+- **[Docs](https://jitsu.com/docs)** — guides and reference
+
+## License
+
+Jitsu is licensed under the [MIT License](LICENSE).

--- a/bulker/README.md
+++ b/bulker/README.md
@@ -1,109 +1,153 @@
 # 🚚 Bulker
 
-Bulker is a tool for streaming and batching large amount of semi-structured data into data warehouses. It uses Kafka internally
+Bulker streams and batches large amounts of semi-structured data into data warehouses. Send it JSON,
+and it takes care of getting that JSON into a table — creating the table, adding columns, picking
+types, retrying on failure, and choosing the write strategy the destination is happiest with.
 
-## How it works?
+Bulker is the ingestion engine behind [Jitsu](../README.md), and lives in the same repository. You
+can use it three ways:
+
+- **As part of Jitsu** — it's what writes your events to the warehouse. Nothing to set up.
+- **As a standalone HTTP service** — `POST` JSON to an endpoint, it lands in your warehouse. See
+  [Server Configuration](./.docs/server-config.md) and [HTTP API](./.docs/http-api.md).
+- **As a Go library** — embed it in your own application, no server involved.
+
+## How it works
 
 <p align="center">
 <img src="./.docs/assets/bulker-summary.excalidraw.png" width="600" />
 </p>
 
-Send and JSON object to Bulker HTTP endpoint, and it will make sure it will be saved to data warehouse:
- 
- * **JSON flattening**. Your object will be flattened - `{a: {b: 1}}` becomes `{a_b: 1}`
- * **Schema managenent** for **semi-structured** data. For each field, bulker will make sure that a corresponding column exist in destination table. If not, Bulker
-will create it. Type will be best-guessed by value, or it could be explicitely set via type hint as in `{"a": "test", "__sql_type_a": "varchar(4)"}`
- * **Reliability**. Bulker will put the object to Kafka Queue immediately, so if datawarehouse is down, data won't be lost
- * **Streaming** or **Batching**. Bulker will send data to datawarehouse either as soon it become available  in Kafka (streaming) or after some time (batching). Most
-data warehouses won't tolerate large number of inserts, that's why we implemented batching
+Send a JSON object to Bulker, and it will make sure the object is saved to the data warehouse:
 
-
-Bulker is a 💜 of [Jitsu](https://github.com/jitsucom/jitsu), an open-source data integration platform.
-
-See full list of features below
-
-
-Bulker is also available as a go library if you want to embed it into your application as opposed to use a HTTP-server
+- **JSON flattening.** Your object is flattened — `{a: {b: 1}}` becomes `{a_b: 1}`.
+- **Schema management for semi-structured data.** For each field, Bulker makes sure a corresponding
+  column exists in the destination table, and creates it if not. The type is best-guessed from the
+  value, or set explicitly with a type hint: `{"a": "test", "__sql_type_a": "varchar(4)"}`.
+- **Reliability.** The object goes to a Kafka queue immediately, so if the warehouse is down, data
+  isn't lost.
+- **Streaming or batching.** Data goes to the warehouse either as soon as it's available in Kafka
+  (streaming) or after an interval (batching). Most warehouses won't tolerate a large number of
+  individual inserts, which is why batching exists.
 
 ## Features
 
-* 🛢️ **Batching** - Bulker sends data in batches in most efficient way for particular database. For example, for Postgres it uses 
-COPY command, for BigQuery it uses batch-files
-* 🚿 **Streaming** - alternatively, Bulker can stream data to database. It is useful when number of records is low. Up to 10 records
-per second for most databases
-* 🐫 **Deduplication** - if configured, Bulker will deduplicate records by primary key 
-* 📋 **Schema management** - Bulker creates tables and columns on the fly. It also flattens nested JSON-objects. Example if you send `{"a": {"b": 1}}` to 
-bulker, it will make sure that there is a column `a_b` in the table (and will create it)
-* 🦾 **Implicit typing** - Bulker infers types of columns from JSON-data.
-* 📌 **Explicit typing** - Explicit types can be by type hints that are placed in JSON. Example: for event `{"a": "test", "__sql_type_a": "varchar(4)"}`
-Bulker will make sure that there is a column `a`, and it's type is `varchar(4)`.
-* 📈 **Horizontal Scaling**. Bulker scales horizontally. Too much data? No problem, just add Bulker instances!
-* 📦 **Dockerized** - Bulker is dockerized and can be deployed to any cloud provider and k8s. 
-* ☁️ **Cloud Native** - each Bulker instance is stateless and is configured by only few environment variables. 
+- 🛢️ **Batching** — Bulker sends data in the most efficient way for the particular database. For
+  Postgres it uses `COPY`, for BigQuery batch files, and so on.
+- 🚿 **Streaming** — alternatively, Bulker streams data row by row. Useful when volume is low: up to
+  roughly 10 records per second for most databases.
+- 🐫 **Deduplication** — if configured, Bulker deduplicates records by primary key.
+- 📋 **Schema management** — tables and columns are created on the fly, and nested JSON is
+  flattened. Send `{"a": {"b": 1}}` and Bulker ensures a column `a_b` exists.
+- 🦾 **Implicit typing** — column types are inferred from the JSON data.
+- 📌 **Explicit typing** — override inference with type hints placed in the JSON. For
+  `{"a": "test", "__sql_type_a": "varchar(4)"}` Bulker ensures column `a` is `varchar(4)`.
+- 📈 **Horizontal scaling** — instances are stateless; add more of them.
+- 📦 **Dockerized** — deployable to any cloud provider or Kubernetes.
+- ☁️ **Cloud native** — each instance is configured by a handful of environment variables.
 
-## Supported databases
+## Supported destinations
 
-Bulker supports the following databases:
+| Destination                | Type            |
+| -------------------------- | --------------- |
+| PostgreSQL                 | SQL             |
+| ClickHouse                 | SQL             |
+| Snowflake                  | SQL             |
+| BigQuery                   | SQL             |
+| Redshift                   | SQL             |
+| MySQL                      | SQL             |
+| DuckDB                     | SQL             |
+| S3                         | File storage    |
+| Google Cloud Storage       | File storage    |
+| Webhook                    | API             |
+| Mixpanel                   | API             |
 
- * ✅ PostgresSQL <br/>
- * ✅ Redshit <br/>
- * ✅ Snowflake <br/>
- * ✅ Clickhouse <br/>
- * ✅ BigQuery <br/>
- * ✅ MySQL <br/>
- * ✅ S3 <br/>
- * ✅ GCS <br/>
+See the [compatibility matrix](.docs/db-feature-matrix.md) for which Bulker features each
+destination supports.
 
-Please see  [Compatibility Matrix](.docs/db-feature-matrix.md) to learn what Bulker features are supported by each database.
+## What's in this directory
 
+Bulker is a set of Go modules tied together by a Go workspace. The services:
 
-## Documentation Links
+| Module                                             | Docker image        | What it does                                                                    |
+| -------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------- |
+| [`bulkerapp/`](./bulkerapp)                        | `jitsucom/bulker`   | The Bulker server — consumes Kafka topics and writes batches to destinations     |
+| [`ingest/`](./ingest)                              | `jitsucom/ingest`   | Jitsu's public ingestion API — accepts events over HTTP and writes them to Kafka |
+| [`sync-controller/`](./sync-controller/README.md)  | `jitsucom/syncctl`  | Runs connector sync tasks as Kubernetes pods and tracks their status             |
+| [`sync-sidecar/`](./sync-sidecar/README.md)        | `jitsucom/sidecar`  | Sidecar to an Airbyte-protocol connector — captures rows, logs and state         |
+| [`ingress-manager/`](./ingress-manager)            | —                   | Manages Kubernetes ingress and TLS certificates for customer custom domains      |
+| [`admin/`](./admin)                                | —                   | Admin service — orchestrates failover and dead-letter reprocessing jobs          |
+| [`reprocessing-worker/`](./reprocessing-worker/README.md) | —            | Worker that runs in K8s Job pods to reprocess failover files in parallel         |
+| [`config-keeper/`](./config-keeper)                | —                   | Caches configuration repositories and serves them to the other services          |
+| [`operator/`](./operator)                          | —                   | Kubernetes operator that provisions functions-server deployments per workspace   |
 
-> **Note**
-> We highly recommend to read [Core Concepts](#core-concepts) below before diving into details
+And the libraries:
 
-* [How to use Bulker as HTTP Service](./.docs/server-config.md)
-  * [Server Configuration](./.docs/server-config.md)  
-  * [HTTP API](./.docs/http-api.md)
-* How to use bulker as Go-lib *(coming soon)*
+| Module                                | What it is                                                                       |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| [`bulkerlib/`](./bulkerlib)           | The core library — bulk modes, schema management, and every destination adapter   |
+| [`jitsubase/`](./jitsubase)           | Shared utilities: app bootstrap, logging, types, safe-go helpers                  |
+| [`kafkabase/`](./kafkabase)           | Kafka producer/consumer plumbing shared by the services                           |
+| [`eventslog/`](./eventslog)           | Event log writers (ClickHouse, Redis) behind Jitsu's Live Events                  |
+| [`connectors/`](./connectors)         | Connector SDKs — Airbyte CDK bindings and the native Firebase connector           |
 
-## Core Concepts
+## Documentation
+
+> **Note:** we recommend reading [Core Concepts](#core-concepts) below before diving into details.
+
+- [Server configuration](./.docs/server-config.md) — every environment variable Bulker server reads
+- [HTTP API](./.docs/http-api.md) — endpoints, auth, request format
+- [Database feature matrix](./.docs/db-feature-matrix.md) — per-destination feature support
+- [Jitsu documentation](https://jitsu.com/docs) — the platform Bulker powers
+
+## Core concepts
 
 ### Destinations
 
-Bulker operates with destinations. Destination is database or
-storage service (e.g. S3, GCS). Each destination has an ID and configuration
-which is represented by JSON object.
-
-Bulker exposes HTTP API to load data into destinations, where those
-destinations are referenced by their IDs.
-
-If destination is a database, you'll need to provide a destination table name.
+Bulker operates with destinations. A destination is a database or storage service (e.g. S3, GCS).
+Each destination has an ID and a configuration represented by a JSON object. The HTTP API loads data
+into destinations by referencing those IDs. If the destination is a database, you also provide a
+table name.
 
 ### Event
 
-The main unit of data in Bulker is an *event*. Event is a represented JSON-object 
+The main unit of data in Bulker is an *event* — a JSON object.
 
-### Batching and Streaming (aka Destination Mode)
+### Batching and streaming (aka destination mode)
 
-Bulker can send data to database in two ways:
- * **Streaming**. Bulker sends evens to destinaion one by one. It is useful when number of events is low (less than 10 events per second for most DBs).
- * **Batching**. Bulker accumulates events in batches and sends them periodically once batch is full or timeout is reached. Batching is more efficient for large amounts of events. Especially for cloud data-warehouses 
-(e.g. Postgres, Clickhouse, BigQuery).
+Bulker can send data to a database in two ways:
+
+- **Streaming** — events go to the destination one by one. Useful when volume is low (under ~10
+  events per second for most databases).
+- **Batching** — events accumulate and are sent periodically, once the batch is full or a timeout is
+  reached. More efficient for large volumes, especially for cloud data warehouses.
 
 <p align="center">
 <img src="./.docs/assets/stream-batch.excalidraw.png" width="600" />
 </p>
 
-### Primary Keys and Deduplication
+### Primary keys and deduplication
 
-Optionally, Bulker can deduplicate events by primary key. It is useful when you same event can be sent to Bulker multiple times.
-If available, Bulker uses primary keys, but for some data warehouses alternative strategies are used.
+Optionally, Bulker deduplicates events by primary key — useful when the same event can be sent more
+than once. Where primary keys are available Bulker uses them; for some warehouses alternative
+strategies apply.
 
->[Read more about deduplication »](./.docs/db-feature-matrix.md)
+> [Read more about deduplication »](./.docs/db-feature-matrix.md)
 
+## Development
 
+Requires Go 1.26. The modules are wired together by a Go workspace (`go.work`, see
+[GOWORK.md](./GOWORK.md) if you need to recreate it):
 
+```bash
+go build ./...
+go test ./...
+```
 
+Destination tests spin up real databases via testcontainers, so Docker needs to be running. Release
+and packaging details are in [CONTRIBUTING.md](./CONTRIBUTING.md); repository-wide conventions are in
+the [root CONTRIBUTING.md](../CONTRIBUTING.md).
 
+## License
 
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
Rewrites the root README and the Bulker README. Prep for `JITSU-132` — the README is what the MCP
directories (PulseMCP, Smithery, Glama) ingest and rate, so it needed to describe the MCP server
properly before we submit anywhere.

## Root README

- **Drops all Jitsu Classic references**, including the banner with the broken nested-markdown link.
- **Repoints every docs link at `jitsu.com/docs`** — `docs.jitsu.com` and `next.jitsu.com` are gone.
- **Leads with Jitsu Cloud**, then a dedicated MCP section: endpoint, the `claude mcp add` one-liner,
  OAuth vs. API-key auth, and a summary of what the 25 tools cover.
- **Rewrites the Segment comparison.** The old text claimed "raw data lands in your storage, no
  vendor lock-in, no sampling", none of which distinguishes us — Segment writes to your warehouse
  too and doesn't sample. Replaced with three claims that hold up: MIT license + self-hosting,
  minutes-not-hours warehouse latency (Segment syncs [once or twice a
  day](https://segment.com/docs/connections/storage/warehouses/warehouse-syncs/), hourly at best),
  and per-event vs. per-MTU billing on Cloud.
- **Demotes self-hosting** to a secondary section, now Helm/Minikube-first with an explanation of
  what `dev-deploy.sh tunnel` does. The Docker Compose instructions are gone — the docs mark that
  path deprecated, and the old snippet was truncated mid-command anyway.
- **Adds an architecture overview** of the five services.
- **Moves repository layout and dev setup into CONTRIBUTING.md**, where the rest of the contributor
  docs already live.

## Bulker README

Still written as if Bulker were its own repository. Now links back to the root README, explains the
three ways to use it, and adds a module map covering every service and library under `bulker/`.
Also adds the destinations registered since it was last touched (DuckDB, Webhook, Mixpanel), a
development section, and fixes the typos.

## Note

`CONTRIBUTING.md` still points contributors at `docker compose --profile jitsu-services-dev` for the
local dev environment, which contradicts the deprecation the README now states. Left alone here —
worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)