### PR TITLE
ci(console): build per-PR canary console image (JITSU-159)

### DIFF
--- a/.github/workflows/build-console-canary.yml
+++ b/.github/workflows/build-console-canary.yml
@@ -1,0 +1,90 @@
+# Builds a per-PR canary console image for JITSU-159.
+#
+# When a PR is labeled `canary:console`, this builds the console image from the
+# PR head and pushes `jitsucom/console:canary-<short_sha>`. The ArgoCD
+# ApplicationSet in jitsucom/jitsu-cloud-infra (k8s/canary-console) then deploys
+# it at pr<N>.use.jitsu.com in read-only mode.
+#
+# TRUST BOUNDARY — this MUST stay on `pull_request`, never `pull_request_target`.
+# GitHub withholds secrets (DOCKERHUB_*) from fork-triggered `pull_request` runs,
+# so a fork PR simply cannot build/push a canary image even if labeled. Combined
+# with the maintainer-only label, that means canary code is always maintainer-
+# opted-in code from a same-repo branch — the guardrail the whole canary design
+# leans on. Using pull_request_target would run PR code with our secrets and
+# break that boundary.
+#
+# TAG CONTRACT — the tag suffix is the FIRST 7 CHARS of the PR head SHA, which is
+# exactly ArgoCD's `head_short_sha_7` template parameter. The ApplicationSet
+# references `canary-{{.head_short_sha_7}}`; the two must stay in lockstep or
+# canaries ImagePullBackOff. We truncate the SHA string (not `git rev-parse
+# --short`, which is ambiguity-aware and can return >7 chars) so it matches
+# ArgoCD's plain truncation exactly.
+name: Build canary console image
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches: [newjitsu]
+
+# Newer pushes supersede in-flight builds for the same PR.
+concurrency:
+  group: canary-console-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & push canary console image
+    if: contains(github.event.pull_request.labels.*.name, 'canary:console')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: 📥 Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          # Build the PR's actual code, not the synthetic pull_request merge ref.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: cloud
+          endpoint: "jitsucom/newjitsu"
+
+      - name: 🏗️ Build and push canary console image
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REGISTRY: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${HEAD_SHA:0:7}"          # == ArgoCD head_short_sha_7
+          TAG="canary-${SHORT_SHA}"
+          IMAGE="${REGISTRY}/console:${TAG}"
+          echo "Building ${IMAGE} (head ${HEAD_SHA})"
+
+          # arm64 only: canaries inherit the production console's
+          # `nodeSelector: {purpose: sync}` + arm64 toleration (from
+          # k8s/jitsu-platform/values.yaml), so they schedule on the arm64 sync
+          # pool. Add linux/amd64 here if that placement ever changes.
+          docker buildx build \
+            --target console \
+            --platform linux/arm64 \
+            --build-arg JITSU_BUILD_VERSION="${TAG}" \
+            --build-arg JITSU_BUILD_DOCKER_TAG=canary \
+            --build-arg JITSU_BUILD_COMMIT_SHA="${HEAD_SHA}" \
+            --build-arg CI=true \
+            -t "${IMAGE}" \
+            -f all.Dockerfile \
+            --push \
+            .
+
+          echo "Pushed ${IMAGE}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Part of [JITSU-159](https://linear.app/maroo/issue/JITSU-159) — the build half of per-PR **canary console** deployments. Companion infra PR: jitsucom/jitsu-cloud-infra#73.

## What

Adds `.github/workflows/build-console-canary.yml`. When a PR is labeled **`canary:console`**, it builds the console image from the PR head and pushes **`jitsucom/console:canary-<short_sha>`**. The ArgoCD ApplicationSet in jitsu-cloud-infra (`k8s/canary-console`) then deploys it at `pr<N>.use.jitsu.com` in read-only mode.

## Key decisions

- **`pull_request`, NOT `pull_request_target`** — this is the trust boundary. GitHub withholds `DOCKERHUB_*` secrets from fork-triggered `pull_request` runs, so a fork PR cannot build/push a canary image even if labeled. Combined with the maintainer-only label, canary code is always maintainer-opted-in code from a same-repo branch.
- **Tag = first 7 chars of the PR head SHA** (`${HEAD_SHA:0:7}`), which is exactly ArgoCD's `head_short_sha_7` and matches this repo's `--short=7` convention. The ApplicationSet references `canary-{{.head_short_sha_7}}`; the two must stay in lockstep or canaries `ImagePullBackOff`. Deliberately not `git rev-parse --short` (which can grow past 7 on ambiguity).
- **Single `console` target, `linux/arm64`** — canaries inherit the prod console's `nodeSelector: {purpose: sync}` + arm64 toleration, so they schedule on the arm64 sync pool. (Comment flags adding amd64 if that placement changes.)
- Mirrors the existing `services.yaml` publish patterns: `docker/login-action@v4` (`DOCKERHUB_USERNAME`/`TOKEN`), buildx cloud driver (`endpoint: jitsucom/newjitsu`), `docker buildx build --target console -f all.Dockerfile .` with the `JITSU_BUILD_*` args.
- `permissions: contents: read`; per-PR `concurrency` with `cancel-in-progress`.

## Notes

- Old `canary-<sha>` tags accumulate in Docker Hub across pushes (not garbage-collected here) — acceptable; can add cleanup later.
- Requires the `canary:console` label to exist in the repo and the DNS/token/controller prerequisites tracked in the infra PR before canaries are live end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
