### PR TITLE
feat(console): JITSU_CONSOLE_READ_ONLY env switch for canary deployments

### DIFF
--- a/webapps/console/lib/api.ts
+++ b/webapps/console/lib/api.ts
@@ -9,7 +9,7 @@ import { getServerSession, Session } from "next-auth";
 import { nextAuthConfig } from "./nextauth.config";
 import { inferTokenTypeFromId, SessionUser } from "./schema";
 import { db } from "./server/db";
-import { isMaintenanceActive } from "./server/maintenance";
+import { isReadOnly } from "./server/maintenance";
 import { prepareZodObjectForDeserialization, safeParseWithDate } from "./zod";
 import { ApiError } from "./shared/errors";
 import { getServerLog } from "./server/log";
@@ -367,7 +367,7 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
     // descriptor sets `visible: false`).
     const isMutatingMethod = method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
     const isMutating = isMutatingMethod || !!handler.mutates;
-    const maintenanceBlocks = isMutating && !handler.allowDuringMaintenance && isMaintenanceActive();
+    const maintenanceBlocks = isMutating && !handler.allowDuringMaintenance && isReadOnly();
     if (maintenanceBlocks && !handler.auth) {
       res.status(503).json({
         error: "maintenance",

--- a/webapps/console/lib/api.ts
+++ b/webapps/console/lib/api.ts
@@ -9,7 +9,7 @@ import { getServerSession, Session } from "next-auth";
 import { nextAuthConfig } from "./nextauth.config";
 import { inferTokenTypeFromId, SessionUser } from "./schema";
 import { db } from "./server/db";
-import { isReadOnly } from "./server/maintenance";
+import { isMaintenanceActive, isReadOnly } from "./server/maintenance";
 import { prepareZodObjectForDeserialization, safeParseWithDate } from "./zod";
 import { ApiError } from "./shared/errors";
 import { getServerLog } from "./server/log";
@@ -367,12 +367,19 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
     // descriptor sets `visible: false`).
     const isMutatingMethod = method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
     const isMutating = isMutatingMethod || !!handler.mutates;
-    const maintenanceBlocks = isMutating && !handler.allowDuringMaintenance && isReadOnly();
-    if (maintenanceBlocks && !handler.auth) {
-      res.status(503).json({
-        error: "maintenance",
-        message: "Jitsu is in maintenance mode; modifications are temporarily disabled.",
-      });
+    const writeBlocked = isMutating && !handler.allowDuringMaintenance && isReadOnly();
+    // Distinguish the two reasons writes are blocked. A time-boxed maintenance
+    // window keeps the maintenance-coded 503 the frontend renders a banner for.
+    // The permanent read-only switch (JITSU_CONSOLE_READ_ONLY — canary/preview
+    // deployments, JITSU-159) must NOT masquerade as maintenance: there is no
+    // window to "end", and mislabeling it skews clients and alerting. It just
+    // rejects the write plainly.
+    const writeBlockedResponse = () =>
+      isMaintenanceActive()
+        ? { error: "maintenance", message: "Jitsu is in maintenance mode; modifications are temporarily disabled." }
+        : { error: "read_only", message: "This Jitsu deployment is read-only; modifications are disabled." };
+    if (writeBlocked && !handler.auth) {
+      res.status(503).json(writeBlockedResponse());
       return;
     }
     let currentUser: SessionUser | undefined = undefined;
@@ -385,13 +392,10 @@ export function nextJsApiHandler(api: Api): NextApiHandler {
           res.status(401).send({ error: "Authorization Required" });
           return;
         }
-        // Auth-required routes only learn about maintenance *after* successful
+        // Auth-required routes only learn about the write block *after* successful
         // auth — see the rationale above.
-        if (maintenanceBlocks) {
-          res.status(503).json({
-            error: "maintenance",
-            message: "Jitsu is in maintenance mode; modifications are temporarily disabled.",
-          });
+        if (writeBlocked) {
+          res.status(503).json(writeBlockedResponse());
           return;
         }
       }

--- a/webapps/console/lib/server/db.ts
+++ b/webapps/console/lib/server/db.ts
@@ -3,7 +3,7 @@ import { Pool, PoolClient } from "pg";
 import Cursor from "pg-cursor";
 import { getSingleton, namedParameters, newError, requireDefined, stopwatch, hideSensitiveInfo } from "juava";
 import { getServerLog } from "./log";
-import { isMaintenanceActive } from "./maintenance";
+import { isReadOnly } from "./maintenance";
 import { isTruish } from "../shared/chores";
 import { getServerEnv } from "./serverEnv";
 
@@ -228,7 +228,7 @@ export function createPrisma(): PrismaClient {
     query: {
       $allModels: {
         async $allOperations({ operation, args, query }) {
-          if (isMaintenanceActive() && mutationActions.find(candidate => operation.indexOf(candidate) === 0)) {
+          if (isReadOnly() && mutationActions.find(candidate => operation.indexOf(candidate) === 0)) {
             throw new Error(`Prisma operation ${operation} is not allowed in read-only mode`);
           }
           return query(args);

--- a/webapps/console/lib/server/maintenance.ts
+++ b/webapps/console/lib/server/maintenance.ts
@@ -104,9 +104,20 @@ export function getMaintenanceState(): MaintenanceState | undefined {
   return cache.value;
 }
 
-// The master switch for read-only enforcement.
+// True while a maintenance window is active. Drives the maintenance-page /
+// public-state and DB-offline semantics. For plain write-blocking use
+// `isReadOnly()` instead, which also covers the permanent read-only env switch.
 export function isMaintenanceActive(): boolean {
   return getMaintenanceState()?.active === true;
+}
+
+// The shared write-blocking gate. Writes are rejected when EITHER a maintenance
+// window is active OR the deployment is pinned read-only via JITSU_CONSOLE_READ_ONLY
+// (canary / preview deployments — see JITSU-159). Callers that enforce read-only
+// (lib/api.ts, lib/server/db.ts, the MCP tool router) must use this rather than
+// isMaintenanceActive() so the env switch is honoured everywhere.
+export function isReadOnly(): boolean {
+  return isMaintenanceActive() || getServerEnv().JITSU_CONSOLE_READ_ONLY === true;
 }
 
 // True iff maintenance is active AND the descriptor declares the DB is offline.

--- a/webapps/console/lib/server/mcp-server/tools.ts
+++ b/webapps/console/lib/server/mcp-server/tools.ts
@@ -7,7 +7,7 @@ import { SessionUser } from "../../schema";
 import { getResourceJsonSchema } from "../../schema/json-schema";
 import { ApiError } from "../../shared/errors";
 import { getServerLog } from "../log";
-import { isReadOnly } from "../maintenance";
+import { isMaintenanceActive, isReadOnly } from "../maintenance";
 import { type ConfigObjectsService, WORKSPACES_PAGE_MAX } from "../config-objects-service";
 import { type EventsLogService, QUERYABLE_TYPES } from "../events-log-service";
 import { type SyncService } from "../sync-service";
@@ -119,18 +119,22 @@ export function registerTools(sdkServer: SdkMcpServer, deps: ToolDeps) {
   const typeList = types.join(", ");
   const eventTypeList = QUERYABLE_TYPES.join(", ");
 
-  // Mutating HTTP routes are blocked while maintenance mode is active (see createRoute
+  // Mutating HTTP routes are blocked while writes are disabled (see createRoute
   // in lib/api.ts). MCP tools don't go through createRoute, so enforce the same
-  // read-only window here: any tool not annotated read-only is rejected during
-  // maintenance before its handler runs.
+  // gate here: any tool not annotated read-only is rejected before its handler
+  // runs. Distinguish a time-boxed maintenance window from the permanent
+  // read-only switch (JITSU_CONSOLE_READ_ONLY) so the latter isn't mislabeled.
   const register: SdkMcpServer["registerTool"] = (name, config, cb) =>
     sdkServer.registerTool(name, config, (async (args: any, extra: any) => {
       if (!config.annotations?.readOnlyHint && isReadOnly()) {
+        const text = isMaintenanceActive()
+          ? "Error (503): Jitsu is in maintenance mode; modifications are temporarily disabled."
+          : "Error (503): Jitsu is read-only; modifications are disabled.";
         return {
           content: [
             {
               type: "text",
-              text: "Error (503): Jitsu is in maintenance mode; modifications are temporarily disabled.",
+              text,
             },
           ],
           isError: true,

--- a/webapps/console/lib/server/mcp-server/tools.ts
+++ b/webapps/console/lib/server/mcp-server/tools.ts
@@ -7,7 +7,7 @@ import { SessionUser } from "../../schema";
 import { getResourceJsonSchema } from "../../schema/json-schema";
 import { ApiError } from "../../shared/errors";
 import { getServerLog } from "../log";
-import { isMaintenanceActive } from "../maintenance";
+import { isReadOnly } from "../maintenance";
 import { type ConfigObjectsService, WORKSPACES_PAGE_MAX } from "../config-objects-service";
 import { type EventsLogService, QUERYABLE_TYPES } from "../events-log-service";
 import { type SyncService } from "../sync-service";
@@ -125,7 +125,7 @@ export function registerTools(sdkServer: SdkMcpServer, deps: ToolDeps) {
   // maintenance before its handler runs.
   const register: SdkMcpServer["registerTool"] = (name, config, cb) =>
     sdkServer.registerTool(name, config, (async (args: any, extra: any) => {
-      if (!config.annotations?.readOnlyHint && isMaintenanceActive()) {
+      if (!config.annotations?.readOnlyHint && isReadOnly()) {
         return {
           content: [
             {

--- a/webapps/console/lib/server/serverEnv.ts
+++ b/webapps/console/lib/server/serverEnv.ts
@@ -369,12 +369,20 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   DATA_DOMAIN: z.string().optional(),
 
   // Maintenance descriptor as a JSON object (fallback when no ConfigMap file is mounted).
-  // Read-only enforcement is driven entirely by this descriptor — there is no separate
-  // JITSU_CONSOLE_READ_ONLY_UNTIL env var anymore.
+  // Time-boxed maintenance windows are driven entirely by this descriptor.
   MAINTENANCE: z.string().optional(),
   // Path to a mounted ConfigMap JSON file holding the maintenance descriptor. Takes
   // precedence over MAINTENANCE so maintenance can be toggled at runtime without redeploy.
   MAINTENANCE_CONFIG_FILE: z.string().optional(),
+
+  // Hard, permanent read-only switch, independent of the maintenance descriptor.
+  // When true the API layer, the Prisma backstop and MCP tools all reject writes
+  // (same enforcement as an active maintenance window) but WITHOUT showing a
+  // maintenance page or claiming the DB is offline — reads work normally. Set for
+  // canary / preview deployments (see JITSU-159) that share the production DB and
+  // must never mutate it. Unlike MAINTENANCE this is a deploy-time constant, not a
+  // runtime-toggleable window.
+  JITSU_CONSOLE_READ_ONLY: z.string().default("false").transform(isTruish),
 
   // Documentation website URL
   JITSU_DOCUMENTATION_URL: z.string().optional().default("https://docs.jitsu.com/"),

--- a/webapps/console/pages/api/admin/sync-quota-check.ts
+++ b/webapps/console/pages/api/admin/sync-quota-check.ts
@@ -4,7 +4,7 @@ import { getServerEnv } from "../../../lib/server/serverEnv";
 import { getServerLog } from "../../../lib/server/log";
 import { checkQuota } from "../../../lib/server/sync";
 import { isEEAvailable } from "../../../lib/server/ee";
-import { isReadOnly } from "../../../lib/server/maintenance";
+import { isMaintenanceActive, isReadOnly } from "../../../lib/server/maintenance";
 
 const log = getServerLog("sync-quota-check");
 const serverEnv = getServerEnv();
@@ -45,11 +45,17 @@ export default createRoute()
     // retries on its next tick, so this naturally turns into a "wait until
     // maintenance ends" loop without any extra coordination.
     if (isReadOnly()) {
+      const maintenance = isMaintenanceActive();
       log.atInfo().log(`Sync ${query.syncId} (workspace ${query.workspaceId}) blocked: read-only mode is active`);
       res.status(200).send({
         ok: false,
-        error: "Jitsu is in maintenance mode; sync is blocked until the maintenance window ends.",
-        errorType: "maintenance",
+        // Time-boxed maintenance keeps its "until the window ends" wording; the
+        // permanent read-only switch (JITSU_CONSOLE_READ_ONLY) has no window, so
+        // don't promise one. The sidecar blocks on ok=false either way.
+        error: maintenance
+          ? "Jitsu is in maintenance mode; sync is blocked until the maintenance window ends."
+          : "Jitsu is running read-only; sync is blocked.",
+        errorType: maintenance ? "maintenance" : "read_only",
       });
       return;
     }

--- a/webapps/console/pages/api/admin/sync-quota-check.ts
+++ b/webapps/console/pages/api/admin/sync-quota-check.ts
@@ -4,7 +4,7 @@ import { getServerEnv } from "../../../lib/server/serverEnv";
 import { getServerLog } from "../../../lib/server/log";
 import { checkQuota } from "../../../lib/server/sync";
 import { isEEAvailable } from "../../../lib/server/ee";
-import { isMaintenanceActive } from "../../../lib/server/maintenance";
+import { isReadOnly } from "../../../lib/server/maintenance";
 
 const log = getServerLog("sync-quota-check");
 const serverEnv = getServerEnv();
@@ -44,8 +44,8 @@ export default createRoute()
     // quota-check init container reads ok=false and exits 1; the k8s CronJob
     // retries on its next tick, so this naturally turns into a "wait until
     // maintenance ends" loop without any extra coordination.
-    if (isMaintenanceActive()) {
-      log.atInfo().log(`Sync ${query.syncId} (workspace ${query.workspaceId}) blocked: maintenance is active`);
+    if (isReadOnly()) {
+      log.atInfo().log(`Sync ${query.syncId} (workspace ${query.workspaceId}) blocked: read-only mode is active`);
       res.status(200).send({
         ok: false,
         error: "Jitsu is in maintenance mode; sync is blocked until the maintenance window ends.",

--- a/webapps/console/pages/api/init-user.ts
+++ b/webapps/console/pages/api/init-user.ts
@@ -7,7 +7,7 @@ import { ApiError } from "../../lib/shared/errors";
 import { initTelemetry, withProductAnalytics } from "../../lib/server/telemetry";
 import { onUserCreated } from "../../lib/server/ee";
 import { getServerEnv } from "../../lib/server/serverEnv";
-import { isMaintenanceActive } from "../../lib/server/maintenance";
+import { isReadOnly } from "../../lib/server/maintenance";
 import { shouldRejectPersonalEmailSignup } from "../../lib/server/signup-restrictions";
 import { WORK_EMAIL_REQUIRED_MESSAGE } from "../../lib/shared/email-domains";
 
@@ -39,7 +39,7 @@ export default createRoute()
         // 503 every login during maintenance. Gate just the create-profile
         // branch so brand-new signups get a clean maintenance error instead of
         // a generic 500 from the Prisma read-only backstop.
-        if (isMaintenanceActive()) {
+        if (isReadOnly()) {
           throw new ApiError(
             "Jitsu is in maintenance mode; account creation is temporarily disabled. Please try again later.",
             { status: 503, responseObject: { code: "maintenance" } }

--- a/webapps/console/pages/api/init-user.ts
+++ b/webapps/console/pages/api/init-user.ts
@@ -7,7 +7,7 @@ import { ApiError } from "../../lib/shared/errors";
 import { initTelemetry, withProductAnalytics } from "../../lib/server/telemetry";
 import { onUserCreated } from "../../lib/server/ee";
 import { getServerEnv } from "../../lib/server/serverEnv";
-import { isReadOnly } from "../../lib/server/maintenance";
+import { isMaintenanceActive, isReadOnly } from "../../lib/server/maintenance";
 import { shouldRejectPersonalEmailSignup } from "../../lib/server/signup-restrictions";
 import { WORK_EMAIL_REQUIRED_MESSAGE } from "../../lib/shared/email-domains";
 
@@ -36,13 +36,16 @@ export default createRoute()
         log.atInfo().log(`User ${user.internalId} has no profile in db. Creating a new one`);
         // The route's GET is a read for existing users (workspaceAccess found
         // above), so we can't flip it to `mutates: true` globally — that would
-        // 503 every login during maintenance. Gate just the create-profile
-        // branch so brand-new signups get a clean maintenance error instead of
-        // a generic 500 from the Prisma read-only backstop.
+        // 503 every login while writes are disabled. Gate just the create-profile
+        // branch so brand-new signups get a clean error instead of a generic 500
+        // from the Prisma read-only backstop. Distinguish a maintenance window
+        // from the permanent read-only switch so we don't imply a window to wait out.
         if (isReadOnly()) {
           throw new ApiError(
-            "Jitsu is in maintenance mode; account creation is temporarily disabled. Please try again later.",
-            { status: 503, responseObject: { code: "maintenance" } }
+            isMaintenanceActive()
+              ? "Jitsu is in maintenance mode; account creation is temporarily disabled. Please try again later."
+              : "Jitsu is read-only; account creation is disabled.",
+            { status: 503, responseObject: { code: isMaintenanceActive() ? "maintenance" : "read_only" } }
           );
         }
         if (serverEnv.DISABLE_SIGNUP) {


### PR DESCRIPTION
## What

Adds a permanent, deploy-time **read-only** switch for the console —
`JITSU_CONSOLE_READ_ONLY` (boolean env, default `false`) — and wires it into the
existing shared write-blocking gate.

## Why

Per-PR **canary console deployments** ([JITSU-159](https://linear.app/maroo/issue/JITSU-159))
share the **production database**. They must be able to read prod data but must
**never mutate it**. The console already had a shared gate (`isMaintenanceActive()`)
that blocks writes during maintenance windows; this reuses that machinery via a new
`isReadOnly()` helper so canaries get the same hard write protection at every layer.

## How

- **`serverEnv.ts`** — declare `JITSU_CONSOLE_READ_ONLY` (parsed with `isTruish`).
- **`lib/server/maintenance.ts`** — new shared gate:
  ```ts
  export function isReadOnly(): boolean {
    return isMaintenanceActive() || getServerEnv().JITSU_CONSOLE_READ_ONLY === true;
  }
  ```
- Repoint every write-enforcement site from `isMaintenanceActive()` → `isReadOnly()`:
  - `lib/api.ts` — mutating-request 503 gate
  - `lib/server/db.ts` — Prisma read-only backstop (catch-all for **all** writes)
  - `lib/server/mcp-server/tools.ts` — MCP tool router
  - `pages/api/init-user.ts` — account-creation short-circuit
  - `pages/api/admin/sync-quota-check.ts` — sync admission gate

## Semantics

Read-only ≠ maintenance. The env switch blocks writes but shows **no maintenance
page** and does **not** report the DB as offline (`getPublicMaintenanceState()` /
`isDatabaseOff()` still key off the maintenance descriptor only). Reads work
normally. Unlike `MAINTENANCE`, this is a deploy-time constant, not a
runtime-toggleable window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)