### PR TITLE
Bulker: forbid ambient/workload_identity Google auth on customer destinations (JITSU-143)

### DIFF
--- a/bulker/bulkerlib/implementations/google_cloud_storage.go
+++ b/bulker/bulkerlib/implementations/google_cloud_storage.go
@@ -68,15 +68,21 @@ func (gc *GoogleConfig) Validate() error {
 		if err != nil {
 			return fmt.Errorf("Malformed google keyFile: %v", err)
 		}
-		gc.Credentials = option.WithCredentialsJSON(b)
+		// Pin to a service-account credential type: WithCredentials{JSON,File}
+		// are deprecated because they accept ANY credential config, so a
+		// customer-supplied keyFile could be an external_account /
+		// impersonated_service_account config that fetches tokens from an
+		// attacker-controlled URL. WithAuthCredentials* + ServiceAccount
+		// rejects those.
+		gc.Credentials = option.WithAuthCredentialsJSON(option.ServiceAccount, b)
 	case string:
 		if keyFile == "" || keyFile == "workload_identity" {
 			return errors.New("Google keyFile is required parameter (ambient/workload_identity credentials are not permitted)")
 		}
 		if strings.Contains(keyFile, "{") {
-			gc.Credentials = option.WithCredentialsJSON([]byte(keyFile))
+			gc.Credentials = option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(keyFile))
 		} else {
-			gc.Credentials = option.WithCredentialsFile(keyFile)
+			gc.Credentials = option.WithAuthCredentialsFile(option.ServiceAccount, keyFile)
 		}
 	default:
 		return errors.New("Google key_file must be string or json object")

--- a/bulker/bulkerlib/implementations/google_cloud_storage.go
+++ b/bulker/bulkerlib/implementations/google_cloud_storage.go
@@ -52,24 +52,26 @@ func (gc *GoogleConfig) Validate() error {
 			}
 		}
 	}
-	switch gc.KeyFile.(type) {
+	// An explicit credential is mandatory. Ambient / Application Default
+	// Credentials — the "workload_identity" sentinel, or an absent/empty
+	// keyFile that would otherwise fall through to ADC — is rejected outright:
+	// bulker would authenticate as its own service account against an
+	// attacker-controlled destination config, a confused deputy (e.g. writing
+	// to another tenant's event-archive bucket). Every success path below sets
+	// gc.Credentials, so no caller ever constructs an ADC client.
+	switch keyFile := gc.KeyFile.(type) {
 	case map[string]any:
-		keyFileObject := gc.KeyFile.(map[string]any)
-		if len(keyFileObject) == 0 {
+		if len(keyFile) == 0 {
 			return errors.New("Google keyFile is required parameter")
 		}
-		b, err := jsoniter.Marshal(keyFileObject)
+		b, err := jsoniter.Marshal(keyFile)
 		if err != nil {
 			return fmt.Errorf("Malformed google keyFile: %v", err)
 		}
 		gc.Credentials = option.WithCredentialsJSON(b)
 	case string:
-		keyFile := gc.KeyFile.(string)
-		if keyFile == "workload_identity" {
-			return nil
-		}
-		if keyFile == "" {
-			return errors.New("Google keyFile is required parameter")
+		if keyFile == "" || keyFile == "workload_identity" {
+			return errors.New("Google keyFile is required parameter (ambient/workload_identity credentials are not permitted)")
 		}
 		if strings.Contains(keyFile, "{") {
 			gc.Credentials = option.WithCredentialsJSON([]byte(keyFile))
@@ -92,14 +94,13 @@ type GoogleCloudStorage struct {
 }
 
 func NewGoogleCloudStorage(config *GoogleConfig) (*GoogleCloudStorage, error) {
-	var client *storage.Client
-	var err error
-	err = config.Validate()
-	if config.Credentials == nil {
-		client, err = storage.NewClient(context.Background())
-	} else {
-		client, err = storage.NewClient(context.Background(), config.Credentials)
+	// Validate both surfaces config errors AND guarantees an explicit
+	// credential (it rejects everything that would leave Credentials nil), so
+	// there is no ADC / ambient-identity client path here.
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
+	client, err := storage.NewClient(context.Background(), config.Credentials)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating google cloud storage client: %v", err)
 	}

--- a/bulker/bulkerlib/implementations/google_cloud_storage_test.go
+++ b/bulker/bulkerlib/implementations/google_cloud_storage_test.go
@@ -1,0 +1,36 @@
+package implementations
+
+import "testing"
+
+// TestGoogleConfigValidateForbidsAmbient locks in that Validate() requires an
+// explicit credential and never accepts ambient / Application Default
+// Credentials — the single chokepoint every gcs/bigquery construction path
+// flows through. See the confused-deputy note on Validate().
+func TestGoogleConfigValidateForbidsAmbient(t *testing.T) {
+	cases := []struct {
+		name    string
+		keyFile any
+		wantErr bool
+	}{
+		{"workload_identity sentinel", "workload_identity", true},
+		{"empty string", "", true},
+		{"absent keyFile (nil)", nil, true},
+		{"empty map", map[string]any{}, true},
+		{"wrong type", 42, true},
+		{"json key string", `{"type":"service_account"}`, false},
+		{"json key object", map[string]any{"type": "service_account"}, false},
+		{"file path", "/etc/gcp/key.json", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gc := &GoogleConfig{KeyFile: c.keyFile}
+			err := gc.Validate()
+			if (err != nil) != c.wantErr {
+				t.Fatalf("Validate() err=%v, wantErr=%v", err, c.wantErr)
+			}
+			if err == nil && gc.Credentials == nil {
+				t.Fatalf("Validate() succeeded but left Credentials nil — an ADC path")
+			}
+		})
+	}
+}

--- a/bulker/bulkerlib/implementations/sql/bigquery.go
+++ b/bulker/bulkerlib/implementations/sql/bigquery.go
@@ -128,19 +128,13 @@ func NewBigquery(bulkerConfig bulker.Config) (bulker.Bulker, error) {
 	if err := utils.ParseObject(bulkerConfig.DestinationConfig, config); err != nil {
 		return nil, fmt.Errorf("failed to parse destination config: %v", err)
 	}
-	var err error
-	err = config.Validate()
-	if err != nil {
+	// Validate guarantees an explicit credential (rejects ambient/
+	// workload_identity), so there is no ADC client path.
+	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate config: %v", err)
 	}
-	var client *bigquery.Client
 	ctx := context.Background()
-	if config.Credentials == nil {
-		client, err = bigquery.NewClient(ctx, config.Project)
-	} else {
-		client, err = bigquery.NewClient(ctx, config.Project, config.Credentials)
-	}
-
+	client, err := bigquery.NewClient(ctx, config.Project, config.Credentials)
 	if err != nil {
 		err = fmt.Errorf("error creating BigQuery client: %v", err)
 	}

--- a/bulker/connectors/firebase/firebase.go
+++ b/bulker/connectors/firebase/firebase.go
@@ -112,7 +112,7 @@ func (f FirebaseSource) Check(srcCfgPath string, logTracker airbyte.LogTracker) 
 
 	app, err := firebase.NewApp(ctx,
 		&firebase.Config{ProjectID: srcCfg.ProjectID},
-		option.WithCredentialsJSON([]byte(srcCfg.ServiceAccountKey)))
+		option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(srcCfg.ServiceAccountKey)))
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (f FirebaseSource) Discover(srcCfgPath string, logTracker airbyte.LogTracke
 
 	app, err := firebase.NewApp(ctx,
 		&firebase.Config{ProjectID: srcCfg.ProjectID},
-		option.WithCredentialsJSON([]byte(srcCfg.ServiceAccountKey)))
+		option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(srcCfg.ServiceAccountKey)))
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func (f FirebaseSource) Read(sourceCfgPath string, prevStatePath string, configu
 
 	app, err := firebase.NewApp(ctx,
 		&firebase.Config{ProjectID: srcCfg.ProjectID},
-		option.WithCredentialsJSON([]byte(srcCfg.ServiceAccountKey)))
+		option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(srcCfg.ServiceAccountKey)))
 	if err != nil {
 		return err
 	}

--- a/bulker/ingress-manager/app.go
+++ b/bulker/ingress-manager/app.go
@@ -25,7 +25,7 @@ func (a *Context) InitContext(settings *appbase.AppSettings) error {
 		return err
 	}
 	ctx := context.Background()
-	a.certMgr, err = certificatemanager.NewClient(ctx, option.WithCredentialsJSON([]byte(a.config.GoogleServiceAccountJson)))
+	a.certMgr, err = certificatemanager.NewClient(ctx, option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(a.config.GoogleServiceAccountJson)))
 	if err != nil {
 		return err
 	}

--- a/bulker/sync-sidecar/read.go
+++ b/bulker/sync-sidecar/read.go
@@ -58,16 +58,16 @@ type ReadSideCar struct {
 	// don't need an equivalent: the dbpool is configured with a 2-minute
 	// statement_timeout, so a stuck UpsertState fails fast with an error.
 	processRecordStart atomic.Int64
-	lastStateMessage  string
-	blk               bulker.Bulker
-	lastStream        *ActiveStream
-	processedStreams  map[string]*ActiveStream
-	catalog           *jsonorder.OrderedMap[string, *Stream]
-	destinationConfig map[string]any
-	initialState      string
-	fullSync          bool
-	eventsCounter     int
-	bytesCounter      int
+	lastStateMessage   string
+	blk                bulker.Bulker
+	lastStream         *ActiveStream
+	processedStreams   map[string]*ActiveStream
+	catalog            *jsonorder.OrderedMap[string, *Stream]
+	destinationConfig  map[string]any
+	initialState       string
+	fullSync           bool
+	eventsCounter      int
+	bytesCounter       int
 }
 
 func (s *ReadSideCar) Run() {


### PR DESCRIPTION
Part of [JITSU-143](https://linear.app/maroo/issue/JITSU-143). Companion PRs: jitsu-cloud-billing#33 (emit a dedicated SA key as the backup accessKey) and jitsu-cloud-infra#75 (writer GSA + drop psconn's storage grant).

## Problem

A gcs/bigquery destination whose credentials resolve to Application Default Credentials makes bulker authenticate as its **ambient psconn identity**. Since JITSU-143 gave psconn `objectAdmin` on `jitsu-backup-*`, a workspace member could self-serve a `gcs` destination with `bucket: jitsu-backup-<victim>` + ambient creds and read/write **another tenant's event archive** — a confused deputy. Destination configs are attacker-controlled.

## Fix — one chokepoint

Enforcement lives entirely in `GoogleConfig.Validate()`, which every gcs/bigquery construction path already flows through (`NewGCSBulker`/`NewBigquery`, reached by the live, `/test`, and sync-sidecar paths). It now:

- **Requires an explicit credential** and sets `gc.Credentials` on every success path — rejecting the `"workload_identity"` sentinel, an empty/absent `keyFile`, and malformed values. ADC was reachable not just via the literal string but via **any** value that left `Credentials` nil (a missing field), because `NewGoogleCloudStorage` previously swallowed `Validate()`'s error and fell through to ADC. That whole class is now closed.
- Since `Credentials` is guaranteed non-nil after a successful `Validate()`, the now-**unreachable `Credentials == nil` ADC branches** in `NewGoogleCloudStorage` and `NewBigquery` are deleted — no ADC client can be constructed at all.

No `Special`/app-layer plumbing is needed (an earlier draft of this PR added a per-call-site guard; it's removed in favor of this simpler single gate). The event-archive connection no longer needs an ambient exemption — ee-api emits an explicit jitsu-backup-writer key for it and fails the export if the key is absent (companion PRs), so nothing relies on ambient auth.

`google_cloud_storage_test.go` covers every keyFile shape (sentinel, empty, absent, wrong-type, JSON string, JSON object, file path) and asserts no success leaves `Credentials` nil.

Note: bigquery's `Ping` retains two pre-existing `Credentials == nil` branches that are now dead (a `*BigQuery` only exists post-`Validate`); left out of scope, safe to prune in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Second commit — deprecated credential API.** `option.WithCredentialsJSON/File` are deprecated (they accept *any* credential config, so an untrusted JSON could be an `external_account`/`impersonated_service_account` config that fetches tokens from an attacker-controlled URL). All 7 call sites — `GoogleConfig.Validate` (gcs/bigquery), the Firebase source connector, and ingress-manager — now use `WithAuthCredentials{JSON,File}(option.ServiceAccount, …)`, which pins to service-account keys and rejects other credential types. Mechanical, strictly tightening; every source is a documented SA key.