### PR TITLE
JITSU-138: thread workspaceId and messageId to Live Events write sites

### DIFF
--- a/bulker/bulkerapp/app/abstract_consumer.go
+++ b/bulker/bulkerapp/app/abstract_consumer.go
@@ -50,6 +50,20 @@ func (ac *AbstractConsumer) GetInstanceId() string {
 	return fmt.Sprintf("%x-%s", firstByte, ac.config.InstanceId)
 }
 
+// MessageIdFromMetricsMeta extracts messageId from serialized 'metrics_meta' kafka header
+func MessageIdFromMetricsMeta(metricsMeta string) string {
+	if metricsMeta == "" {
+		return ""
+	}
+	meta := struct {
+		MessageId string `json:"messageId"`
+	}{}
+	if err := jsoniter.Unmarshal([]byte(metricsMeta), &meta); err != nil {
+		return ""
+	}
+	return meta.MessageId
+}
+
 func (ac *AbstractConsumer) SendMetrics(metricsMeta string, status string, events int) {
 	if metricsMeta == "" || events <= 0 {
 		return

--- a/bulker/bulkerapp/app/batch_consumer.go
+++ b/bulker/bulkerapp/app/batch_consumer.go
@@ -460,7 +460,11 @@ func (bc *BatchConsumerImpl) postEventsLog(state bulker.State, processedObjectSa
 	if batchErr != nil {
 		level = eventslog.LevelError
 	}
-	bc.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeBatch, Level: level, ActorId: bc.destinationId, Event: batchState})
+	workspaceId := ""
+	if destination := bc.repository.GetDestination(bc.destinationId); destination != nil {
+		workspaceId = destination.WorkspaceId()
+	}
+	bc.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeBatch, Level: level, ActorId: bc.destinationId, WorkspaceId: workspaceId, Event: batchState})
 }
 
 type BatchState struct {

--- a/bulker/bulkerapp/app/configuration_source.go
+++ b/bulker/bulkerapp/app/configuration_source.go
@@ -21,6 +21,7 @@ const defaultEnvDestinationPrefix = "DESTINATION"
 type DestinationConfig struct {
 	UpdatedAt           time.Time `mapstructure:"updatedAt" json:"updatedAt"`
 	UsesBulker          bool      `mapstructure:"usesBulker" json:"usesBulker"`
+	WorkspaceId         string    `mapstructure:"workspaceId" json:"workspaceId"`
 	bulker.Config       `mapstructure:",squash"`
 	bulker.StreamConfig `mapstructure:",squash"`
 	Special             string `mapstructure:"special" json:"special"`

--- a/bulker/bulkerapp/app/repository.go
+++ b/bulker/bulkerapp/app/repository.go
@@ -226,6 +226,11 @@ func (d *Destination) Id() string {
 	return d.config.Id()
 }
 
+// WorkspaceId returns id of workspace that owns the destination. Empty for special and env-configured destinations
+func (d *Destination) WorkspaceId() string {
+	return d.config.WorkspaceId
+}
+
 func (d *Destination) InitBulkerInstance() {
 	if d.bulker != nil {
 		return

--- a/bulker/bulkerapp/app/router.go
+++ b/bulker/bulkerapp/app/router.go
@@ -330,7 +330,11 @@ func (r *Router) postEventsLog(destinationId string, state bulker.State, process
 	if batchErr != nil {
 		level = eventslog.LevelError
 	}
-	r.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeBatch, Level: level, ActorId: destinationId, Event: batchState})
+	workspaceId := ""
+	if destination := r.repository.GetDestination(destinationId); destination != nil {
+		workspaceId = destination.WorkspaceId()
+	}
+	r.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeBatch, Level: level, ActorId: destinationId, WorkspaceId: workspaceId, Event: batchState})
 }
 
 func maskWriteKey(wk string) string {

--- a/bulker/bulkerapp/app/stream_consumer.go
+++ b/bulker/bulkerapp/app/stream_consumer.go
@@ -257,7 +257,7 @@ func (sc *StreamConsumerImpl) start() {
 				state, processedObject, err = sc.stream.Load().Consume(context.Background(), message)
 				processedPerInterval++
 				queueSize--
-				sc.postEventsLog(message.Value, state.Representation, processedObject, queueSize, speed, err)
+				sc.postEventsLog(message.Value, MessageIdFromMetricsMeta(metricsMeta), state.Representation, processedObject, queueSize, speed, err)
 				if err != nil {
 					metrics.ConsumerErrors(sc.topicId, "stream", sc.destination.Id(), sc.tableName, "bulker_stream_error").Inc()
 					sc.Errorf("Failed to inject event to bulker stream: %v", err)
@@ -344,7 +344,7 @@ func (sc *StreamConsumerImpl) UpdateDestination(destination *Destination) error 
 	return nil
 }
 
-func (sc *StreamConsumerImpl) postEventsLog(message []byte, representation any, processedObject types.Object, queueSize float64, speed float64, processedErr error) {
+func (sc *StreamConsumerImpl) postEventsLog(message []byte, messageId string, representation any, processedObject types.Object, queueSize float64, speed float64, processedErr error) {
 	object := map[string]any{
 		"original":  string(message),
 		"status":    "SUCCESS",
@@ -364,5 +364,5 @@ func (sc *StreamConsumerImpl) postEventsLog(message []byte, representation any, 
 		object["status"] = "FAILED"
 		level = eventslog.LevelError
 	}
-	sc.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeProcessed, Level: level, ActorId: sc.destination.Id(), Event: object})
+	sc.eventsLogService.PostAsync(&eventslog.ActorEvent{EventType: eventslog.EventTypeProcessed, Level: level, ActorId: sc.destination.Id(), WorkspaceId: sc.destination.WorkspaceId(), MessageId: messageId, Event: object})
 }

--- a/bulker/eventslog/events_log.go
+++ b/bulker/eventslog/events_log.go
@@ -45,6 +45,10 @@ type ActorEvent struct {
 	EventType EventType
 	Level     Level
 	ActorId   string
+	// WorkspaceId of the actor. May be empty for callers that don't have it in scope (e.g. 'incoming' events before stream resolution)
+	WorkspaceId string
+	// MessageId of the source event this record was produced for, when the record relates to a single event
+	MessageId string
 	Event     any
 	Timestamp time.Time
 }

--- a/bulker/eventslog/events_log_test.go
+++ b/bulker/eventslog/events_log_test.go
@@ -31,7 +31,7 @@ func TestEventsLog(t *testing.T) {
 			"_timestamp": ts,
 			"id":         i,
 		}
-		id, err := redisEl.PostEvent(&ActorEvent{EventTypeIncoming, LevelInfo, "test", event, time.Now()})
+		id, err := redisEl.PostEvent(&ActorEvent{EventType: EventTypeIncoming, Level: LevelInfo, ActorId: "test", Event: event, Timestamp: time.Now()})
 		reqr.NoError(err)
 		logging.Infof("Posted event %s", id)
 		// for latter testing of interval filters

--- a/bulker/ingest/router.go
+++ b/bulker/ingest/router.go
@@ -742,10 +742,12 @@ func (r *Router) callFunctionsEndpoint(stream *StreamWithDestinations, destinati
 			obj := map[string]any{"error": err.Error()}
 			for _, id := range ids {
 				r.eventsLogService.PostAsync(&eventslog.ActorEvent{
-					EventType: eventslog.EventTypeFunction,
-					Level:     eventslog.LevelError,
-					ActorId:   id,
-					Event:     obj,
+					EventType:   eventslog.EventTypeFunction,
+					Level:       eventslog.LevelError,
+					ActorId:     id,
+					WorkspaceId: stream.Stream.WorkspaceId,
+					MessageId:   messageId,
+					Event:       obj,
 				})
 				DeviceFunctions(id, "error").Inc()
 				DeviceFunctions("total", "error").Inc()
@@ -804,14 +806,14 @@ func (r *Router) callFunctionsEndpoint(stream *StreamWithDestinations, destinati
 	// Process results - extract events and process execLog + logs
 	for connectionId, chainResult := range result {
 		functionsResults[connectionId] = chainResult.Events
-		r.processExecLog(connectionId, chainResult.ExecLog, chainResult.Logs)
+		r.processExecLog(connectionId, stream.Stream.WorkspaceId, messageId, chainResult.ExecLog, chainResult.Logs)
 	}
 	r.emitSyncMetrics(stream, destinations, result, messageId, receivedAt)
 	return result, nil
 }
 
 // processExecLog processes the execution log and function logs from functions server
-func (r *Router) processExecLog(connectionId string, execLog []FunctionExecLogEntry, logs []FunctionLogEntry) {
+func (r *Router) processExecLog(connectionId, workspaceId, messageId string, execLog []FunctionExecLogEntry, logs []FunctionLogEntry) {
 	// Process execution log entries (errors and dropped events)
 	for _, el := range execLog {
 		if el.Error != nil {
@@ -826,10 +828,12 @@ func (r *Router) processExecLog(connectionId string, execLog []FunctionExecLogEn
 				"ms":           el.Ms,
 			}
 			r.eventsLogService.PostAsync(&eventslog.ActorEvent{
-				EventType: eventslog.EventTypeFunction,
-				Level:     eventslog.LevelError,
-				ActorId:   connectionId,
-				Event:     logEvent,
+				EventType:   eventslog.EventTypeFunction,
+				Level:       eventslog.LevelError,
+				ActorId:     connectionId,
+				WorkspaceId: workspaceId,
+				MessageId:   messageId,
+				Event:       logEvent,
 			})
 		}
 		if el.Dropped {
@@ -868,10 +872,12 @@ func (r *Router) processExecLog(connectionId string, execLog []FunctionExecLogEn
 			logEvent["args"] = logEntry.Args
 		}
 		r.eventsLogService.PostAsync(&eventslog.ActorEvent{
-			EventType: eventslog.EventTypeFunction,
-			Level:     level,
-			ActorId:   connectionId,
-			Event:     logEvent,
+			EventType:   eventslog.EventTypeFunction,
+			Level:       level,
+			ActorId:     connectionId,
+			WorkspaceId: workspaceId,
+			MessageId:   messageId,
+			Event:       logEvent,
 		})
 	}
 }

--- a/bulker/sync-sidecar/main.go
+++ b/bulker/sync-sidecar/main.go
@@ -38,10 +38,11 @@ type SideCar interface {
 }
 
 type AbstractSideCar struct {
-	syncId     string
-	taskId     string
-	storageKey string
-	command    string
+	syncId      string
+	taskId      string
+	workspaceId string
+	storageKey  string
+	command     string
 
 	packageName    string
 	packageVersion string
@@ -136,6 +137,7 @@ func main() {
 	abstract := &AbstractSideCar{
 		syncId:           os.Getenv("SYNC_ID"),
 		taskId:           os.Getenv("TASK_ID"),
+		workspaceId:      os.Getenv("WORKSPACE_ID"),
 		command:          os.Getenv("COMMAND"),
 		storageKey:       os.Getenv("STORAGE_KEY"),
 		packageName:      os.Getenv("PACKAGE"),

--- a/bulker/sync-sidecar/read.go
+++ b/bulker/sync-sidecar/read.go
@@ -449,7 +449,7 @@ func (s *ReadSideCar) postEventsLog(destinationId string, state bulker.State, pr
 	if batchErr != "" {
 		level = eventslog.LevelError
 	}
-	_, err := s.eventsLogService.PostEvent(&eventslog.ActorEvent{Timestamp: time.Now().UTC(), EventType: eventslog.EventTypeBatch, Level: level, ActorId: destinationId, Event: batchState})
+	_, err := s.eventsLogService.PostEvent(&eventslog.ActorEvent{Timestamp: time.Now().UTC(), EventType: eventslog.EventTypeBatch, Level: level, ActorId: destinationId, WorkspaceId: s.workspaceId, Event: batchState})
 	if err != nil {
 		s.errprint("Error posting events log: %v", err)
 	}

--- a/libs/core-functions-lib/src/functions/lib/index.ts
+++ b/libs/core-functions-lib/src/functions/lib/index.ts
@@ -75,30 +75,60 @@ const fetchLocalWhitelist = process.env.FETCH_LOCAL_WHITELIST
 const publicHostnamesCache = new NodeCache({ stdTTL: 300, checkperiod: 60, useClones: false });
 
 /**
+ * Origin of an events-log record: ids of the workspace and the source event the record was produced for.
+ * Both are optional — not every write site has them in scope
+ */
+export type EventsLogContext = {
+  workspaceId?: string;
+  messageId?: string;
+};
+
+/**
  * Store for incoming events, destination results and function log messages
  */
 export interface EventsStore {
-  log(connectionId: string, level: LogLevel, msg: Record<string, any>): void;
-  deadLetter(workspaceId: string, connectionId: string, type: string, payload: any, error: any): void;
+  log(connectionId: string, level: LogLevel, msg: Record<string, any>, opts?: EventsLogContext): void;
+  deadLetter(
+    workspaceId: string,
+    connectionId: string,
+    type: string,
+    payload: any,
+    error: any,
+    messageId?: string
+  ): void;
   close(): void;
 }
 
 export const DummyEventsStore: EventsStore = {
-  log(connectionId: string, level: LogLevel, msg: Record<string, any>): void {},
-  deadLetter(workspaceId: string, connectionId: string, type: string, payload: any, error: any): void {},
+  log(connectionId: string, level: LogLevel, msg: Record<string, any>, opts?: EventsLogContext): void {},
+  deadLetter(
+    workspaceId: string,
+    connectionId: string,
+    type: string,
+    payload: any,
+    error: any,
+    messageId?: string
+  ): void {},
   close(): void {},
 };
 
 export function MultiEventsStore(stores: EventsStore[]): EventsStore {
   return {
-    log(connectionId: string, level: LogLevel, msg: Record<string, any>): void {
+    log(connectionId: string, level: LogLevel, msg: Record<string, any>, opts?: EventsLogContext): void {
       for (const store of stores) {
-        store.log(connectionId, level, msg);
+        store.log(connectionId, level, msg, opts);
       }
     },
-    deadLetter(workspaceId: string, connectionId: string, type: string, payload: any, error: any): void {
+    deadLetter(
+      workspaceId: string,
+      connectionId: string,
+      type: string,
+      payload: any,
+      error: any,
+      messageId?: string
+    ): void {
       for (const store of stores) {
-        store.deadLetter(workspaceId, connectionId, type, payload, error);
+        store.deadLetter(workspaceId, connectionId, type, payload, error, messageId);
       }
     },
     close(): void {
@@ -204,9 +234,10 @@ export function wrapperFunction<E extends AnyEvent = AnyEvent, P extends AnyProp
         return fetchWithLog(url, opts, { ...extra, event });
       };
     }
+    const messageId = (event as any)?.messageId;
     const fullContext: FullContext<P> = {
       ...ctx,
-      log,
+      log: messageId ? createFunctionLogger(chainCtx, { ...funcCtx, eventMessageId: messageId }) : log,
       fetch: ftch,
       getWarehouse: () => {
         throw newError("Warehouse API is not available in builtin functions");
@@ -242,6 +273,9 @@ export type FunctionContext<P extends AnyProps = AnyProps> = {
     debugTill?: Date;
   };
   props: P;
+  // messageId of the event being processed when the log call happens. Function chains are cached
+  // across events, so per-event ids can't be baked into makeLog — they ride on this context instead
+  eventMessageId?: string;
 };
 
 export type JitsuFunctionWrapper<E extends AnyEvent = AnyEvent> = (
@@ -339,7 +373,12 @@ export function eventTimeSafeMs(event: AnalyticsServerEvent) {
   return Math.min(!isNaN(ts) ? ts : now, !isNaN(receivedAt) ? receivedAt : now, now);
 }
 
-export const makeLog = (connectionId: string, eventsStore: EventsStore, repeatToLog?: boolean) => {
+export const makeLog = (
+  connectionId: string,
+  eventsStore: EventsStore,
+  repeatToLog?: boolean,
+  workspaceId?: string
+) => {
   const logFunc = (lb: () => LogMessageBuilder, callback: (l: LogMessageBuilder) => void) => {
     if (repeatToLog) {
       callback(lb());
@@ -347,46 +386,62 @@ export const makeLog = (connectionId: string, eventsStore: EventsStore, repeatTo
       log.inDebug(callback);
     }
   };
+  const logContext = (ctx: FunctionContext): EventsLogContext => ({ workspaceId, messageId: ctx.eventMessageId });
   return {
     debug: (ctx: FunctionContext, message: any, ...args: any[]) => {
       if (ctx.function.debugTill && ctx.function.debugTill > new Date()) {
         const fid = ctx.function.id;
         logFunc(log.atDebug, l => l.log(`[CON:${connectionId}]: [f:${fid}][DEBUG]: ${message}`, ...args));
-        eventsStore.log(connectionId, "debug", {
-          type: "log-debug",
+        eventsStore.log(
+          connectionId,
+          "debug",
+          {
+            type: "log-debug",
+            functionId: fid,
+            functionType: ctx.function.type,
+            message: {
+              text: message,
+              args,
+            },
+          },
+          logContext(ctx)
+        );
+      }
+    },
+    warn: (ctx: FunctionContext, message: any, ...args: any[]) => {
+      const fid = ctx.function.id;
+      logFunc(log.atWarn, l => l.log(`[CON:${connectionId}]: [f:${fid}][WARN]: ${message}`, ...args));
+      eventsStore.log(
+        connectionId,
+        "warn",
+        {
+          type: "log-warn",
           functionId: fid,
           functionType: ctx.function.type,
           message: {
             text: message,
             args,
           },
-        });
-      }
-    },
-    warn: (ctx: FunctionContext, message: any, ...args: any[]) => {
-      const fid = ctx.function.id;
-      logFunc(log.atWarn, l => l.log(`[CON:${connectionId}]: [f:${fid}][WARN]: ${message}`, ...args));
-      eventsStore.log(connectionId, "warn", {
-        type: "log-warn",
-        functionId: fid,
-        functionType: ctx.function.type,
-        message: {
-          text: message,
-          args,
         },
-      });
+        logContext(ctx)
+      );
     },
     error: (ctx: FunctionContext, message: any, ...args: any[]) => {
       const fid = ctx.function.id;
-      eventsStore.log(connectionId, "error", {
-        type: "log-error",
-        functionId: fid,
-        functionType: ctx.function.type,
-        message: {
-          text: message,
-          args,
+      eventsStore.log(
+        connectionId,
+        "error",
+        {
+          type: "log-error",
+          functionId: fid,
+          functionType: ctx.function.type,
+          message: {
+            text: message,
+            args,
+          },
         },
-      });
+        logContext(ctx)
+      );
       logFunc(log.atError, l => {
         if (args?.length > 0) {
           const last = args[args.length - 1];
@@ -401,15 +456,20 @@ export const makeLog = (connectionId: string, eventsStore: EventsStore, repeatTo
     info: (ctx: FunctionContext, message: any, ...args: any[]) => {
       const fid = ctx.function.id;
       logFunc(log.atInfo, l => l.log(`[CON:${connectionId}]: [f:${fid}][INFO]: ${message}`, ...args));
-      eventsStore.log(connectionId, "info", {
-        type: "log-info",
-        functionId: fid,
-        functionType: ctx.function.type,
-        message: {
-          text: message,
-          args,
+      eventsStore.log(
+        connectionId,
+        "info",
+        {
+          type: "log-info",
+          functionId: fid,
+          functionType: ctx.function.type,
+          message: {
+            text: message,
+            args,
+          },
         },
-      });
+        logContext(ctx)
+      );
     },
   };
 };
@@ -454,7 +514,8 @@ export const makeFetch = (
   connectionId: string,
   eventsStore: EventsStore,
   logLevel: "info" | "debug",
-  fetchTimeoutMs: number = 2000
+  fetchTimeoutMs: number = 2000,
+  workspaceId?: string
 ) => {
   const throttle = connectionId === "clke5lrfm0000ii0gahryc37d-wbyo-5jyq-KIMXwt" ? getThrottle(5000) : noThrottle();
 
@@ -488,6 +549,10 @@ export const makeFetch = (
     const ctx = extra?.ctx?.function;
     const id = ctx?.id || "unknown";
     const type = ctx?.type || "unknown";
+    const logCtx: EventsLogContext = {
+      workspaceId,
+      messageId: (extra?.event as any)?.messageId || extra?.ctx?.eventMessageId,
+    };
     const logEnabled = logLevel === "info" || (ctx?.debugTill && ctx?.debugTill > new Date());
     const logToRedis = typeof extra?.log === "boolean" ? extra.log : true;
     const baseInfo =
@@ -534,7 +599,12 @@ export const makeFetch = (
       if (logEnabled) {
         const elapsedMs = sw.elapsedMs();
         if (logToRedis) {
-          eventsStore.log(connectionId, logLevel, { ...baseInfo, error: getErrorMessage(err), elapsedMs: elapsedMs });
+          eventsStore.log(
+            connectionId,
+            logLevel,
+            { ...baseInfo, error: getErrorMessage(err), elapsedMs: elapsedMs },
+            logCtx
+          );
         }
         log.inDebug(l =>
           l.log(
@@ -555,13 +625,18 @@ export const makeFetch = (
       const elapsedMs = sw.elapsedMs();
       const respText = await trimResponse(buffered);
       if (logToRedis) {
-        eventsStore.log(connectionId, logLevel, {
-          ...baseInfo,
-          status: fetchResult.status,
-          statusText: fetchResult.statusText,
-          elapsedMs: elapsedMs,
-          response: tryJson(respText),
-        });
+        eventsStore.log(
+          connectionId,
+          logLevel,
+          {
+            ...baseInfo,
+            status: fetchResult.status,
+            statusText: fetchResult.statusText,
+            elapsedMs: elapsedMs,
+            response: tryJson(respText),
+          },
+          logCtx
+        );
       }
       if (fetchResult.status >= 300) {
         log.inDebug(l =>

--- a/services/rotor/src/lib/builder.ts
+++ b/services/rotor/src/lib/builder.ts
@@ -412,18 +412,23 @@ async function processProfile(
 
         if (typeof entry.message === "object" && entry.message.type === "http-request") {
           // HTTP request logs are sent directly to eventsLogger
-          eventsLogger.log(connectionId, entry.level as LogLevel, entry.message);
+          eventsLogger.log(connectionId, entry.level as LogLevel, entry.message, { workspaceId });
         } else {
           // Regular logs: send to eventsLogger in the standard format
-          eventsLogger.log(connectionId, entry.level as LogLevel, {
-            type: `log-${entry.level}`,
-            functionId,
-            functionType,
-            message: {
-              text: entry.message,
-              args: entry.args,
+          eventsLogger.log(
+            connectionId,
+            entry.level as LogLevel,
+            {
+              type: `log-${entry.level}`,
+              functionId,
+              functionType,
+              message: {
+                text: entry.message,
+                args: entry.args,
+              },
             },
-          });
+            { workspaceId }
+          );
         }
       }
     }

--- a/services/rotor/src/lib/functions-chain.ts
+++ b/services/rotor/src/lib/functions-chain.ts
@@ -151,8 +151,14 @@ export function buildFunctionChain(
   }
 
   const chainCtx: FunctionChainContext = {
-    fetch: makeFetch(conId, rotorContext.eventsLogger, connectionData.fetchLogLevel || "info", fetchTimeoutMs),
-    log: makeLog(conId, rotorContext.eventsLogger),
+    fetch: makeFetch(
+      conId,
+      rotorContext.eventsLogger,
+      connectionData.fetchLogLevel || "info",
+      fetchTimeoutMs,
+      conWorkspaceId
+    ),
+    log: makeLog(conId, rotorContext.eventsLogger, undefined, conWorkspaceId),
     store,
     query: async (conId: string, query: string, params: any) => {
       return warehouseQuery(conWorkspaceId, connStore, conId, query, params, rotorContext.metrics);

--- a/services/rotor/src/lib/functions-server-client.ts
+++ b/services/rotor/src/lib/functions-server-client.ts
@@ -113,6 +113,8 @@ export async function callFunctionsServer(
 
     // Replay function logs from the server using FunctionChainContext
     if (result.logs && result.logs.length > 0 && chainCtx) {
+      const messageId = (event as any)?.messageId;
+      const workspaceId = eventContext.workspace?.id;
       for (const logEntry of result.logs) {
         // Restore FunctionContext from log entry or use the provided one
         const logFuncCtx: FunctionContext = {
@@ -122,9 +124,10 @@ export async function callFunctionsServer(
             debugTill: funcCtx?.function.debugTill,
           },
           props: funcCtx?.props || {},
+          eventMessageId: messageId,
         };
         if (typeof logEntry.message === "object" && logEntry.message.type === "http-request") {
-          eventsLogger.log(connectionId, logEntry.level as LogLevel, logEntry.message);
+          eventsLogger.log(connectionId, logEntry.level as LogLevel, logEntry.message, { workspaceId, messageId });
         } else {
           const logFn =
             logEntry.level === "error"

--- a/services/rotor/src/lib/rotor.ts
+++ b/services/rotor/src/lib/rotor.ts
@@ -209,7 +209,8 @@ export function kafkaRotor(cfg: KafkaRotorConfig): KafkaRotor {
                     {
                       functionId: e.functionId,
                       error: e.toString(),
-                    }
+                    },
+                    ingestMessage.messageId
                   );
                 }
               } catch (e) {

--- a/webapps/console/pages/api/admin/export/[name]/index.ts
+++ b/webapps/console/pages/api/admin/export/[name]/index.ts
@@ -234,6 +234,7 @@ async function exportBulkerConnections(writer: Writer) {
               workspace: { id: workspace.id, name: workspace.slug },
             },
             id: id,
+            workspaceId: workspace.id,
             type: destinationType,
             options: omit(data as any, "clickhouseSettings"),
             updatedAt: dateMax(updatedAt, to.updatedAt),
@@ -274,6 +275,7 @@ async function exportBulkerConnections(writer: Writer) {
               workspace: { id: workspace.id, name: workspace.slug },
             },
             id: id,
+            workspaceId: workspace.id,
             type: destinationType,
             options: {
               mode: "batch",


### PR DESCRIPTION
Part 1 of `JITSU-138` (Export Live Events as OTLP logs): every events-log record now carries the owning `workspaceId` and, where the record relates to a single source event, that event's `messageId`. Deliberately inert — no behavior change, nothing consumes the new fields yet.

## Changes

**Go (bulker)**
- `ActorEvent` gains `WorkspaceId` and `MessageId`
- ingest: function-event sites fill both from the resolved stream (`incoming` sites intentionally untouched — excluded from export, and workspaceId isn't in scope in those defer closures before stream resolution)
- bulkerapp: batch/stream consumers and the bulk router fill `WorkspaceId` via a new `workspaceId` field on `DestinationConfig`; stream events also extract `messageId` from the `metrics_meta` Kafka header (the same header `SendMetrics` already parses per message on the success path — no new per-message cost class)
- sync-sidecar: fills `WorkspaceId` from the `WORKSPACE_ID` env the pod already receives (`sync-controller/pod_template.go` `baseEnv`)

**Console**
- `bulker-connections` export emits a first-class `workspaceId` per connection (previously only inside `__debug`); ee-api backup connections don't carry it — their batch events aren't workspace Live Events

**TS (core-functions-lib / rotor)**
- `EventsStore.log()` gains optional `{workspaceId, messageId}` context; `deadLetter()` gains an optional trailing `messageId`. Structural typing keeps existing implementations compiling untouched; `clickhouse-logger` intentionally ignores the new context in this PR — ClickHouse columns land separately in `JITSU-162`
- Function chains are cached across events (`funcsChainCache`), so `workspaceId` is baked into the `makeLog`/`makeFetch` factories (per-connection, cache-safe) while per-event `messageId` rides `FunctionContext.eventMessageId`, bound per event in `wrapperFunction` and per entry in the functions-server replay paths
- `eventId` needs no plumbing at all: per the plan of record it's a content hash (`actorId|timestamp|payload`) computed at fan-out time

## Validation

- All Go workspace modules build; `eventslog` + `ingest` tests pass (one test switched from positional to named `ActorEvent` literal)
- `@jitsu/core-functions-lib`, `@jitsu/destination-functions`, rotor, and console typecheck clean
- Known env limitation: rotor's `functions-chain.test.ts` needs a local `deno` binary (spawns functions-server); fails with ENOENT locally — pre-existing, unrelated

Design/plan of record: see the discussion on `JITSU-138`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)