### PR TITLE
JITSU-142 fix(bulker): reprocessing worker drops the last batches — zero flush timeout on close

### DIFF
--- a/bulker/kafkabase/producer.go
+++ b/bulker/kafkabase/producer.go
@@ -294,13 +294,26 @@ func (p *Producer) ProduceAsync(topic string, messageKey string, event []byte, h
 	return errs.ErrorOrNil()
 }
 
+// defaultFlushTimeoutMs bounds the flush on Close when no delivery timeout is
+// configured
+const defaultFlushTimeoutMs = 10000
+
 // Close closes producer
 func (p *Producer) Close() error {
 	if p == nil || p.isClosed() {
 		return nil
 	}
 	p.closed.Store(true)
-	notProduced := p.producer.Flush(p.config.ProducerDeliveryTimeoutMs)
+	// A KafkaConfig built literally (not loaded through appbase) has no
+	// mapstructure defaults, so this can be zero — and Flush(0) returns at once,
+	// abandoning whatever is still queued. Fall back to the timeout used before
+	// the value became configurable, so a missing setting cannot silently drop
+	// messages on shutdown.
+	flushTimeoutMs := p.config.ProducerDeliveryTimeoutMs
+	if flushTimeoutMs <= 0 {
+		flushTimeoutMs = defaultFlushTimeoutMs
+	}
+	notProduced := p.producer.Flush(flushTimeoutMs)
 	if notProduced > 0 {
 		p.Errorf("%d message left unsent in producer queue.", notProduced)
 		//TODO: suck p.producer.ProduceChannel() and store to fallback file or some retry queue

--- a/bulker/reprocessing-worker/integration_test.go
+++ b/bulker/reprocessing-worker/integration_test.go
@@ -334,3 +334,57 @@ func TestDrainProducer(t *testing.T) {
 		}
 	})
 }
+
+// Messages still queued at the end were already counted as sent — except when a
+// file attempt failed and its counts were rolled back before the retry, leaving
+// its messages in the queue with nothing to subtract them from.
+func TestAccountUndelivered(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      WorkerStatus
+		undelivered int
+		wantSuccess int64
+		wantErrors  int64
+	}{
+		{
+			name:        "moves the undelivered out of success",
+			status:      WorkerStatus{SuccessCount: 100, ErrorCount: 2},
+			undelivered: 23,
+			wantSuccess: 77,
+			wantErrors:  25,
+		},
+		{
+			// The surplus is duplicates from an attempt whose counts were rolled
+			// back and whose lines were re-counted by the retry, so they are not
+			// represented in the counters at all — adding them to errors would
+			// push success+skipped+errors past the line count. LastError still
+			// reports the real queue depth.
+			name:        "never counts more than was reported as sent",
+			status:      WorkerStatus{SuccessCount: 5, ErrorCount: 1},
+			undelivered: 40,
+			wantSuccess: 0,
+			wantErrors:  6,
+		},
+		{
+			name:        "nothing counted as sent leaves the counters alone",
+			status:      WorkerStatus{SuccessCount: 0, ErrorCount: 3},
+			undelivered: 7,
+			wantSuccess: 0,
+			wantErrors:  3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := tt.status
+			accountUndelivered(&status, tt.undelivered)
+			if status.SuccessCount != tt.wantSuccess || status.ErrorCount != tt.wantErrors {
+				t.Errorf("success/errors = %d/%d, want %d/%d",
+					status.SuccessCount, status.ErrorCount, tt.wantSuccess, tt.wantErrors)
+			}
+			if status.SuccessCount < 0 {
+				t.Errorf("SuccessCount went negative: %d", status.SuccessCount)
+			}
+		})
+	}
+}

--- a/bulker/reprocessing-worker/integration_test.go
+++ b/bulker/reprocessing-worker/integration_test.go
@@ -287,3 +287,50 @@ func TestReprocessLocalFilesProduceFailure(t *testing.T) {
 			status.SuccessCount, status.SkippedCount, status.ErrorCount, status.TotalLines)
 	}
 }
+
+// queueStub reports a shrinking producer queue, then an error once "closed"
+type queueStub struct {
+	sizes []int
+	calls int
+	err   error
+}
+
+func (q *queueStub) QueueSize() (int, error) {
+	if q.err != nil {
+		return 0, q.err
+	}
+	if q.calls < len(q.sizes) {
+		size := q.sizes[q.calls]
+		q.calls++
+		return size, nil
+	}
+	return 0, nil
+}
+
+// The tail of a run is still in the producer queue when the last file is done —
+// reporting completion before it drains would claim delivery for messages that
+// never left the worker.
+func TestDrainProducer(t *testing.T) {
+	t.Run("waits for the queue to empty", func(t *testing.T) {
+		stub := &queueStub{sizes: []int{23, 9, 0}}
+		if undelivered := drainProducer(stub, time.Second, time.Millisecond); undelivered != 0 {
+			t.Errorf("undelivered = %d, want 0", undelivered)
+		}
+		if stub.calls != 3 {
+			t.Errorf("polled %d times, want 3", stub.calls)
+		}
+	})
+
+	t.Run("reports what is left when the wait runs out", func(t *testing.T) {
+		stub := &queueStub{sizes: []int{5, 5, 5, 5, 5, 5, 5, 5, 5, 5}}
+		if undelivered := drainProducer(stub, 5*time.Millisecond, time.Millisecond); undelivered != 5 {
+			t.Errorf("undelivered = %d, want 5", undelivered)
+		}
+	})
+
+	t.Run("a closed producer is not an error", func(t *testing.T) {
+		if undelivered := drainProducer(&queueStub{err: os.ErrClosed}, time.Second, time.Millisecond); undelivered != 0 {
+			t.Errorf("undelivered = %d, want 0", undelivered)
+		}
+	})
+}

--- a/bulker/reprocessing-worker/main.go
+++ b/bulker/reprocessing-worker/main.go
@@ -42,6 +42,11 @@ type WorkerConfig struct {
 	RepositoryAuthToken   string
 }
 
+// producerQueue reports how many messages are still waiting to be delivered
+type producerQueue interface {
+	QueueSize() (int, error)
+}
+
 // messageProducer is the slice of kafkabase.Producer the reprocessing path uses,
 // so tests can capture what would be sent
 type messageProducer interface {
@@ -194,7 +199,7 @@ func main() {
 		updateWorkerError(dbpool, config, "Failed to initialize Kafka producer: "+err.Error())
 		os.Exit(1)
 	}
-	defer producer.Close()
+	// closed explicitly before the final status update — see the end of main
 
 	// Initialize AWS S3 client
 	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background())
@@ -228,6 +233,7 @@ func main() {
 	if len(myFiles) == 0 {
 		fmt.Printf("No files assigned to worker %d\n", config.WorkerIndex)
 		updateWorkerStatus(dbpool, config, &WorkerStatus{}, "completed")
+		_ = producer.Close()
 		return
 	}
 
@@ -314,6 +320,20 @@ func main() {
 		updateWorkerStatus(dbpool, config, status, "running")
 	}
 
+	// Deliver what is still queued before reporting the outcome: these messages
+	// were already counted as sent, so a status update ahead of the flush would
+	// report success for events that never left the worker.
+	if undelivered := drainProducer(producer, deliveryTimeoutMs*time.Millisecond, time.Second); undelivered > 0 {
+		status.SuccessCount -= int64(undelivered)
+		status.ErrorCount += int64(undelivered)
+		status.LastError = fmt.Sprintf("%d message(s) still queued after %ds — not delivered", undelivered, deliveryTimeoutMs/1000)
+		fmt.Fprintf(os.Stderr, "%s\n", status.LastError)
+		updateWorkerStatus(dbpool, config, status, "failed")
+		_ = producer.Close()
+		os.Exit(1)
+	}
+	_ = producer.Close()
+
 	// Mark as completed
 	updateWorkerStatus(dbpool, config, status, "completed")
 	fmt.Printf("Worker %d completed processing %d files\n", config.WorkerIndex, len(myFiles))
@@ -383,6 +403,12 @@ func loadConfig() (*WorkerConfig, error) {
 	}, nil
 }
 
+// deliveryTimeoutMs bounds both delivery and the flush on close. Other services
+// get this from PRODUCER_DELIVERY_TIMEOUT_MS via appbase; the worker builds its
+// config literally, where an unset value would mean Flush(0) — an immediate
+// return that drops whatever is still queued.
+const deliveryTimeoutMs = 300000
+
 func initKafkaProducer(config *WorkerConfig) (*kafkabase.Producer, error) {
 	producerConfig := &kafka.ConfigMap{
 		"bootstrap.servers":            config.KafkaBootstrapServers,
@@ -390,15 +416,36 @@ func initKafkaProducer(config *WorkerConfig) (*kafkabase.Producer, error) {
 		"batch.size":                   1048576,
 		"linger.ms":                    1000,
 		"compression.type":             "zstd",
+		"delivery.timeout.ms":          deliveryTimeoutMs,
 	}
 
-	producer, err := kafkabase.NewProducer(&kafkabase.KafkaConfig{}, producerConfig, true, nil)
+	producer, err := kafkabase.NewProducer(
+		&kafkabase.KafkaConfig{ProducerDeliveryTimeoutMs: deliveryTimeoutMs}, producerConfig, true, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	producer.Start()
 	return producer, nil
+}
+
+// drainProducer waits for the producer's queue to empty. ProduceAsync only
+// enqueues, so at the end of a run the tail of the batch is still in flight;
+// reporting completion before it lands would claim delivery for messages that
+// were never sent. Returns how many were still queued when the wait ran out.
+func drainProducer(producer producerQueue, timeout, poll time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for {
+		queued, err := producer.QueueSize()
+		if err != nil || queued == 0 {
+			return 0
+		}
+		if time.Now().After(deadline) {
+			return queued
+		}
+		fmt.Printf("Waiting for %d message(s) to be delivered...\n", queued)
+		time.Sleep(poll)
+	}
 }
 
 func gzipDecompress(data []byte) ([]byte, error) {

--- a/bulker/reprocessing-worker/main.go
+++ b/bulker/reprocessing-worker/main.go
@@ -324,8 +324,7 @@ func main() {
 	// were already counted as sent, so a status update ahead of the flush would
 	// report success for events that never left the worker.
 	if undelivered := drainProducer(producer, deliveryTimeoutMs*time.Millisecond, time.Second); undelivered > 0 {
-		status.SuccessCount -= int64(undelivered)
-		status.ErrorCount += int64(undelivered)
+		accountUndelivered(status, undelivered)
 		status.LastError = fmt.Sprintf("%d message(s) still queued after %ds — not delivered", undelivered, deliveryTimeoutMs/1000)
 		fmt.Fprintf(os.Stderr, "%s\n", status.LastError)
 		updateWorkerStatus(dbpool, config, status, "failed")
@@ -427,6 +426,20 @@ func initKafkaProducer(config *WorkerConfig) (*kafkabase.Producer, error) {
 
 	producer.Start()
 	return producer, nil
+}
+
+// accountUndelivered moves messages that never left the producer from the
+// success bucket to the error one. It moves at most what was counted as sent:
+// a file attempt that failed mid-way has its counts rolled back before the
+// retry, yet its messages stay in the queue, so the queue can hold more than
+// the counters represent. The full number is reported in LastError.
+func accountUndelivered(status *WorkerStatus, undelivered int) {
+	moved := int64(undelivered)
+	if moved > status.SuccessCount {
+		moved = status.SuccessCount
+	}
+	status.SuccessCount -= moved
+	status.ErrorCount += moved
 }
 
 // drainProducer waits for the producer's queue to empty. ProduceAsync only


### PR DESCRIPTION
`JITSU-142`

A reprocessing run ends with:

```
level=error msg="[producer] 23 message left unsent in producer queue."
level=info  msg="[producer] Closing producer."
```

and the worker still reports **completed**, with those events counted as sent. They were never delivered.

## The regression

`e7237fc72` (2026-03-03, "customize delivery.timeout.ms") changed `kafkabase.Producer.Close()`:

```diff
-	notProduced := p.producer.Flush(10000)
+	notProduced := p.producer.Flush(p.config.ProducerDeliveryTimeoutMs)
```

`ProducerDeliveryTimeoutMs` gets its `300000` default from mapstructure, so every service that loads its config through appbase kept flushing normally. The reprocessing worker builds `&kafkabase.KafkaConfig{}` **literally**, so its value is `0` — and `Flush(0)` returns immediately, abandoning the queue. With `linger.ms: 1000` there is always a tail in flight when a run finishes, so since March every reprocessing run has dropped its last batches. Before March the hardcoded 10s covered it.

The worker is currently the only place in the repo constructing a `KafkaConfig` literally, but the trap is general, which is why the first commit fixes it in the shared code.

## A second defect, present since the worker was written

`defer producer.Close()` runs *after* `updateWorkerStatus(..., "completed")`. The worker announces success and only then attempts the flush — so even a failed flush leaves the status at "completed" with the messages already counted by `sendBatch`. Pre-March this was invisible because the flush nearly always succeeded.

## Changes

**`kafkabase`** — `Close()` falls back to the pre-`e7237fc72` 10s timeout when none is configured. A missing setting can no longer silently drop messages on shutdown, for any caller.

**`reprocessing-worker`** —

- sets the delivery timeout explicitly (300s) on both the `KafkaConfig` and `delivery.timeout.ms`, matching what ingest and bulkerapp pass;
- waits for the producer queue to drain **before** reporting the outcome. Anything still queued when the wait expires moves from `SuccessCount` to `ErrorCount`, is recorded in `LastError`, marks the worker failed, and exits non-zero, so the job reflects partial delivery instead of claiming success;
- closes the producer on the "no files assigned" path too, which the removed `defer` used to cover.

`drainProducer` sits behind a small `producerQueue` interface and is unit-tested (drains, times out, tolerates a closed producer).

## Not fixed here

Delivery errors arrive asynchronously on the producer's event channel and are only logged — they never reach worker status, so a message that leaves the queue but fails at the broker is still counted as success. Closing that needs kafkabase to surface per-message delivery outcomes to callers, which affects other services too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
