### PR TITLE
JITSU-160 fix(console): allow removing entries from free-form config maps

### DIFF
--- a/cli/jitsu-cli/src/commands/config/index.ts
+++ b/cli/jitsu-cli/src/commands/config/index.ts
@@ -30,6 +30,8 @@ function withBodyOpts(cmd: Command): Command {
         '  --credentials.keys=\'["a","b"]\'',
         'Values starting with [, {, " or matching number/boolean/null are parsed as JSON;',
         "everything else is a plain string. -f, --json, and --field flags merge in that order.",
+        "On update, omitted fields keep their stored value - except free-form maps (e.g. a warehouse's",
+        "`parameters`), which are replaced by what you send, so pass the whole map, not one entry.",
       ].join("\n")
     );
 }

--- a/webapps/console/__tests__/unit/free-form-maps.test.ts
+++ b/webapps/console/__tests__/unit/free-form-maps.test.ts
@@ -90,7 +90,7 @@ describe("destination update: credentials.parameters", () => {
 });
 
 describe("collectJsonSchemaFreeFormPaths (service specs)", () => {
-  it("finds objects with additionalProperties, nested and in oneOf branches", () => {
+  it("finds objects with a schema-valued additionalProperties, nested and in oneOf branches", () => {
     const spec = {
       properties: {
         host: { type: "string" },
@@ -98,7 +98,7 @@ describe("collectJsonSchemaFreeFormPaths (service specs)", () => {
         tunnel: {
           type: "object",
           properties: {
-            extra: { type: "object", additionalProperties: true },
+            extra: { type: "object", additionalProperties: { type: "string" } },
             port: { type: "integer" },
           },
         },
@@ -117,6 +117,57 @@ describe("collectJsonSchemaFreeFormPaths (service specs)", () => {
     ]);
   });
 
+  // `additionalProperties: true` is a laxness flag in Airbyte specs, not an open key set.
+  // Treating it as a free-form map replaces the object wholesale on a partial update, which
+  // drops the keys the caller didn't send - including secrets stripped by removeMaskedValues.
+  it("ignores a bare `additionalProperties: true` on a declared object", () => {
+    // Shape of airbyte/source-youtube-analytics `credentials`, all three fields airbyte_secret.
+    const spec = {
+      properties: {
+        credentials: {
+          type: "object",
+          additionalProperties: true,
+          properties: {
+            client_id: { type: "string", airbyte_secret: true },
+            client_secret: { type: "string", airbyte_secret: true },
+            refresh_token: { type: "string", airbyte_secret: true },
+          },
+        },
+      },
+    };
+    expect(collectJsonSchemaFreeFormPaths(spec)).toEqual([]);
+  });
+
+  // Pins the deliberate choice not to treat a oneOf/anyOf branch as a map itself: only the
+  // properties inside a branch are walked. Every branch-level `additionalProperties` in the
+  // connector specs we ship is the boolean laxness flag, never a real open key set.
+  it("does not treat a oneOf/anyOf branch itself as an open map", () => {
+    // Shape of airbyte/source-postgres `ssl_mode` / `replication_method`: every branch
+    // declares properties alongside `additionalProperties: true`.
+    const spec = {
+      properties: {
+        ssl_mode: {
+          title: "SSL Modes",
+          oneOf: [
+            { title: "disable", additionalProperties: true, properties: { mode: { type: "string" } } },
+            {
+              title: "verify-ca",
+              additionalProperties: true,
+              properties: { mode: { type: "string" }, ca_certificate: { type: "string", airbyte_secret: true } },
+            },
+          ],
+        },
+      },
+    };
+    expect(collectJsonSchemaFreeFormPaths(spec)).toEqual([]);
+  });
+
+  it("finds a bare `additionalProperties: true` when nothing is declared beside it", () => {
+    // The "arbitrary key/value bag" idiom - an open key set, unlike the laxness-flag case above.
+    const spec = { properties: { tags: { type: "object", additionalProperties: true } } };
+    expect(collectJsonSchemaFreeFormPaths(spec)).toEqual(["credentials.tags"]);
+  });
+
   it("ignores objects with a closed key set", () => {
     const spec = { properties: { nested: { type: "object", properties: { a: { type: "string" } } } } };
     expect(collectJsonSchemaFreeFormPaths(spec)).toEqual([]);
@@ -125,5 +176,45 @@ describe("collectJsonSchemaFreeFormPaths (service specs)", () => {
   it("tolerates a missing or empty spec", () => {
     expect(collectJsonSchemaFreeFormPaths(undefined)).toEqual([]);
     expect(collectJsonSchemaFreeFormPaths({})).toEqual([]);
+  });
+});
+
+describe("service update: partial patch of a declared object", () => {
+  // The bug this guards: `credentials` on airbyte/source-youtube-analytics is a declared
+  // object carrying `additionalProperties: true`. Reading that as a free-form map made
+  // replaceFreeFormMaps overwrite it with the patch - and the patch has the masked secrets
+  // removed by removeMaskedValues, so client_secret / refresh_token were silently lost.
+  const spec = {
+    properties: {
+      credentials: {
+        type: "object",
+        additionalProperties: true,
+        properties: {
+          client_id: { type: "string", airbyte_secret: true },
+          client_secret: { type: "string", airbyte_secret: true },
+          refresh_token: { type: "string", airbyte_secret: true },
+        },
+      },
+    },
+  };
+
+  it("keeps the stored secrets the patch didn't carry", () => {
+    const stored = {
+      credentials: { credentials: { client_id: "CID", client_secret: "REAL_SECRET", refresh_token: "REAL_TOKEN" } },
+    };
+    // What removeMaskedValues leaves behind when the user edits only client_id.
+    const cleanedPatch = { credentials: { credentials: { client_id: "CID2" } } };
+
+    const result = replaceFreeFormMaps(
+      deepMerge(stored, cleanedPatch),
+      cleanedPatch,
+      collectJsonSchemaFreeFormPaths(spec)
+    );
+
+    expect(result.credentials.credentials).toEqual({
+      client_id: "CID2",
+      client_secret: "REAL_SECRET",
+      refresh_token: "REAL_TOKEN",
+    });
   });
 });

--- a/webapps/console/__tests__/unit/free-form-maps.test.ts
+++ b/webapps/console/__tests__/unit/free-form-maps.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { deepMerge } from "juava";
+import {
+  collectJsonSchemaFreeFormPaths,
+  getDestinationFreeFormPaths,
+  replaceFreeFormMaps,
+} from "../../lib/schema/free-form-maps";
+
+// Regression guard for the "can't remove a warehouse `parameters` entry" bug:
+// config updates deepMerge the patch into the stored object, which can add and
+// overwrite keys but never remove them. Free-form maps have to be replaced.
+
+/** What configObjectType.merge("destination") does, minus the secret masking. */
+function mergeDestination(stored: any, patch: any) {
+  return replaceFreeFormMaps(deepMerge(stored, patch), patch, getDestinationFreeFormPaths(stored.destinationType));
+}
+
+describe("getDestinationFreeFormPaths", () => {
+  it("finds `parameters` on the warehouses that declare a catchall", () => {
+    for (const type of ["clickhouse", "snowflake", "mysql"]) {
+      expect(getDestinationFreeFormPaths(type), type).toContain("parameters");
+    }
+  });
+
+  it("finds it on mysql, whose `parameters` declares `tls` alongside the catchall", () => {
+    // The signal is the catchall, not an empty shape.
+    expect(getDestinationFreeFormPaths("mysql")).toEqual(["parameters"]);
+  });
+
+  it("returns nothing for destinations with fully declared credentials", () => {
+    expect(getDestinationFreeFormPaths("webhook")).toEqual([]);
+  });
+
+  it("returns nothing for an unknown destination type", () => {
+    expect(getDestinationFreeFormPaths("no-such-destination")).toEqual([]);
+  });
+});
+
+describe("destination update: credentials.parameters", () => {
+  const stored = () => ({
+    id: "d1",
+    destinationType: "snowflake",
+    account: "acct",
+    database: "DB",
+    password: "secret",
+    parameters: { QUERY_TAG: "jitsu", CLIENT_SESSION_KEEP_ALIVE: "true" },
+  });
+
+  it("adds a parameter", () => {
+    const patch = { parameters: { QUERY_TAG: "jitsu", CLIENT_SESSION_KEEP_ALIVE: "true", TIMEZONE: "UTC" } };
+    expect(mergeDestination(stored(), patch).parameters).toEqual({
+      QUERY_TAG: "jitsu",
+      CLIENT_SESSION_KEEP_ALIVE: "true",
+      TIMEZONE: "UTC",
+    });
+  });
+
+  it("changes a parameter", () => {
+    const patch = { parameters: { QUERY_TAG: "changed", CLIENT_SESSION_KEEP_ALIVE: "true" } };
+    expect(mergeDestination(stored(), patch).parameters).toEqual({
+      QUERY_TAG: "changed",
+      CLIENT_SESSION_KEEP_ALIVE: "true",
+    });
+  });
+
+  it("removes one parameter", () => {
+    const patch = { parameters: { QUERY_TAG: "jitsu" } };
+    expect(mergeDestination(stored(), patch).parameters).toEqual({ QUERY_TAG: "jitsu" });
+  });
+
+  it("removes all parameters", () => {
+    const patch = { parameters: {} };
+    expect(mergeDestination(stored(), patch).parameters).toEqual({});
+  });
+
+  it("leaves other fields merged as before", () => {
+    const patch = { parameters: {}, database: "DB2" };
+    const result = mergeDestination(stored(), patch);
+    expect(result.database).toEqual("DB2");
+    expect(result.account).toEqual("acct");
+  });
+
+  it("keeps the stored map when the patch doesn't mention it (partial update)", () => {
+    // The write-key auto-save / CLI --field / MCP update_resource shape.
+    const patch = { database: "DB2" };
+    const result = mergeDestination(stored(), patch);
+    expect(result.parameters).toEqual({ QUERY_TAG: "jitsu", CLIENT_SESSION_KEEP_ALIVE: "true" });
+    expect(result.password).toEqual("secret");
+  });
+});
+
+describe("collectJsonSchemaFreeFormPaths (service specs)", () => {
+  it("finds objects with additionalProperties, nested and in oneOf branches", () => {
+    const spec = {
+      properties: {
+        host: { type: "string" },
+        options: { type: "object", additionalProperties: { type: "string" } },
+        tunnel: {
+          type: "object",
+          properties: {
+            extra: { type: "object", additionalProperties: true },
+            port: { type: "integer" },
+          },
+        },
+        auth: {
+          oneOf: [
+            { properties: { token: { type: "string" } } },
+            { properties: { headers: { type: "object", additionalProperties: { type: "string" } } } },
+          ],
+        },
+      },
+    };
+    expect(collectJsonSchemaFreeFormPaths(spec).sort()).toEqual([
+      "credentials.auth.headers",
+      "credentials.options",
+      "credentials.tunnel.extra",
+    ]);
+  });
+
+  it("ignores objects with a closed key set", () => {
+    const spec = { properties: { nested: { type: "object", properties: { a: { type: "string" } } } } };
+    expect(collectJsonSchemaFreeFormPaths(spec)).toEqual([]);
+  });
+
+  it("tolerates a missing or empty spec", () => {
+    expect(collectJsonSchemaFreeFormPaths(undefined)).toEqual([]);
+    expect(collectJsonSchemaFreeFormPaths({})).toEqual([]);
+  });
+});

--- a/webapps/console/lib/schema/config-objects.ts
+++ b/webapps/console/lib/schema/config-objects.ts
@@ -19,6 +19,7 @@ import { ZodType, ZodTypeDef } from "zod";
 import { getServerLog } from "../server/log";
 import { getWildcardDomains } from "../../pages/api/[workspaceId]/domain-check";
 import { getDestinationSecretPaths, getServiceSecretPaths, maskSecrets, removeMaskedValues } from "./secrets";
+import { getDestinationFreeFormPaths, getServiceFreeFormPaths, replaceFreeFormMaps } from "./free-form-maps";
 import { db } from "../server/db";
 import { ConfigApiDeleteOptions } from "../useApi";
 import pick from "lodash/pick";
@@ -161,7 +162,10 @@ const configObjectTypes: Record<string, ConfigObjectType> = {
       // Remove masked values before merge
       const secretPaths = getDestinationSecretPaths(original.destinationType);
       const cleanedPatch = removeMaskedValues(patch, secretPaths);
-      return deepMerge(original, cleanedPatch);
+      const merged = deepMerge(original, cleanedPatch);
+      // deepMerge can't remove keys, so free-form maps (`parameters`) are replaced
+      // wholesale when the patch supplies them — otherwise they can only grow.
+      return replaceFreeFormMaps(merged, cleanedPatch, getDestinationFreeFormPaths(original.destinationType));
     },
 
     inputFilter: async (obj: DestinationConfig, context) => {
@@ -328,7 +332,11 @@ const configObjectTypes: Record<string, ConfigObjectType> = {
       // Remove masked values before merge
       const secretPaths = await getServiceSecretPaths(original.package, original.version);
       const cleanedPatch = removeMaskedValues(patch, secretPaths);
-      return deepMerge(original, cleanedPatch);
+      const merged = deepMerge(original, cleanedPatch);
+      // Same as destinations, but the open key sets come from the connector's
+      // declarative spec (`additionalProperties`) rather than a zod catchall.
+      const freeFormPaths = await getServiceFreeFormPaths(original.package, original.version);
+      return replaceFreeFormMaps(merged, cleanedPatch, freeFormPaths);
     },
     inputFilter: async (obj: ServiceConfig) => {
       // Remove masked values

--- a/webapps/console/lib/schema/free-form-maps.ts
+++ b/webapps/console/lib/schema/free-form-maps.ts
@@ -5,6 +5,7 @@ import { getServerLog } from "../server/log";
 import get from "lodash/get";
 import set from "lodash/set";
 import has from "lodash/has";
+import isEmpty from "lodash/isEmpty";
 
 const log = getServerLog("free-form-maps");
 
@@ -16,14 +17,17 @@ const log = getServerLog("free-form-maps");
  *
  * Merging breaks down for *free-form maps* — fields whose key set is itself user
  * data, e.g. a warehouse's `parameters`. deepMerge only adds or overwrites keys,
- * so a removed key survives and the user cannot clear it (JITSU-xxx). For those
+ * so a removed key survives and the user cannot clear it (JITSU-160). For those
  * fields the map has to be replaced wholesale.
  *
  * A field counts as free-form when its schema leaves the key set open:
  *   - zod (destinations): `z.object({...}).catchall(...)`, `.passthrough()`, or
  *     `z.record(...)` — note Mysql's `parameters` declares `tls` *and* a catchall,
  *     so the presence of a catchall is the signal, not an empty shape.
- *   - JSON Schema (services): `type: "object"` carrying `additionalProperties`.
+ *   - JSON Schema (services): `type: "object"` whose `additionalProperties` is a
+ *     *schema*, or is `true` with no `properties` declared beside it. A bare
+ *     `additionalProperties: true` on a declared object does not count — Airbyte uses
+ *     it there as a laxness flag (see `isOpenMapSchema`).
  *
  * Replacement is still keyed off the patch: a path absent from the patch is left
  * alone, so partial updates keep working. Only a map the caller actually sent —
@@ -110,6 +114,28 @@ export function getDestinationFreeFormPaths(destinationType: string): string[] {
 }
 
 /**
+ * Is this JSON Schema node a free-form map, i.e. is its key set genuinely user data?
+ *
+ * A *schema-valued* `additionalProperties` always counts — it describes the values of keys
+ * the spec cannot name, which is exactly an open map.
+ *
+ * A bare `additionalProperties: true` only counts when nothing is declared alongside it.
+ * On its own it is the "arbitrary key/value bag" idiom; next to `properties` it is merely a
+ * laxness flag, which Airbyte specs use routinely on ordinary declared objects (e.g.
+ * source-postgres `ssl_mode`, whose every branch declares `properties` *and*
+ * `additionalProperties: true`). Reading the latter as a map would replace the object
+ * wholesale on a partial update and drop the untouched keys — including stored secrets,
+ * which `removeMaskedValues` strips out of the patch before the merge.
+ */
+function isOpenMapSchema(schema: any): boolean {
+  const ap = schema?.additionalProperties;
+  if (typeof ap === "object" && ap !== null) {
+    return true;
+  }
+  return ap === true && isEmpty(schema?.properties);
+}
+
+/**
  * Walk an Airbyte `connectionSpecification` and return `credentials.`-prefixed
  * paths of every free-form map. Mirrors `getServiceSecretPaths`, including the
  * oneOf/anyOf handling. Pure — exported so it's unit-testable without a DB.
@@ -125,9 +151,8 @@ export function collectJsonSchemaFreeFormPaths(connectionSpec: any): string[] {
     }
     Object.entries(properties).forEach(([key, schema]: [string, any]) => {
       const path = basePath ? `${basePath}.${key}` : key;
-      if (schema?.type === "object" && schema.additionalProperties) {
-        // Open key set — replace rather than merge. Declared `properties`
-        // alongside additionalProperties don't change that (cf. Mysql's `tls`).
+      if (schema?.type === "object" && isOpenMapSchema(schema)) {
+        // Open key set — replace rather than merge (see `isOpenMapSchema`).
         paths.push(`credentials.${path}`);
         return;
       }

--- a/webapps/console/lib/schema/free-form-maps.ts
+++ b/webapps/console/lib/schema/free-form-maps.ts
@@ -1,0 +1,175 @@
+import { ZodTypeAny } from "zod";
+import { coreDestinationsMap } from "./destinations";
+import { db } from "../server/db";
+import { getServerLog } from "../server/log";
+import get from "lodash/get";
+import set from "lodash/set";
+import has from "lodash/has";
+
+const log = getServerLog("free-form-maps");
+
+/**
+ * Config updates are a merge (`deepMerge`), so a PUT that omits a field keeps the
+ * stored value — that's what makes partial updates work (the write-key auto-save,
+ * `jitsu-cli config update --field.x=y`, the MCP `update_resource` tool) and what
+ * preserves masked secrets the client never sends back.
+ *
+ * Merging breaks down for *free-form maps* — fields whose key set is itself user
+ * data, e.g. a warehouse's `parameters`. deepMerge only adds or overwrites keys,
+ * so a removed key survives and the user cannot clear it (JITSU-xxx). For those
+ * fields the map has to be replaced wholesale.
+ *
+ * A field counts as free-form when its schema leaves the key set open:
+ *   - zod (destinations): `z.object({...}).catchall(...)`, `.passthrough()`, or
+ *     `z.record(...)` — note Mysql's `parameters` declares `tls` *and* a catchall,
+ *     so the presence of a catchall is the signal, not an empty shape.
+ *   - JSON Schema (services): `type: "object"` carrying `additionalProperties`.
+ *
+ * Replacement is still keyed off the patch: a path absent from the patch is left
+ * alone, so partial updates keep working. Only a map the caller actually sent —
+ * including an empty `{}` — replaces what's stored.
+ */
+
+/** Strip .optional() / .default() / .nullable() / .describe() wrappers. */
+function unwrap(schema: ZodTypeAny | undefined): any {
+  let s: any = schema;
+  // Bounded to avoid spinning on an unexpected self-referential schema.
+  for (let i = 0; s && i < 20; i++) {
+    const def = s._def;
+    if (!def) {
+      return s;
+    }
+    if (def.innerType) {
+      s = def.innerType; // ZodOptional / ZodDefault / ZodNullable / ZodBranded
+    } else if (def.schema) {
+      s = def.schema; // ZodEffects
+    } else {
+      return s;
+    }
+  }
+  return s;
+}
+
+function isFreeFormMap(schema: any): boolean {
+  const def = schema?._def;
+  if (!def) {
+    return false;
+  }
+  if (def.typeName === "ZodRecord") {
+    return true;
+  }
+  if (def.typeName !== "ZodObject") {
+    return false;
+  }
+  return def.unknownKeys === "passthrough" || (!!def.catchall && def.catchall._def?.typeName !== "ZodNever");
+}
+
+/**
+ * Walk a zod object schema and return dot-paths of every free-form map field.
+ * Recurses into declared sub-objects so a nested `parameters` is still found.
+ */
+function collectZodFreeFormPaths(schema: ZodTypeAny | undefined, basePath = "", depth = 0): string[] {
+  const node = unwrap(schema);
+  if (depth > 10 || node?._def?.typeName !== "ZodObject") {
+    return [];
+  }
+  const shape = typeof node._def.shape === "function" ? node._def.shape() : node._def.shape;
+  if (!shape) {
+    return [];
+  }
+  const paths: string[] = [];
+  for (const [key, field] of Object.entries<ZodTypeAny>(shape)) {
+    const path = basePath ? `${basePath}.${key}` : key;
+    const inner = unwrap(field);
+    if (isFreeFormMap(inner)) {
+      // The map itself is the unit of edit — don't descend into it.
+      paths.push(path);
+    } else {
+      paths.push(...collectZodFreeFormPaths(inner, path, depth + 1));
+    }
+  }
+  return paths;
+}
+
+/**
+ * Free-form map paths for a destination. Destination credentials are merged into
+ * the config object at the top level (see `narrowSchema`), so paths are relative
+ * to the config object itself — `parameters`, not `credentials.parameters`.
+ */
+export function getDestinationFreeFormPaths(destinationType: string): string[] {
+  const destination = coreDestinationsMap[destinationType];
+  if (!destination?.credentials) {
+    return [];
+  }
+  try {
+    return collectZodFreeFormPaths(destination.credentials);
+  } catch (error) {
+    log.atError().withCause(error).log(`Failed to collect free-form paths for destination ${destinationType}`);
+    return [];
+  }
+}
+
+/**
+ * Walk an Airbyte `connectionSpecification` and return `credentials.`-prefixed
+ * paths of every free-form map. Mirrors `getServiceSecretPaths`, including the
+ * oneOf/anyOf handling. Pure — exported so it's unit-testable without a DB.
+ */
+export function collectJsonSchemaFreeFormPaths(connectionSpec: any): string[] {
+  if (!connectionSpec?.properties) {
+    return [];
+  }
+  const paths: string[] = [];
+  const walk = (properties: any, basePath = "", depth = 0) => {
+    if (depth > 10) {
+      return;
+    }
+    Object.entries(properties).forEach(([key, schema]: [string, any]) => {
+      const path = basePath ? `${basePath}.${key}` : key;
+      if (schema?.type === "object" && schema.additionalProperties) {
+        // Open key set — replace rather than merge. Declared `properties`
+        // alongside additionalProperties don't change that (cf. Mysql's `tls`).
+        paths.push(`credentials.${path}`);
+        return;
+      }
+      if (schema?.type === "object" && schema.properties) {
+        walk(schema.properties, path, depth + 1);
+      }
+      const branches = schema?.oneOf || schema?.anyOf;
+      if (branches) {
+        branches.forEach((branch: any) => branch?.properties && walk(branch.properties, path, depth + 1));
+      }
+    });
+  };
+  walk(connectionSpec.properties);
+  return [...new Set(paths)];
+}
+
+/**
+ * Free-form map paths for a service, read from the connector's declarative
+ * (Airbyte JSON Schema) spec.
+ */
+export async function getServiceFreeFormPaths(packageName: string, version: string): Promise<string[]> {
+  try {
+    const sourceSpec = await db.prisma().source_spec.findUnique({
+      where: { package_version: { package: packageName, version } },
+    });
+    return collectJsonSchemaFreeFormPaths((sourceSpec?.specs as any)?.connectionSpecification);
+  } catch (error) {
+    log.atError().withCause(error).log(`Failed to collect free-form paths for service ${packageName}@${version}`);
+    return [];
+  }
+}
+
+/**
+ * Overwrite each free-form map that the patch actually supplied. `merged` is the
+ * deepMerge result (deepMerge mutates and returns `original`), so this restores
+ * removals the merge swallowed.
+ */
+export function replaceFreeFormMaps<T>(merged: T, patch: any, freeFormPaths: string[]): T {
+  for (const path of freeFormPaths) {
+    if (has(patch, path)) {
+      set(merged as any, path, get(patch, path));
+    }
+  }
+  return merged;
+}

--- a/webapps/console/lib/server/mcp-server/tools.ts
+++ b/webapps/console/lib/server/mcp-server/tools.ts
@@ -250,7 +250,10 @@ export function registerTools(sdkServer: SdkMcpServer, deps: ToolDeps) {
       title: "Update resource",
       annotations: DESTRUCTIVE,
       description:
-        `Update a configuration resource by id (merged into the existing object). type ∈ {${typeList}}. ` +
+        `Update a configuration resource by id (merged into the existing object, so omitted fields keep ` +
+        `their stored value). Free-form maps are the exception: a map you send replaces the stored one ` +
+        `outright, so send its complete contents, not just the entries you want to change. ` +
+        `type ∈ {${typeList}}. ` +
         `For "${CONNECTION}", \`data\` is the connection body and the link is upserted by id.`,
       inputSchema: {
         workspaceId: z.string(),


### PR DESCRIPTION
## Problem

Removing an entry from a data-warehouse destination's `parameters` doesn't stick. Adding and changing entries works; deleting one silently keeps it.

Config updates deepMerge the incoming patch into the stored object (`config-objects.ts` → `deepMerge`), and `deepMerge` reduces over **source** keys only, so keys present in the stored object but absent from the patch are never touched. Invisible for fixed-key fields — the form always submits every key — but `parameters` is a map whose key set *is* the data, so it can only ever grow.

Reproduced against the real `deepMerge` with a stored Snowflake `parameters`:

| patch | before |
|---|---|
| add `TIMEZONE` | ✅ |
| change `QUERY_TAG` | ✅ |
| drop one key | ❌ key survives |
| `parameters: {}` | ❌ all keys survive |

## Why not just make updates replace

`merge` runs `removeMaskedValues` first, so the UI's masked secrets are stripped from the patch and `deepMerge` is the only reason the stored `password` / `privateKey` survives a save. Merge semantics are also load-bearing for genuine partial updates:

- `ApiKeyEditor.tsx` auto-save on adding a write key → `{ privateKeys: [...] }` only
- `ProfileBuilderPage.tsx` save/rollback → `{ draft, type }` only
- `jitsu-cli config update --field.path=value`
- the MCP `update_resource` tool, documented as "merged into the existing object"

The CLI is published to npm, so old versions would keep sending partial PUTs indefinitely — flipping PUT to replace would silently destroy config for anyone who hasn't upgraded.

## Fix

Merge everything as before, except fields whose schema leaves the key set **open** — those get replaced.

- **Destinations (zod)** — `ZodRecord`, `.passthrough()`, or a `ZodObject` with a non-`ZodNever` catchall. The catchall is the signal, not an empty shape: Mysql's `parameters` declares `tls` *alongside* its catchall, so an "is `object({})`" test would miss it. Wrappers (`.optional()` / `.default()` / `.nullable()`) are unwrapped and declared sub-objects are recursed into.
- **Services (declarative)** — connectors carry Airbyte JSON Schema, not zod, so the equivalent signal is `type: "object"` with `additionalProperties`. Walks nested objects and `oneOf`/`anyOf` branches, mirroring `getServiceSecretPaths`.

Replacement is keyed off the patch (`has(patch, path)`): a map the caller didn't send is left alone, so every partial-update caller above keeps working and secrets stay put. A map the caller *did* send — including an empty `{}` — replaces what's stored.

Affects `parameters` on ClickHouse, Snowflake and Mysql today, and any future field declared the same way, without a hardcoded list.

## Testing

`__tests__/unit/free-form-maps.test.ts` — 13 cases: detection across the three warehouses plus a closed-schema and unknown destination; add / change / remove-one / remove-all; other fields still merging; a partial patch leaving both the map and the stored secret intact; and the JSON-Schema walk over nesting, `oneOf`, closed objects and empty specs.

- `vitest run --project unit` — 43 passed
- `tsc --noEmit` — clean

## Note

There is one behaviour change: a partial patch that touches a map now replaces it rather than merging into it, so `parameters: { tls: "true" }` drops the other entries. That's inherent to treating the map as the unit of edit and is what makes removal work.

Related: `config-objects.ts:198-201` carries a `// TODO: dirty workaround for not be able to clear authorizedJavaScriptDomains` — same root cause, left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


JITSU-160
