### PR TITLE
Console: retention-aware backupEnabled + server-side backup bucket provisioning (JITSU-143)

### DIFF
--- a/webapps/console/components/ConfigObjectEditor/ConfigEditor.tsx
+++ b/webapps/console/components/ConfigObjectEditor/ConfigEditor.tsx
@@ -28,7 +28,6 @@ import {
 
 import { ConfigEntityBase } from "../../lib/schema";
 import { useAppConfig, useWorkspace, useWorkspaceRole } from "../../lib/context";
-import { useEeApi } from "../../lib/eeApi";
 import { LoadingAnimation } from "../GlobalLoader/GlobalLoader";
 import { WLink } from "../Workspace/WLink";
 import { CheckCircleTwoTone, DeleteOutlined, InfoCircleTwoTone } from "@ant-design/icons";
@@ -633,18 +632,12 @@ const SingleObjectEditor: React.FC<SingleObjectEditorProps> = props => {
   const appConfig = useAppConfig();
   const router = useRouter();
   const reloadStore = useStoreReload();
-  const { eeRpc } = useEeApi();
 
   const onSaveMutation = useConfigObjectMutation(type as any, async (newObject: any) => {
     if (isNew) {
+      // Backup-bucket provisioning happens server-side in config-objects-service
+      // on stream creation (ee-api s3-init), so all creation paths get it.
       await getConfigApi(workspace.id, type).create(newObject);
-      if (type === "stream" && appConfig.ee.available) {
-        try {
-          await eeRpc("s3-init", { method: "GET", query: { workspaceId: workspace.id } });
-        } catch (e: any) {
-          console.error("Failed to init S3 bucket", e.message);
-        }
-      }
     } else {
       await getConfigApi(workspace.id, type).update(object.id, newObject);
     }

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import type { NextApiRequest } from "next";
-import { deepCopy, randomId, requireDefined } from "juava";
+import { deepCopy, randomId, requireDefined, rpc } from "juava";
 import { SessionUser, SyncOptionsType } from "../schema";
 import { getAllConfigObjectTypeNames, getConfigObjectType, parseObject } from "../schema/config-objects";
 import { containsMaskedSecrets, unmaskSecretsFromOriginal } from "../schema/secrets";
@@ -11,6 +11,7 @@ import { ApiError } from "../shared/errors";
 import { configObjectAuditLog } from "./audit-log";
 import { productTelemetryEnabled, trackTelemetryEvent, withProductAnalytics } from "./telemetry";
 import { scheduleSync, validateSyncSchedule } from "./sync";
+import { getEeConnection, isEEAvailable, serviceTokenHeaders } from "./ee";
 import { omitDeletedList } from "./omit-deleted";
 import { getServerLog } from "./log";
 
@@ -251,6 +252,21 @@ export class ConfigObjectsService {
       { user, workspace, req: opts.req }
     );
     await configObjectAuditLog(user, workspaceId, created.id, type, "create", { newVersion: object }, opts.req);
+
+    if (type === "stream" && isEEAvailable()) {
+      // Provision the workspace's event-archive bucket on first stream. Server-side
+      // so API/MCP/CLI stream creation triggers it too (this replaced a browser-only
+      // eeRpc call in ConfigEditor). Best-effort: the hourly backup-retention-sync
+      // job on ee-api is the backstop, so a failure must not fail stream creation.
+      try {
+        await rpc(`${getEeConnection().host}api/s3-init?workspaceId=${encodeURIComponent(workspaceId)}`, {
+          method: "GET",
+          headers: { "Content-Type": "application/json", ...serviceTokenHeaders() },
+        });
+      } catch (e) {
+        log.atWarn().withCause(e).log(`Failed to provision backup bucket for workspace ${workspaceId}`);
+      }
+    }
     return { id: created.id };
   }
 

--- a/webapps/console/lib/server/config-objects-service.ts
+++ b/webapps/console/lib/server/config-objects-service.ts
@@ -262,6 +262,9 @@ export class ConfigObjectsService {
         await rpc(`${getEeConnection().host}api/s3-init?workspaceId=${encodeURIComponent(workspaceId)}`, {
           method: "GET",
           headers: { "Content-Type": "application/json", ...serviceTokenHeaders() },
+          // This await sits on the stream-creation response path; a hung
+          // ee-api must degrade to the reconciler backstop, not stall the UI.
+          signal: AbortSignal.timeout(5_000),
         });
       } catch (e) {
         log.atWarn().withCause(e).log(`Failed to provision backup bucket for workspace ${workspaceId}`);

--- a/webapps/console/lib/shared/data-retention.ts
+++ b/webapps/console/lib/shared/data-retention.ts
@@ -10,6 +10,13 @@ export const DataRetentionSettings = z.object({
   }),
   customMongoDb: z.string().optional(),
   disableS3Archive: z.coerce.boolean().default(false).optional(),
+  /**
+   * Event-archive retention in hours; 0 disables archiving entirely (and
+   * drains the existing archive). Absent → the `nobackup` feature flag (a
+   * permanent alias for 0), then the 90-day default. Admin-set for now; see
+   * resolveRetentionHours().
+   */
+  backupRetentionHours: z.coerce.number().min(0).optional(),
   pendingUpdate: z.coerce.boolean().default(false).optional(),
 });
 
@@ -24,3 +31,47 @@ export const defaultDataRetentionSettings: DataRetentionSettings = {
     maxHours: 7 * 24,
   },
 };
+
+/**
+ * Intended default retention (90 days) for the eventual fleet-wide backfill.
+ * NOT applied implicitly: a workspace without an explicit setting is
+ * "unmigrated" and keeps today's S3 behavior — see {@link resolveBackupMode}.
+ */
+export const DEFAULT_BACKUP_RETENTION_HOURS = 90 * 24;
+
+/**
+ * Migration gate (per-workspace): an explicit `backupRetentionHours` in the
+ * `WorkspaceOptions(namespace='data-retention')` JSON migrates the workspace
+ * to the GCS event archive with enforced retention (`0` = no archive at all;
+ * the existing archive drains). Without it the workspace is UNMIGRATED and
+ * keeps today's behavior: S3 archive, no retention enforcement, `nobackup`
+ * feature flag as the only off switch.
+ *
+ * The ee billing server mirrors this logic (`lib/data-retention.ts` in
+ * jitsu-cloud-billing) to emit bulker backup connections and manage bucket
+ * lifecycle rules — keep the two in sync. The raw value is parsed loosely
+ * (numbers or numeric strings) because rows are written through
+ * `z.coerce.number()` and may predate this field; garbage or negative values
+ * are treated as unset, i.e. unmigrated.
+ */
+export type BackupMode = { migrated: true; retentionHours: number } | { migrated: false; legacyBackupEnabled: boolean };
+
+export function resolveBackupMode(
+  featuresEnabled: string[] | null | undefined,
+  dataRetentionValue: unknown
+): BackupMode {
+  const raw = (dataRetentionValue as { backupRetentionHours?: unknown } | null | undefined)?.backupRetentionHours;
+  if (raw !== undefined && raw !== null && raw !== "") {
+    const hours = Number(raw);
+    if (Number.isFinite(hours) && hours >= 0) {
+      return { migrated: true, retentionHours: hours };
+    }
+  }
+  return { migrated: false, legacyBackupEnabled: !(featuresEnabled ?? []).includes("nobackup") };
+}
+
+/** Whether ingest should copy this workspace's events to the backup topic. */
+export function isBackupEnabled(featuresEnabled: string[] | null | undefined, dataRetentionValue: unknown): boolean {
+  const mode = resolveBackupMode(featuresEnabled, dataRetentionValue);
+  return mode.migrated ? mode.retentionHours > 0 : mode.legacyBackupEnabled;
+}

--- a/webapps/console/lib/shared/data-retention.ts
+++ b/webapps/console/lib/shared/data-retention.ts
@@ -11,10 +11,12 @@ export const DataRetentionSettings = z.object({
   customMongoDb: z.string().optional(),
   disableS3Archive: z.coerce.boolean().default(false).optional(),
   /**
-   * Event-archive retention in hours; 0 disables archiving entirely (and
-   * drains the existing archive). Absent → the `nobackup` feature flag (a
-   * permanent alias for 0), then the 90-day default. Admin-set for now; see
-   * resolveRetentionHours().
+   * Event-archive retention in hours; setting it migrates the workspace to
+   * the GCS archive with enforced retention, 0 meaning "no archive at all"
+   * (the existing archive drains). Absent = unmigrated: today's S3 behavior,
+   * `nobackup` feature flag as the only off switch, no implicit default.
+   * ADMIN-SET ONLY — the workspace-options POST endpoint strips it from
+   * member requests. See resolveBackupMode().
    */
   backupRetentionHours: z.coerce.number().min(0).optional(),
   pendingUpdate: z.coerce.boolean().default(false).optional(),
@@ -61,13 +63,15 @@ export function resolveBackupMode(
   dataRetentionValue: unknown
 ): BackupMode {
   const raw = (dataRetentionValue as { backupRetentionHours?: unknown } | null | undefined)?.backupRetentionHours;
-  // Only numbers and numeric strings migrate — Number() would coerce booleans
-  // (true -> 1) and arrays, and a malformed row must never flip a workspace.
-  if ((typeof raw === "number" || typeof raw === "string") && raw !== "") {
-    const hours = Number(raw);
-    if (Number.isFinite(hours) && hours >= 0) {
-      return { migrated: true, retentionHours: hours };
-    }
+  // Only plain non-negative numbers and plain-decimal strings migrate.
+  // Number() would coerce booleans (true -> 1), arrays, and whitespace
+  // (" " -> 0 — i.e. "drain everything"); a malformed row must never flip a
+  // workspace, least of all to retention 0.
+  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
+    return { migrated: true, retentionHours: raw };
+  }
+  if (typeof raw === "string" && /^[0-9]+(\.[0-9]+)?$/.test(raw.trim()) && raw.trim() !== "") {
+    return { migrated: true, retentionHours: Number(raw.trim()) };
   }
   return { migrated: false, legacyBackupEnabled: !(featuresEnabled ?? []).includes("nobackup") };
 }

--- a/webapps/console/lib/shared/data-retention.ts
+++ b/webapps/console/lib/shared/data-retention.ts
@@ -70,8 +70,12 @@ export function resolveBackupMode(
   if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
     return { migrated: true, retentionHours: raw };
   }
-  if (typeof raw === "string" && /^[0-9]+(\.[0-9]+)?$/.test(raw.trim()) && raw.trim() !== "") {
-    return { migrated: true, retentionHours: Number(raw.trim()) };
+  if (typeof raw === "string" && /^[0-9]+(\.[0-9]+)?$/.test(raw.trim())) {
+    const hours = Number(raw.trim());
+    // A long digit string coerces to Infinity — still malformed, still unmigrated.
+    if (Number.isFinite(hours)) {
+      return { migrated: true, retentionHours: hours };
+    }
   }
   return { migrated: false, legacyBackupEnabled: !(featuresEnabled ?? []).includes("nobackup") };
 }

--- a/webapps/console/lib/shared/data-retention.ts
+++ b/webapps/console/lib/shared/data-retention.ts
@@ -61,7 +61,9 @@ export function resolveBackupMode(
   dataRetentionValue: unknown
 ): BackupMode {
   const raw = (dataRetentionValue as { backupRetentionHours?: unknown } | null | undefined)?.backupRetentionHours;
-  if (raw !== undefined && raw !== null && raw !== "") {
+  // Only numbers and numeric strings migrate — Number() would coerce booleans
+  // (true -> 1) and arrays, and a malformed row must never flip a workspace.
+  if ((typeof raw === "number" || typeof raw === "string") && raw !== "") {
     const hours = Number(raw);
     if (Number.isFinite(hours) && hours >= 0) {
       return { migrated: true, retentionHours: hours };

--- a/webapps/console/pages/_app.tsx
+++ b/webapps/console/pages/_app.tsx
@@ -14,7 +14,6 @@ import {
   UserContextProvider,
   useUser,
   useUserSafe,
-  useWorkspace,
   WorkspaceContextProvider,
 } from "../lib/context";
 import { AppConfig, ContextApiResponse, SessionUser } from "../lib/schema";

--- a/webapps/console/pages/_app.tsx
+++ b/webapps/console/pages/_app.tsx
@@ -31,8 +31,7 @@ import { VerifyEmailGate } from "../components/SignInOrUp/VerifyEmailGate";
 import { FirebaseSignup } from "../components/SignInOrUp/FirebaseSignup";
 import { JitsuButton } from "../components/JitsuButton/JitsuButton";
 import { BillingProvider } from "../components/Billing/BillingProvider";
-import { useEeApi } from "../lib/eeApi";
-import { useConfigObjectList, useConfigObjectsUpdater, useLoadedWorkspace } from "../lib/store";
+import { useConfigObjectsUpdater, useLoadedWorkspace } from "../lib/store";
 import { useQuery } from "@tanstack/react-query";
 import { get } from "../lib/useApi";
 import { WorkspaceRoleType, WorkspaceRoleWithPermissions, WorkspaceRolePermissions } from "../lib/workspace-roles";
@@ -421,31 +420,6 @@ const WorkspaceWrapper: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   } else {
     return <>{children}</>;
   }
-};
-
-/**
- * We need to get rid of this, and move this to the backend completely.
- *
- * We should actually use this component somewhere in the app
- * @constructor
- */
-export const S3BucketInitializer: React.FC<{}> = () => {
-  const appConfig = useAppConfig();
-  const workspace = useWorkspace();
-  const streams = useConfigObjectList("stream");
-  const { eeRpc } = useEeApi();
-  useEffect(() => {
-    (async () => {
-      if (appConfig.ee.available && workspace?.id && streams.length > 0) {
-        try {
-          await eeRpc("s3-init", { method: "GET", query: { workspaceId: workspace.id } });
-        } catch (e: any) {
-          console.error("Failed to init S3 bucket", e.message);
-        }
-      }
-    })();
-  }, [workspace?.id, streams, appConfig, eeRpc]);
-  return <></>;
 };
 
 const WorkspaceLoader: React.FC<

--- a/webapps/console/pages/api/admin/export/[name]/index.ts
+++ b/webapps/console/pages/api/admin/export/[name]/index.ts
@@ -162,6 +162,9 @@ async function exportBulkerConnections(writer: Writer) {
         "Content-Type": "application/json",
         ...serviceTokenHeaders(),
       },
+      // A stalled ee-api must fail this export fast (clean 500, bulker keeps
+      // its last good config), not hang the request until infra timeouts.
+      signal: AbortSignal.timeout(15_000),
     });
     if (!Array.isArray(response)) {
       //ee-api returns {error: "..."} when its object storage isn't configured

--- a/webapps/console/pages/api/admin/export/[name]/index.ts
+++ b/webapps/console/pages/api/admin/export/[name]/index.ts
@@ -142,6 +142,32 @@ async function getLastUpdated(): Promise<Date | undefined> {
 }
 
 async function exportBulkerConnections(writer: Writer) {
+  //pull event-archive (GCS/S3 backup) connections from ee-api BEFORE writing
+  //anything: an ee-api failure then surfaces as a clean 500 (headers not yet
+  //sent) instead of a truncated 200, and bulker/config-keeper keep their last
+  //good config. This export is consumed by the bulker service — there is no
+  //signed-in user — so it authenticates with the static service token.
+  //
+  //Deliberately NOT wrapped in try/catch: swallowing an ee-api failure here
+  //used to ship a well-formed export with no backup destinations at all,
+  //silently disarming archiving fleet-wide.
+  let backupConnections: any[] = [];
+  if (isEEAvailable()) {
+    const url = `${getEeConnection().host}api/s3-connections`;
+    const response = await rpc(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        ...serviceTokenHeaders(),
+      },
+    });
+    if (!Array.isArray(response)) {
+      //ee-api returns {error: "..."} when its object storage isn't configured
+      throw new Error(`Unexpected s3-connections response: ${JSON.stringify(response)}`);
+    }
+    backupConnections = response;
+  }
+
   writer.write("[");
 
   let lastId: string | undefined = undefined;
@@ -260,34 +286,12 @@ async function exportBulkerConnections(writer: Writer) {
       break;
     }
   }
-  if (isEEAvailable()) {
-    //pull event-archive (GCS backup) connections from ee-api. This export is
-    //consumed by the bulker service — there is no signed-in user — so it
-    //authenticates with the static service token.
-    //
-    //Deliberately NOT wrapped in try/catch: swallowing an ee-api failure here
-    //used to ship a well-formed export with no backup destinations at all,
-    //silently disarming archiving fleet-wide. Failing breaks the response
-    //mid-stream instead, and bulker keeps its last good config.
-    const url = `${getEeConnection().host}api/s3-connections`;
-    const backupConnections = await rpc(url, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        ...serviceTokenHeaders(),
-      },
-    });
-    if (!Array.isArray(backupConnections)) {
-      //ee-api returns {error: "GCS backup is not configured"} when unconfigured
-      throw new Error(`Unexpected s3-connections response: ${JSON.stringify(backupConnections)}`);
+  for (const conn of backupConnections) {
+    if (needComma) {
+      writer.write(",");
     }
-    for (const conn of backupConnections) {
-      if (needComma) {
-        writer.write(",");
-      }
-      writer.write(JSON.stringify(conn));
-      needComma = true;
-    }
+    writer.write(JSON.stringify(conn));
+    needComma = true;
   }
 
   writer.write("]");
@@ -576,12 +580,17 @@ async function exportStreamsWithDestinations(writer: Writer) {
     const pbs = pbMap.get(pb.workspaceId) || [];
     pbMap.set(pb.workspaceId, [...pbs, pb as unknown as ProfileBuilder]);
   }
-  // backup retention per workspace — drives backupEnabled below
+  // backup retention per workspace — drives backupEnabled below. Ascending
+  // order + Map overwrite = freshest row wins: (workspaceId, namespace) has no
+  // unique constraint, and the write path's find-then-create race can leave
+  // duplicate rows.
   const dataRetentionMap = new Map<string, unknown>(
-    (await db.prisma().workspaceOptions.findMany({ where: { namespace: "data-retention" } })).map(row => [
-      row.workspaceId,
-      row.value,
-    ])
+    (
+      await db.prisma().workspaceOptions.findMany({
+        where: { namespace: "data-retention" },
+        orderBy: { updatedAt: "asc" },
+      })
+    ).map(row => [row.workspaceId, row.value])
   );
 
   writer.write("[");

--- a/webapps/console/pages/api/admin/export/[name]/index.ts
+++ b/webapps/console/pages/api/admin/export/[name]/index.ts
@@ -135,8 +135,10 @@ async function getLastUpdated(): Promise<Date | undefined> {
                     (select max("updatedAt") from newjitsu."Workspace"),
                     -- backup retention lives in WorkspaceOptions(namespace='data-retention');
                     -- a retention change must invalidate streams-with-destinations
-                    -- (backupEnabled) and bulker-connections (backup destinations)
-                    (select max("updatedAt") from newjitsu."WorkspaceOptions")
+                    -- (backupEnabled) and bulker-connections (backup destinations).
+                    -- Scoped to that namespace: getLastUpdated() also gates
+                    -- rotor-connections/functions/syncs, which don't read options.
+                    (select max("updatedAt") from newjitsu."WorkspaceOptions" where namespace = 'data-retention')
             ) as "last_updated"`) as any
   )[0]["last_updated"];
 }

--- a/webapps/console/pages/api/admin/export/[name]/index.ts
+++ b/webapps/console/pages/api/admin/export/[name]/index.ts
@@ -593,7 +593,9 @@ async function exportStreamsWithDestinations(writer: Writer) {
     (
       await db.prisma().workspaceOptions.findMany({
         where: { namespace: "data-retention" },
-        orderBy: { updatedAt: "asc" },
+        // id as tiebreaker: same-millisecond concurrent writes (the very race
+        // that creates duplicates) can share an updatedAt
+        orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
       })
     ).map(row => [row.workspaceId, row.value])
   );

--- a/webapps/console/pages/api/admin/export/[name]/index.ts
+++ b/webapps/console/pages/api/admin/export/[name]/index.ts
@@ -11,6 +11,7 @@ import { default as stableHash } from "stable-hash";
 import { WorkspaceDbModel, FunctionsServerDbModel } from "../../../../../prisma/schema";
 import { ProfileBuilder } from "@jitsu/destination-functions";
 import { getServerEnv } from "../../../../../lib/server/serverEnv";
+import { isBackupEnabled } from "../../../../../lib/shared/data-retention";
 
 const serverEnv = getServerEnv();
 const defaultFunctionsClass = serverEnv.DEFAULT_FUNCTIONS_CLASS;
@@ -131,7 +132,11 @@ async function getLastUpdated(): Promise<Date | undefined> {
                     (select max("updatedAt") from newjitsu."ProfileBuilder"),
                     (select max("updatedAt") from newjitsu."ConfigurationObject"),
                     (select max("updatedAt") from newjitsu."FunctionsServer"),
-                    (select max("updatedAt") from newjitsu."Workspace")
+                    (select max("updatedAt") from newjitsu."Workspace"),
+                    -- backup retention lives in WorkspaceOptions(namespace='data-retention');
+                    -- a retention change must invalidate streams-with-destinations
+                    -- (backupEnabled) and bulker-connections (backup destinations)
+                    (select max("updatedAt") from newjitsu."WorkspaceOptions")
             ) as "last_updated"`) as any
   )[0]["last_updated"];
 }
@@ -256,27 +261,32 @@ async function exportBulkerConnections(writer: Writer) {
     }
   }
   if (isEEAvailable()) {
-    //pull S3 backup connections from ee-api. This export is consumed by the
-    //bulker service — there is no signed-in user — so it authenticates with
-    //the static service token.
+    //pull event-archive (GCS backup) connections from ee-api. This export is
+    //consumed by the bulker service — there is no signed-in user — so it
+    //authenticates with the static service token.
+    //
+    //Deliberately NOT wrapped in try/catch: swallowing an ee-api failure here
+    //used to ship a well-formed export with no backup destinations at all,
+    //silently disarming archiving fleet-wide. Failing breaks the response
+    //mid-stream instead, and bulker keeps its last good config.
     const url = `${getEeConnection().host}api/s3-connections`;
-    try {
-      const backupConnections = await rpc(url, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          ...serviceTokenHeaders(),
-        },
-      });
-      for (const conn of backupConnections) {
-        if (needComma) {
-          writer.write(",");
-        }
-        writer.write(JSON.stringify(conn));
-        needComma = true;
+    const backupConnections = await rpc(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        ...serviceTokenHeaders(),
+      },
+    });
+    if (!Array.isArray(backupConnections)) {
+      //ee-api returns {error: "GCS backup is not configured"} when unconfigured
+      throw new Error(`Unexpected s3-connections response: ${JSON.stringify(backupConnections)}`);
+    }
+    for (const conn of backupConnections) {
+      if (needComma) {
+        writer.write(",");
       }
-    } catch (e) {
-      console.error("Error getting backup connections", e);
+      writer.write(JSON.stringify(conn));
+      needComma = true;
     }
   }
 
@@ -566,6 +576,13 @@ async function exportStreamsWithDestinations(writer: Writer) {
     const pbs = pbMap.get(pb.workspaceId) || [];
     pbMap.set(pb.workspaceId, [...pbs, pb as unknown as ProfileBuilder]);
   }
+  // backup retention per workspace — drives backupEnabled below
+  const dataRetentionMap = new Map<string, unknown>(
+    (await db.prisma().workspaceOptions.findMany({ where: { namespace: "data-retention" } })).map(row => [
+      row.workspaceId,
+      row.value,
+    ])
+  );
 
   writer.write("[");
   let lastId: string | undefined = undefined;
@@ -609,7 +626,8 @@ async function exportStreamsWithDestinations(writer: Writer) {
             },
             workspaceId: obj.workspace.id,
           },
-          backupEnabled: isEEAvailable() && !(obj.workspace.featuresEnabled || []).includes("nobackup"),
+          backupEnabled:
+            isEEAvailable() && isBackupEnabled(obj.workspace.featuresEnabled, dataRetentionMap.get(obj.workspace.id)),
           throttle: throttlePercent,
           shard: shardNumber,
           // opt-in per workspace (Settings → Capture HTTP headers): ingest stores

--- a/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/[section]/index.tsx
+++ b/webapps/console/pages/api/workspace/[workspaceIdOrSlug]/[section]/index.tsx
@@ -49,6 +49,13 @@ export default createRoute()
     await verifyAccessWithRole(user, workspace.id, "editEntities");
     if (section == "data-retention") {
       (body as any).pendingUpdate = true;
+      // Admin-set only (JITSU-143): backupRetentionHours gates the workspace's
+      // migration to the GCS event archive and its retention enforcement —
+      // retention 0 drains the whole archive. This endpoint merges the body
+      // unvalidated for workspace editors, so the field must never be
+      // writable here; deleting it from the body preserves any existing
+      // admin-set value through the deep merge below.
+      delete (body as any).backupRetentionHours;
     }
     const existing = await db.prisma().workspaceOptions.findFirst({
       where: { workspaceId: workspace.id, namespace: section },


### PR DESCRIPTION
Console side of [JITSU-143](https://linear.app/maroo/issue/JITSU-143/per-workspace-backup-retention-move-event-archive-to-gcs). Companion PRs: jitsucom/jitsu-cloud-billing#32 (retention resolution, GCS connections, reconciler job) and jitsu-cloud-infra (GSA/KSA + CronJob).

Migration to the GCS archive is gated per workspace by an explicit `backupRetentionHours` in `WorkspaceOptions(namespace='data-retention')`; workspaces without it keep today's `nobackup`-flag behavior bit-for-bit, so this is a no-op for the whole fleet until workspaces are opted in.

## Changes

- **`lib/shared/data-retention.ts`**: `backupRetentionHours` field + `resolveBackupMode()` / `isBackupEnabled()`. Mirrored in jitsu-cloud-billing's `lib/data-retention.ts` — keep the two in sync.
- **streams-with-destinations export**: `backupEnabled` now goes through `isBackupEnabled()`; `getLastUpdated()` gains `WorkspaceOptions` so retention changes actually invalidate the exports (previously only `Workspace.updatedAt` was watched).
- **bulker-connections export**: dropped the try/catch that swallowed ee-api `s3-connections` failures — it shipped a well-formed export with zero backup destinations, silently disarming archiving fleet-wide. Now the export breaks mid-stream and bulker keeps its last good config.
- **Bucket provisioning moved server-side**: `configObjectsService.create()` calls ee-api `s3-init` on stream creation (covers UI, API and MCP callers; best-effort — the hourly reconciler on ee-api is the backstop). Removed the browser-side `eeRpc("s3-init")` call from `ConfigEditor` and deleted the dead `S3BucketInitializer` from `_app.tsx`.

No bulker changes needed: `gcs` is already a registered type and `accessKey: "workload_identity"` already routes to Application Default Credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)