### PR TITLE
fix(console): return client_secret_expires_at in MCP DCR response

### DIFF
--- a/webapps/console/__tests__/integration/mcp-auth.test.ts
+++ b/webapps/console/__tests__/integration/mcp-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createHash } from "juava";
 import { deps, seedWorkspace } from "./support/harness";
 import { AuthChecker } from "../../lib/server/mcp-server/auth";
+import { OAuthHandlers } from "../../lib/server/mcp-server/oauth";
 
 // No origin stub: send401 builds the WWW-Authenticate metadata URL from
 // getPublicOrigin(), which reads JITSU_PUBLIC_URL at call time — the harness
@@ -12,6 +13,10 @@ const noopSchedule = (_fn: () => Promise<any>) => {};
 
 function makeReq(authorization: string) {
   return { headers: { authorization } } as any;
+}
+
+function makePostReq(body: any) {
+  return { method: "POST", headers: {}, socket: {}, body } as any;
 }
 
 function makeRes() {
@@ -91,4 +96,28 @@ describe("AuthChecker: MCP auth via personal API key", () => {
     expect(auth).toBeUndefined();
     expect(res.statusCode).toBe(401);
   });
+});
+
+// Regression: omitting client_secret_expires_at made openid-client (used by
+// Smithery) reject registration outright with
+// `"client_secret_expires_at" property must be a number`. RFC 7591 §3.2.1 makes
+// it REQUIRED whenever a client_secret is issued; 0 == never expires.
+it("register returns an RFC 7591 DCR response", async () => {
+  const deps_ = { prisma: deps().prisma, kv: {}, accessTokenTtlSec: 3600, refreshTokenTtlDays: 30 } as any;
+  const res = makeRes();
+  await new OAuthHandlers(deps_).register(
+    makePostReq({ client_name: "Smithery", redirect_uris: ["https://smithery.ai/callback"] }),
+    res
+  );
+  expect(res.statusCode).toBe(201);
+  expect(res.body).toMatchObject({
+    client_id: expect.any(String),
+    client_secret: expect.any(String),
+    client_secret_expires_at: 0, // number, not undefined — the actual bug
+    client_id_issued_at: expect.any(Number),
+    client_name: "Smithery",
+    redirect_uris: ["https://smithery.ai/callback"],
+  });
+  // seconds, not milliseconds — a ms value would be ~1000x too large
+  expect(res.body.client_id_issued_at).toBeCloseTo(Date.now() / 1000, -2);
 });

--- a/webapps/console/lib/server/mcp-server/clients.ts
+++ b/webapps/console/lib/server/mcp-server/clients.ts
@@ -6,6 +6,7 @@ export type RegisteredClient = {
   clientSecret: string; // plaintext — returned only at registration time
   name: string;
   redirectUris: string[];
+  createdAt: Date;
 };
 
 // Thin CRUD + secret hashing for OAuthClient rows. Used by OAuthHandlers.
@@ -32,7 +33,13 @@ export class OAuthClientsRepo {
         redirectUris,
       },
     });
-    return { clientId: row.id, clientSecret, name: row.name, redirectUris: row.redirectUris };
+    return {
+      clientId: row.id,
+      clientSecret,
+      name: row.name,
+      redirectUris: row.redirectUris,
+      createdAt: row.createdAt,
+    };
   }
 
   async findById(clientId: string) {

--- a/webapps/console/lib/server/mcp-server/oauth.ts
+++ b/webapps/console/lib/server/mcp-server/oauth.ts
@@ -162,6 +162,13 @@ export class OAuthHandlers {
       res.status(201).json({
         client_id: c.clientId,
         client_secret: c.clientSecret,
+        // RFC 7591 §3.2.1: client_secret_expires_at is REQUIRED whenever a
+        // client_secret is issued, and 0 means "never expires" (ours don't).
+        // Omitting it makes strict clients (openid-client, used by Smithery)
+        // reject the whole registration with
+        // `"client_secret_expires_at" property must be a number`.
+        client_id_issued_at: Math.floor(c.createdAt.getTime() / 1000),
+        client_secret_expires_at: 0,
         client_name: c.name,
         redirect_uris: c.redirectUris,
         token_endpoint_auth_method: "client_secret_post",


### PR DESCRIPTION
## Problem

Smithery failed to connect to our MCP server during dynamic client registration:

```
"error": "internal_error",
"message": "Failed to process dynamic client registration response: \"response\" body \"client_secret_expires_at\" property must be a number",
"code": "oauth/dcr_response_process_failed",
"retryable": false
```

Our DCR endpoint issued a `client_secret` but never returned `client_secret_expires_at`. [RFC 7591 §3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1) makes that field **REQUIRED** whenever a secret is issued. Smithery's OAuth client (`openid-client`) validates the response strictly, reads `undefined`, and rejects the entire registration.

Nothing was wrong on Smithery's side — the response was genuinely non-conformant. Lenient clients like Claude Desktop ignore the missing field, which is why this only surfaced now.

## Fix

`OAuthHandlers.register` now returns:

- `client_secret_expires_at: 0` — `0` means "never expires", which matches reality; there's no secret-expiry logic anywhere in the codebase.
- `client_id_issued_at` — optional in the RFC, but some clients want it and it's free since we already have `createdAt`.

`OAuthClientsRepo.register` returns `createdAt` so the handler can derive `client_id_issued_at`.

## Tests

New `register returns an RFC 7591 DCR response` case in `__tests__/integration/mcp-auth.test.ts`.

Verified it's a real regression test: stripping `client_secret_expires_at` back out of `oauth.ts` fails it with `expected 'undefined' to be 'number'` — the same symptom Smithery reported — and it passes with the fix in place. Full file: 4 tests, all green.

## Notes

- Console-only; no schema change, no migration.
- Unblocks JITSU-132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
