### PR TITLE
JITSU-157 follow-up: don't retry a schema patch the database rejects on its merits

### DIFF
--- a/bulker/bulkerlib/implementations/sql/same_patch_test.go
+++ b/bulker/bulkerlib/implementations/sql/same_patch_test.go
@@ -1,0 +1,92 @@
+package sql
+
+import (
+	"testing"
+
+	types2 "github.com/jitsucom/bulker/bulkerlib/types"
+	"github.com/jitsucom/bulker/jitsubase/jsonorder"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSamePatch covers the decision ensureTable makes after a patch fails: re-reading
+// the table tells it whether its view was stale (retry) or whether the database is
+// rejecting the patch itself (give up, and report why).
+func TestSamePatch(t *testing.T) {
+	columns := func(pairs ...string) Columns {
+		cols := NewColumns(len(pairs) / 2)
+		for i := 0; i < len(pairs); i += 2 {
+			cols.Set(pairs[i], types2.SQLColumn{Type: pairs[i+1]})
+		}
+		return cols
+	}
+	diff := func(cols Columns, pk ...string) *Table {
+		return &Table{Columns: cols, PKFields: jsonorder.NewOrderedSet[string](pk...)}
+	}
+
+	tests := []struct {
+		name     string
+		before   *Table
+		after    *Table
+		expected bool
+	}{
+		{
+			// the table has duplicate rows, so the primary key is refused every time -
+			// retrying only rebuilds the same unique index on the destination
+			name:     "same primary key still missing",
+			before:   diff(NewColumns(0), "id"),
+			after:    diff(NewColumns(0), "id"),
+			expected: true,
+		},
+		{
+			// what JITSU-157 is about: another instance added the column while our batch
+			// was running, so the fresh schema has less to do and the retry succeeds
+			name:     "column arrived while we were patching",
+			before:   diff(columns("b", "text")),
+			after:    diff(NewColumns(0)),
+			expected: false,
+		},
+		{
+			name:     "same column still missing",
+			before:   diff(columns("b", "text")),
+			after:    diff(columns("b", "text")),
+			expected: true,
+		},
+		{
+			name:     "same column name, different type",
+			before:   diff(columns("b", "text")),
+			after:    diff(columns("b", "bigint")),
+			expected: false,
+		},
+		{
+			name:     "one of the columns arrived",
+			before:   diff(columns("b", "text", "c", "text")),
+			after:    diff(columns("c", "text")),
+			expected: false,
+		},
+		{
+			name:     "primary key gained a field",
+			before:   diff(NewColumns(0), "id"),
+			after:    diff(NewColumns(0), "id", "day"),
+			expected: false,
+		},
+		{
+			name:     "primary key rename to drop is new",
+			before:   diff(NewColumns(0), "id"),
+			after:    &Table{Columns: NewColumns(0), PKFields: jsonorder.NewOrderedSet[string]("id"), DeletePrimaryKeyNamed: "jitsu_pk_old"},
+			expected: false,
+		},
+		{
+			name:     "nothing to do either way",
+			before:   diff(NewColumns(0)),
+			after:    diff(NewColumns(0)),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.after.samePatch(tt.before))
+			require.Equal(t, tt.expected, tt.before.samePatch(tt.after), "comparison must be symmetric")
+		})
+	}
+}

--- a/bulker/bulkerlib/implementations/sql/table.go
+++ b/bulker/bulkerlib/implementations/sql/table.go
@@ -235,6 +235,22 @@ func (t *Table) Diff(another *Table) *Table {
 	return diff
 }
 
+// samePatch reports whether two diffs describe the same change - the same columns to
+// add and the same primary key work. Used to tell a stale view of the table (worth
+// re-reading and patching again) from a patch the database rejects on its merits.
+func (t *Table) samePatch(another *Table) bool {
+	if t.ColumnsCount() != another.ColumnsCount() {
+		return false
+	}
+	for el := t.Columns.Front(); el != nil; el = el.Next() {
+		column, ok := another.Columns.Get(el.Key)
+		if !ok || column.Type != el.Value.Type {
+			return false
+		}
+	}
+	return t.DeletePrimaryKeyNamed == another.DeletePrimaryKeyNamed && t.PKFields.Equals(another.PKFields)
+}
+
 func (t *Table) ToSimpleMap() *jsonorder.OrderedMap[string, any] {
 	simple := jsonorder.NewOrderedMap[string, any](t.ColumnsCount())
 	for el := t.Columns.Front(); el != nil; el = el.Next() {

--- a/bulker/bulkerlib/implementations/sql/table_helper.go
+++ b/bulker/bulkerlib/implementations/sql/table_helper.go
@@ -157,25 +157,32 @@ func (th *TableHelper) ensureTable(ctx context.Context, sqlAdapter SQLAdapter, d
 		return nil, err
 	}
 
+	attemptedPatch := actualSchema.Diff(desiredSchema)
 	patchedSchema, patchErr := th.patchTableIfNeeded(ctx, sqlAdapter, destinationID, actualSchema, desiredSchema, cacheTable)
 	if patchErr == nil {
 		return patchedSchema, nil
 	}
 	// Patching failed - that may mean the table was changed outside of bulker, or that
 	// another bulker instance writing to the same table won the race to add the same
-	// column (SQLSTATE 42701 on Postgres). Either way our view of the table is stale:
-	// get a fresh schema from the db and patch again with whatever is really missing.
-	//
+	// column (SQLSTATE 42701 on Postgres). Either way our view of the table would be
+	// stale, so get a fresh schema from the db and see what is really missing.
+	actualSchema, err = th.getOrCreateWithLock(ctx, sqlAdapter, destinationID, desiredSchema)
+	if err != nil {
+		return nil, err
+	}
+	if actualSchema.Diff(desiredSchema).samePatch(attemptedPatch) {
+		// The db says exactly what we already believed, so our view was not stale after
+		// all and patching again would run the same statement and fail the same way.
+		// Some of these fail for good: a table with duplicate rows rejects the primary
+		// key every time, and each attempt is a full unique index build holding a lock
+		// on the destination table. Report the original error instead.
+		return nil, patchErr
+	}
 	// This log line is the only place the original error is visible: the retry below
 	// reports its own error, and until the patch statements were isolated in savepoints
 	// it always was "current transaction is aborted" (25P02) - the aftermath rather than
 	// the cause.
 	logging.Warnf("[%s] failed to patch table %s: %v. Getting fresh table schema from db and trying again", destinationID, desiredSchema.Name, patchErr)
-
-	actualSchema, err = th.getOrCreateWithLock(ctx, sqlAdapter, destinationID, desiredSchema)
-	if err != nil {
-		return nil, err
-	}
 	if cacheTable {
 		th.UpdateCached(actualSchema)
 	}


### PR DESCRIPTION
Follow-up to #1440, found in production after deploying it.

## What I saw

The `.*-1lwk` destination from JITSU-157 is fine: its last `25P02` was at 13:09:59 — a batch that had been running **7.7 hours** (`time: 27740.34 s`) and predates the deploy. Nothing since. What's left there is the retry-topic backlog draining.

But the new `failed to patch table … Getting fresh table schema` warn line lit up a different, pre-existing problem on **other** destinations:

```
failed to patch table events: report.sql.create_primary_keys: failed to set primary key
statement: ALTER TABLE "public"."events" ADD CONSTRAINT "jitsu_pk_<uuid>" PRIMARY KEY ("eventn_ctx_event_id")
cause: ERROR: could not create unique index "jitsu_pk_<uuid>" (SQLSTATE 23505)
```

Those tables contain duplicate rows, so the primary key is refused **every time** — 764 occurrences between Aug 2 and this morning, long before this branch. It's not a race and re-reading the schema cannot help.

## Why it matters

`ensureTable`'s retry assumed a failed patch means a stale view of the table. On this class of failure it just runs the same statement again — and `ADD CONSTRAINT … PRIMARY KEY` builds a full unique index under an `ACCESS EXCLUSIVE` lock on the customer's table before failing. Measured over 2h on the affected destinations: **394 of these extra doomed index builds**, on top of the 260 the failing events caused anyway.

The retry-on-any-patch-error predates #1440 for the cached path; #1440 extended it to the non-cached path and, by logging it, made it visible. Either way it shouldn't be doing this.

## The fix

`ensureTable` now compares what it tried to patch against what the fresh schema says is still missing:

- **identical** → our view was never stale, the retry would fail identically → return the original error, no second statement
- **different** (the column is there now) → a genuine lost race → retry as before

`TestSamePatch` covers the decision table; `TestConcurrentAddColumn` still passes, and forcing `samePatch` to always return true makes it fail — so the JITSU-157 recovery is still exercised.

Full `bulkerlib/implementations/sql` suite green against Postgres.

## Not fixed here

The underlying condition — destinations whose `events` table has duplicate values in the primary key column, so bulker retries the constraint forever — is still there. This change stops us from making it worse; it doesn't stop the per-event attempt. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)