### PR TITLE
JITSU-138: otlp destination — Live Events observability export delivery

### DIFF
--- a/bulker/bulkerapp/app/topic_manager.go
+++ b/bulker/bulkerapp/app/topic_manager.go
@@ -321,11 +321,16 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 				dstTopics.Remove(topic)
 			}
 		}
-		if destination.config.Special == "backup" || destination.config.Special == "metrics" {
-			// create predefined tables for special kind of destinations: backup and metrics
+		if destination.config.Special == "backup" || destination.config.Special == "metrics" || destination.config.Special == "otlp" {
+			// create predefined tables for special kind of destinations: backup, metrics and otlp
 			tables := []string{destination.config.Special}
 			if destination.config.Special == "metrics" {
 				tables = append(tables, "active_incoming")
+			}
+			if destination.config.Special == "otlp" {
+				// live-events observability export (JITSU-138): events-log write sites
+				// produce export envelopes into this topic
+				tables = []string{"live_events"}
 			}
 			for _, table := range tables {
 				topicId, _ := MakeTopicId(destination.Id(), "batch", table, tm.config.KafkaTopicPrefix, 0, false)

--- a/bulker/bulkerlib/implementations/api_based/otlp.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp.go
@@ -281,6 +281,12 @@ func (o *OtlpBulker) Upload(reader io.Reader, _ string, _ int, _ map[string]any)
 		}
 		switch {
 		case statusCode >= 200 && statusCode < 300:
+			// per the OTLP spec a 2xx may carry partial_success; such a response
+			// must NOT be retried (accepted records would duplicate), so surface
+			// it in the server log only
+			if rejected, message := parseOtlpPartialSuccess(bodyBytes); rejected > 0 || message != "" {
+				o.Errorf("OTLP endpoint accepted the batch with partial success: %d records rejected: %s", rejected, message)
+			}
 			return statusCode, respBody, nil
 		case statusCode == 429 || statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504:
 			// standard OTLP retryable statuses: retry in-process, and if the

--- a/bulker/bulkerlib/implementations/api_based/otlp.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp.go
@@ -178,6 +178,12 @@ func (o *OtlpBulker) buildRequest(reader io.Reader) ([]byte, int, error) {
 			if err := jsoniter.Unmarshal(trimmed, &envelope); err != nil {
 				skipped++
 				o.Errorf("skipping malformed live-events envelope: %v", err)
+			} else if envelope.EventId == "" || envelope.WorkspaceId == "" || envelope.ActorId == "" ||
+				envelope.Type == "" || envelope.Timestamp <= 0 {
+				// valid JSON that violates the envelope contract is as unexportable
+				// as unparseable JSON — skip it rather than emit a junk LogRecord
+				skipped++
+				o.Errorf("skipping invalid live-events envelope: missing required fields")
 			} else {
 				request.logRecords = append(request.logRecords, o.mapLogRecord(&envelope))
 			}

--- a/bulker/bulkerlib/implementations/api_based/otlp.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp.go
@@ -1,0 +1,311 @@
+package api_based
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"time"
+
+	bulker "github.com/jitsucom/bulker/bulkerlib"
+	types2 "github.com/jitsucom/bulker/bulkerlib/types"
+	"github.com/jitsucom/bulker/jitsubase/appbase"
+	"github.com/jitsucom/bulker/jitsubase/jsoniter"
+	"github.com/jitsucom/bulker/jitsubase/utils"
+)
+
+// OTLP live-events export destination (JITSU-138): posts Live Events records to a
+// customer's OTLP/HTTP logs endpoint as protobuf. One synthesized internal
+// connection per enabled workspace (see the console's bulker-connections export);
+// batch mode only, riding the standard batch consumer + retry-topic machinery.
+const OtlpBulkerTypeId = "otlp"
+const OtlpUnsupported = "Only 'batch' mode is supported"
+
+const otlpServiceName = "jitsu-live-events"
+
+// records bigger than this are skipped, not batch-failing: a bufio.Scanner-style
+// hard stop would redeliver the same batch through the retry machinery and wedge
+// the workspace's export forever on a single oversized record
+const maxEnvelopeBytes = 20 * 1024 * 1024
+
+func init() {
+	bulker.RegisterBulker(OtlpBulkerTypeId, NewOtlpBulker)
+}
+
+type OtlpHeader struct {
+	Name  string `mapstructure:"name" json:"name" yaml:"name"`
+	Value string `mapstructure:"value" json:"value" yaml:"value"`
+}
+
+type OtlpConfig struct {
+	Endpoint string       `mapstructure:"endpoint" json:"endpoint" yaml:"endpoint"`
+	Headers  []OtlpHeader `mapstructure:"headers" json:"headers" yaml:"headers"`
+}
+
+// OtlpEnvelope is the record shape events-log write sites produce into the
+// otlp destination's `live_events` topic. Producers live in the eventslog
+// package (Go) and rotor (TS) — keep the three shapes in sync.
+type OtlpEnvelope struct {
+	EventId          string         `json:"eventId"`
+	WorkspaceId      string         `json:"workspaceId"`
+	MessageId        string         `json:"messageId,omitempty"`
+	Type             string         `json:"type"`
+	Level            string         `json:"level"`
+	Timestamp        int64          `json:"timestamp"` // unix millis of the original Live Events record
+	ActorId          string         `json:"actorId"`
+	ConnectionId     string         `json:"connectionId,omitempty"`
+	DestinationId    string         `json:"destinationId,omitempty"`
+	ProfileBuilderId string         `json:"profileBuilderId,omitempty"`
+	Body             map[string]any `json:"body"`
+}
+
+// severity mapping per the OpenTelemetry Logs data model: each conventional
+// level owns a 4-number range; we use the first slot
+var otlpSeverity = map[string]struct {
+	number int
+	text   string
+}{
+	"debug": {5, "DEBUG"},
+	"info":  {9, "INFO"},
+	"warn":  {13, "WARN"},
+	"error": {17, "ERROR"},
+}
+
+type OtlpBulker struct {
+	appbase.Service
+	config         OtlpConfig
+	httpClient     *http.Client
+	serviceVersion string
+
+	closed *atomic.Bool
+}
+
+func NewOtlpBulker(bulkerConfig bulker.Config) (bulker.Bulker, error) {
+	config := OtlpConfig{}
+	if err := utils.ParseObject(bulkerConfig.DestinationConfig, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse destination config: %v", err)
+	}
+	if config.Endpoint == "" {
+		return nil, errors.New("otlp destination requires an endpoint")
+	}
+	httpClient := &http.Client{
+		Timeout: time.Duration(15) * time.Second,
+	}
+	return &OtlpBulker{
+		Service:        appbase.NewServiceBase(OtlpBulkerTypeId),
+		config:         config,
+		httpClient:     httpClient,
+		serviceVersion: os.Getenv("VERSION"),
+		closed:         &atomic.Bool{},
+	}, nil
+}
+
+func (o *OtlpBulker) CreateStream(id, tableName string, mode bulker.BulkMode, streamOptions ...bulker.StreamOption) (bulker.BulkerStream, error) {
+	if mode != bulker.Batch {
+		return nil, errors.New(OtlpUnsupported)
+	}
+	return NewTransactionalStream(id, o, tableName, streamOptions...)
+}
+
+func (o *OtlpBulker) Type() string {
+	return OtlpBulkerTypeId
+}
+
+func (o *OtlpBulker) mapLogRecord(envelope *OtlpEnvelope) otlpLogRecord {
+	severity, ok := otlpSeverity[envelope.Level]
+	if !ok {
+		severity = otlpSeverity["info"]
+	}
+	// workspace/event fields stay log attributes, never resource attributes —
+	// resource identity must remain low-cardinality (service name/version only)
+	attributes := []entry{
+		{"jitsu.workspace.id", envelope.WorkspaceId},
+		{"jitsu.live_event.id", envelope.EventId},
+		{"jitsu.live_event.type", envelope.Type},
+		{"jitsu.actor.id", envelope.ActorId},
+	}
+	if envelope.MessageId != "" {
+		attributes = append(attributes, entry{"jitsu.message_id", envelope.MessageId})
+	}
+	if envelope.ConnectionId != "" {
+		attributes = append(attributes, entry{"jitsu.connection.id", envelope.ConnectionId})
+	}
+	if envelope.DestinationId != "" {
+		attributes = append(attributes, entry{"jitsu.destination.id", envelope.DestinationId})
+	}
+	if envelope.ProfileBuilderId != "" {
+		attributes = append(attributes, entry{"jitsu.profile_builder.id", envelope.ProfileBuilderId})
+	}
+	var body any
+	if envelope.Body != nil {
+		body = envelope.Body
+	}
+	return otlpLogRecord{
+		timestamp:      time.UnixMilli(envelope.Timestamp),
+		severityNumber: severity.number,
+		severityText:   severity.text,
+		body:           body,
+		attributes:     attributes,
+	}
+}
+
+func (o *OtlpBulker) buildRequest(reader io.Reader) ([]byte, int, error) {
+	request := &otlpLogsRequest{
+		resourceAttributes: []entry{{"service.name", otlpServiceName}},
+		scopeName:          "jitsu",
+	}
+	if o.serviceVersion != "" {
+		request.resourceAttributes = append(request.resourceAttributes, entry{"service.version", o.serviceVersion})
+	}
+	br := bufio.NewReaderSize(reader, 64*1024)
+	skipped := 0
+	oversized := 0
+	for {
+		line, tooLong, err := readEnvelopeLine(br, maxEnvelopeBytes)
+		eof := errors.Is(err, io.EOF)
+		if err != nil && !eof {
+			return nil, 0, fmt.Errorf("failed to read batch: %v", err)
+		}
+		if tooLong {
+			oversized++
+		} else if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+			envelope := OtlpEnvelope{}
+			if err := jsoniter.Unmarshal(trimmed, &envelope); err != nil {
+				skipped++
+				o.Errorf("skipping malformed live-events envelope: %v", err)
+			} else {
+				request.logRecords = append(request.logRecords, o.mapLogRecord(&envelope))
+			}
+		}
+		if eof {
+			break
+		}
+	}
+	if skipped > 0 {
+		o.Errorf("skipped %d malformed envelopes in batch", skipped)
+	}
+	if oversized > 0 {
+		o.Errorf("skipped %d oversized envelopes (> %d bytes) in batch", oversized, maxEnvelopeBytes)
+	}
+	if len(request.logRecords) == 0 {
+		return nil, 0, nil
+	}
+	payload := encodeOtlpLogsRequest(request)
+	var gzipped bytes.Buffer
+	gz := gzip.NewWriter(&gzipped)
+	if _, err := gz.Write(payload); err != nil {
+		return nil, 0, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, 0, err
+	}
+	return gzipped.Bytes(), len(request.logRecords), nil
+}
+
+// readEnvelopeLine reads one newline-terminated line, accumulating ReadLine
+// fragments. Lines longer than maxBytes are consumed to their end and reported
+// as tooLong with no content, so the caller can skip them and keep reading —
+// unlike bufio.Scanner, which cannot resume after ErrTooLong
+func readEnvelopeLine(br *bufio.Reader, maxBytes int) (line []byte, tooLong bool, err error) {
+	for {
+		var chunk []byte
+		var isPrefix bool
+		chunk, isPrefix, err = br.ReadLine()
+		if err != nil {
+			// bufio.ReadLine never returns data together with an error
+			return line, tooLong, err
+		}
+		if !tooLong {
+			line = append(line, chunk...)
+			if len(line) > maxBytes {
+				line = nil
+				tooLong = true
+			}
+		}
+		if !isPrefix {
+			return line, tooLong, nil
+		}
+	}
+}
+
+func (o *OtlpBulker) Upload(reader io.Reader, _ string, _ int, _ map[string]any) (statusCode int, respBody string, err error) {
+	if o.closed.Load() {
+		return 0, "", fmt.Errorf("attempt to use closed OTLP instance")
+	}
+	body, records, err := o.buildRequest(reader)
+	if err != nil {
+		return 0, "", err
+	}
+	if records == 0 {
+		return 200, "", nil
+	}
+	for _, retryDelayMs := range retryDelaysMs {
+		var req *http.Request
+		req, err = http.NewRequest("POST", o.config.Endpoint, bytes.NewReader(body))
+		if err != nil {
+			return 0, "", err
+		}
+		req.Header.Set("Content-Type", "application/x-protobuf")
+		req.Header.Set("Content-Encoding", "gzip")
+		for _, header := range o.config.Headers {
+			req.Header.Set(header.Name, header.Value)
+		}
+		var res *http.Response
+		res, err = o.httpClient.Do(req)
+		if err != nil {
+			// network errors and timeouts: transient, retry in-process
+			statusCode = 0
+			respBody = ""
+			time.Sleep(time.Duration(retryDelayMs) * time.Millisecond)
+			continue
+		}
+		var bodyBytes []byte
+		bodyBytes, err = io.ReadAll(res.Body)
+		_ = res.Body.Close()
+		respBody = string(bodyBytes)
+		statusCode = res.StatusCode
+		errText := ""
+		if err != nil {
+			errText = ": " + err.Error()
+		}
+		switch {
+		case statusCode >= 200 && statusCode < 300:
+			return statusCode, respBody, nil
+		case statusCode == 429 || statusCode == 500 || statusCode == 502 || statusCode == 503:
+			// standard OTLP retryable statuses: retry in-process, and if the
+			// budget runs out the returned error sends the batch through the
+			// batch consumer's retry-topic machinery
+			err = o.NewError("http status: %v%s", statusCode, errText)
+			time.Sleep(time.Duration(retryDelayMs) * time.Millisecond)
+			continue
+		default:
+			// permanent (bad endpoint/auth/payload): fail the batch without
+			// in-process retries; server-side logging only in V1
+			return statusCode, respBody, o.NewError("http status: %v%s", statusCode, errText)
+		}
+	}
+	return
+}
+
+func (o *OtlpBulker) GetBatchFileFormat() types2.FileFormat {
+	return types2.FileFormatNDJSON
+}
+
+func (o *OtlpBulker) GetBatchFileCompression() types2.FileCompression {
+	return types2.FileCompressionNONE
+}
+
+func (o *OtlpBulker) InmemoryBatch() bool {
+	return true
+}
+
+func (o *OtlpBulker) Close() error {
+	o.closed.Store(true)
+	o.httpClient.CloseIdleConnections()
+	return nil
+}

--- a/bulker/bulkerlib/implementations/api_based/otlp.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp.go
@@ -276,7 +276,7 @@ func (o *OtlpBulker) Upload(reader io.Reader, _ string, _ int, _ map[string]any)
 		switch {
 		case statusCode >= 200 && statusCode < 300:
 			return statusCode, respBody, nil
-		case statusCode == 429 || statusCode == 500 || statusCode == 502 || statusCode == 503:
+		case statusCode == 429 || statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504:
 			// standard OTLP retryable statuses: retry in-process, and if the
 			// budget runs out the returned error sends the batch through the
 			// batch consumer's retry-topic machinery

--- a/bulker/bulkerlib/implementations/api_based/otlp.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp.go
@@ -33,6 +33,9 @@ const otlpServiceName = "jitsu-live-events"
 // the workspace's export forever on a single oversized record
 const maxEnvelopeBytes = 20 * 1024 * 1024
 
+// cap on the OTLP endpoint's response body (status text / partial_success only)
+const otlpResponseLimit = 64 * 1024
+
 func init() {
 	bulker.RegisterBulker(OtlpBulkerTypeId, NewOtlpBulker)
 }
@@ -271,7 +274,10 @@ func (o *OtlpBulker) Upload(reader io.Reader, _ string, _ int, _ map[string]any)
 			continue
 		}
 		var bodyBytes []byte
-		bodyBytes, err = io.ReadAll(res.Body)
+		// the endpoint is customer-configured: cap the response read so a
+		// misbehaving server can't force unbounded allocation. Real
+		// ExportLogsServiceResponse bodies are tiny
+		bodyBytes, err = io.ReadAll(io.LimitReader(res.Body, otlpResponseLimit))
 		_ = res.Body.Close()
 		respBody = string(bodyBytes)
 		statusCode = res.StatusCode

--- a/bulker/bulkerlib/implementations/api_based/otlp_protobuf.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp_protobuf.go
@@ -136,6 +136,67 @@ type otlpLogsRequest struct {
 	logRecords         []otlpLogRecord
 }
 
+// protoScan walks a protobuf message and calls visit for every field with its
+// wire type and payload (varint value for wire type 0, raw bytes for wire type
+// 2). Stops silently on malformed input — callers treat that as "not present"
+func protoScan(buf []byte, visit func(fieldNumber int, varint uint64, bytes []byte)) {
+	pos := 0
+	for pos < len(buf) {
+		key, n := binary.Uvarint(buf[pos:])
+		if n <= 0 {
+			return
+		}
+		pos += n
+		fieldNumber := int(key >> 3)
+		switch key & 0x7 {
+		case 0:
+			v, n := binary.Uvarint(buf[pos:])
+			if n <= 0 {
+				return
+			}
+			pos += n
+			visit(fieldNumber, v, nil)
+		case 1:
+			pos += 8
+		case 5:
+			pos += 4
+		case 2:
+			length, n := binary.Uvarint(buf[pos:])
+			// compare in uint64 space: a hostile length > MaxInt64 would wrap
+			// negative through int() and slip past an int-space bounds check
+			// straight into a slice-bounds panic
+			if n <= 0 || length > uint64(len(buf)-pos-n) {
+				return
+			}
+			visit(fieldNumber, 0, buf[pos+n:pos+n+int(length)])
+			pos += n + int(length)
+		default:
+			return
+		}
+	}
+}
+
+// parseOtlpPartialSuccess extracts (rejected_log_records, error_message) from an
+// ExportLogsServiceResponse body: partial_success=1 { rejected_log_records=1
+// (int64), error_message=2 (string) }. An empty/omitted body means full success;
+// malformed bytes return (0, "") — the status code stays the delivery signal
+func parseOtlpPartialSuccess(body []byte) (rejected int64, errorMessage string) {
+	protoScan(body, func(field int, _ uint64, partial []byte) {
+		if field != 1 || partial == nil {
+			return
+		}
+		protoScan(partial, func(field int, varint uint64, bytes []byte) {
+			switch {
+			case field == 1 && bytes == nil:
+				rejected = int64(varint)
+			case field == 2 && bytes != nil:
+				errorMessage = string(bytes)
+			}
+		})
+	})
+	return rejected, errorMessage
+}
+
 func encodeOtlpLogsRequest(request *otlpLogsRequest) []byte {
 	// resource/v1 Resource: attributes=1
 	resource := &protoWriter{}

--- a/bulker/bulkerlib/implementations/api_based/otlp_protobuf.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp_protobuf.go
@@ -1,0 +1,178 @@
+package api_based
+
+import (
+	"encoding/binary"
+	"math"
+	"time"
+)
+
+// Minimal OTLP/HTTP Logs protobuf encoder — just enough to serialize an
+// ExportLogsServiceRequest. Hand-encoded to keep bulkerlib free of the
+// go.opentelemetry.io/proto dependency chain for a handful of fixed messages
+// on a frozen (v1) data model. Field numbers come from the OTLP protos:
+// collector/logs/v1/logs_service.proto, logs/v1/logs.proto,
+// common/v1/common.proto, resource/v1/resource.proto.
+// Mirrors webapps/console/lib/server/otlp-logs.ts — keep the two in sync.
+
+type protoWriter struct {
+	buf []byte
+}
+
+func (w *protoWriter) varint(v uint64) {
+	w.buf = binary.AppendUvarint(w.buf, v)
+}
+
+func (w *protoWriter) key(fieldNumber int, wireType int) {
+	w.varint(uint64(fieldNumber<<3 | wireType))
+}
+
+func (w *protoWriter) varintField(fieldNumber int, v uint64) {
+	w.key(fieldNumber, 0)
+	w.varint(v)
+}
+
+func (w *protoWriter) fixed64Field(fieldNumber int, v uint64) {
+	w.key(fieldNumber, 1)
+	w.buf = binary.LittleEndian.AppendUint64(w.buf, v)
+}
+
+func (w *protoWriter) bytesField(fieldNumber int, v []byte) {
+	w.key(fieldNumber, 2)
+	w.varint(uint64(len(v)))
+	w.buf = append(w.buf, v...)
+}
+
+func (w *protoWriter) stringField(fieldNumber int, v string) {
+	w.key(fieldNumber, 2)
+	w.varint(uint64(len(v)))
+	w.buf = append(w.buf, v...)
+}
+
+func (w *protoWriter) messageField(fieldNumber int, m *protoWriter) {
+	w.bytesField(fieldNumber, m.buf)
+}
+
+// common/v1 AnyValue: string_value=1, bool_value=2, int_value=3, double_value=4,
+// array_value=5, kvlist_value=6
+func encodeAnyValue(value any) *protoWriter {
+	w := &protoWriter{}
+	switch v := value.(type) {
+	case string:
+		w.stringField(1, v)
+	case bool:
+		b := uint64(0)
+		if v {
+			b = 1
+		}
+		w.varintField(2, b)
+	case float64:
+		if v == math.Trunc(v) && math.Abs(v) < 1<<53 {
+			// int_value is int64: negative values use two's-complement varint
+			w.varintField(3, uint64(int64(v)))
+		} else {
+			w.key(4, 1)
+			w.buf = binary.LittleEndian.AppendUint64(w.buf, math.Float64bits(v))
+		}
+	case int:
+		w.varintField(3, uint64(int64(v)))
+	case int64:
+		w.varintField(3, uint64(v))
+	case []any:
+		arr := &protoWriter{} // ArrayValue: values=1
+		for _, item := range v {
+			arr.messageField(1, encodeAnyValue(item))
+		}
+		w.messageField(5, arr)
+	case map[string]any:
+		kvlist := &protoWriter{} // KeyValueList: values=1
+		for _, kv := range stableEntries(v) {
+			kvlist.messageField(1, encodeKeyValue(kv.key, kv.value))
+		}
+		w.messageField(6, kvlist)
+	}
+	// nil and unknown types → empty AnyValue
+	return w
+}
+
+type entry struct {
+	key   string
+	value any
+}
+
+// map iteration order is random in Go; stable output keeps encoding
+// deterministic for tests and for byte-identical retries
+func stableEntries(m map[string]any) []entry {
+	entries := make([]entry, 0, len(m))
+	for k, v := range m {
+		entries = append(entries, entry{k, v})
+	}
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0 && entries[j-1].key > entries[j].key; j-- {
+			entries[j-1], entries[j] = entries[j], entries[j-1]
+		}
+	}
+	return entries
+}
+
+// common/v1 KeyValue: key=1, value=2
+func encodeKeyValue(k string, v any) *protoWriter {
+	w := &protoWriter{}
+	w.stringField(1, k)
+	w.messageField(2, encodeAnyValue(v))
+	return w
+}
+
+type otlpLogRecord struct {
+	timestamp      time.Time
+	severityNumber int
+	severityText   string
+	body           any
+	attributes     []entry
+}
+
+type otlpLogsRequest struct {
+	resourceAttributes []entry
+	scopeName          string
+	logRecords         []otlpLogRecord
+}
+
+func encodeOtlpLogsRequest(request *otlpLogsRequest) []byte {
+	// resource/v1 Resource: attributes=1
+	resource := &protoWriter{}
+	for _, kv := range request.resourceAttributes {
+		resource.messageField(1, encodeKeyValue(kv.key, kv.value))
+	}
+
+	// common/v1 InstrumentationScope: name=1
+	scope := &protoWriter{}
+	scope.stringField(1, request.scopeName)
+
+	// logs/v1 ScopeLogs: scope=1, log_records=2
+	scopeLogs := &protoWriter{}
+	scopeLogs.messageField(1, scope)
+	observedNanos := uint64(time.Now().UnixNano())
+	for _, record := range request.logRecords {
+		// logs/v1 LogRecord: time_unix_nano=1 (fixed64), severity_number=2,
+		// severity_text=3, body=5, attributes=6, observed_time_unix_nano=11 (fixed64)
+		logRecord := &protoWriter{}
+		logRecord.fixed64Field(1, uint64(record.timestamp.UnixNano()))
+		logRecord.varintField(2, uint64(record.severityNumber))
+		logRecord.stringField(3, record.severityText)
+		logRecord.messageField(5, encodeAnyValue(record.body))
+		for _, kv := range record.attributes {
+			logRecord.messageField(6, encodeKeyValue(kv.key, kv.value))
+		}
+		logRecord.fixed64Field(11, observedNanos)
+		scopeLogs.messageField(2, logRecord)
+	}
+
+	// logs/v1 ResourceLogs: resource=1, scope_logs=2
+	resourceLogs := &protoWriter{}
+	resourceLogs.messageField(1, resource)
+	resourceLogs.messageField(2, scopeLogs)
+
+	// collector/logs/v1 ExportLogsServiceRequest: resource_logs=1
+	requestMessage := &protoWriter{}
+	requestMessage.messageField(1, resourceLogs)
+	return requestMessage.buf
+}

--- a/bulker/bulkerlib/implementations/api_based/otlp_test.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp_test.go
@@ -250,6 +250,30 @@ func TestOtlpUploadEmptyBatch(t *testing.T) {
 	require.Equal(t, 200, status)
 }
 
+func TestOtlpParsePartialSuccess(t *testing.T) {
+	// hand-encode ExportLogsServiceResponse{partial_success: {rejected_log_records: 3, error_message: "boom"}}
+	partial := &protoWriter{}
+	partial.varintField(1, 3)
+	partial.stringField(2, "boom")
+	response := &protoWriter{}
+	response.messageField(1, partial)
+
+	rejected, message := parseOtlpPartialSuccess(response.buf)
+	require.Equal(t, int64(3), rejected)
+	require.Equal(t, "boom", message)
+
+	// empty body = full success; garbage is treated as absent
+	rejected, message = parseOtlpPartialSuccess(nil)
+	require.Equal(t, int64(0), rejected)
+	require.Empty(t, message)
+	rejected, message = parseOtlpPartialSuccess([]byte("not-protobuf"))
+	require.Empty(t, message)
+
+	// hostile length prefix > MaxInt64 must not panic (int() would wrap negative)
+	overflow := append([]byte{0x0a}, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01)
+	require.NotPanics(t, func() { parseOtlpPartialSuccess(overflow) })
+}
+
 func TestOtlpStreamModesRejected(t *testing.T) {
 	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
 	for _, mode := range []bulker.BulkMode{bulker.Stream, bulker.ReplaceTable, bulker.ReplacePartition} {

--- a/bulker/bulkerlib/implementations/api_based/otlp_test.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp_test.go
@@ -133,6 +133,9 @@ func TestOtlpBuildRequestWireFormat(t *testing.T) {
 func TestOtlpBuildRequestSkipsMalformedLines(t *testing.T) {
 	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
 	input := "not-json\n" +
+		// valid JSON that violates the envelope contract is skipped too
+		`{"foo":"bar"}` + "\n" +
+		`{"eventId":"ev1","workspaceId":"ws1","type":"function","level":"info","timestamp":0,"actorId":"a","body":{}}` + "\n" +
 		`{"eventId":"ev1","workspaceId":"ws1","type":"function","level":"info","timestamp":1,"actorId":"a","body":{}}` + "\n"
 	_, records, err := b.buildRequest(strings.NewReader(input))
 	require.NoError(t, err)

--- a/bulker/bulkerlib/implementations/api_based/otlp_test.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp_test.go
@@ -220,17 +220,19 @@ func TestOtlpUploadPermanentErrorNoRetry(t *testing.T) {
 }
 
 func TestOtlpUploadTransientExhaustsRetries(t *testing.T) {
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests.Add(1)
-		w.WriteHeader(429)
-	}))
-	defer server.Close()
+	for _, transientStatus := range []int{429, 504} {
+		var requests atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(transientStatus)
+		}))
 
-	b := newTestOtlpBulker(t, server.URL)
-	_, _, err := b.Upload(strings.NewReader(otlpEnvelopeLine()), "live_events", 1, nil)
-	require.Error(t, err)
-	require.Equal(t, int32(len(retryDelaysMs)), requests.Load())
+		b := newTestOtlpBulker(t, server.URL)
+		_, _, err := b.Upload(strings.NewReader(otlpEnvelopeLine()), "live_events", 1, nil)
+		require.Error(t, err)
+		require.Equal(t, int32(len(retryDelaysMs)), requests.Load())
+		server.Close()
+	}
 }
 
 func TestOtlpUploadEmptyBatch(t *testing.T) {

--- a/bulker/bulkerlib/implementations/api_based/otlp_test.go
+++ b/bulker/bulkerlib/implementations/api_based/otlp_test.go
@@ -1,0 +1,254 @@
+package api_based
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bulker "github.com/jitsucom/bulker/bulkerlib"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOtlpBulker(t *testing.T, endpoint string) *OtlpBulker {
+	b, err := NewOtlpBulker(bulker.Config{
+		Id:         "test_otlp",
+		BulkerType: OtlpBulkerTypeId,
+		DestinationConfig: map[string]any{
+			"endpoint": endpoint,
+			"headers":  []map[string]any{{"name": "dd-api-key", "value": "test-key"}},
+		},
+	})
+	require.NoError(t, err)
+	return b.(*OtlpBulker)
+}
+
+func TestOtlpMapLogRecord(t *testing.T) {
+	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
+
+	attrsAsMap := func(r otlpLogRecord) map[string]any {
+		m := map[string]any{}
+		for _, kv := range r.attributes {
+			m[kv.key] = kv.value
+		}
+		return m
+	}
+
+	// function log record
+	r := b.mapLogRecord(&OtlpEnvelope{
+		EventId:      "ev1",
+		WorkspaceId:  "ws1",
+		MessageId:    "msg1",
+		Type:         "function",
+		Level:        "error",
+		Timestamp:    1700000000000,
+		ActorId:      "con1",
+		ConnectionId: "con1",
+		Body:         map[string]any{"type": "log-error", "functionId": "udf.f1"},
+	})
+	require.Equal(t, 17, r.severityNumber)
+	require.Equal(t, "ERROR", r.severityText)
+	require.Equal(t, time.UnixMilli(1700000000000), r.timestamp)
+	attrs := attrsAsMap(r)
+	require.Equal(t, "ws1", attrs["jitsu.workspace.id"])
+	require.Equal(t, "ev1", attrs["jitsu.live_event.id"])
+	require.Equal(t, "function", attrs["jitsu.live_event.type"])
+	require.Equal(t, "con1", attrs["jitsu.actor.id"])
+	require.Equal(t, "msg1", attrs["jitsu.message_id"])
+	require.Equal(t, "con1", attrs["jitsu.connection.id"])
+	require.NotContains(t, attrs, "jitsu.destination.id")
+
+	// batch/warehouse record: no messageId, destination-scoped
+	r = b.mapLogRecord(&OtlpEnvelope{
+		EventId:       "ev2",
+		WorkspaceId:   "ws1",
+		Type:          "bulker_batch",
+		Level:         "info",
+		Timestamp:     1700000000001,
+		ActorId:       "dst1",
+		DestinationId: "dst1",
+		Body:          map[string]any{"status": "COMPLETED", "processedRows": float64(100)},
+	})
+	require.Equal(t, 9, r.severityNumber)
+	attrs = attrsAsMap(r)
+	require.NotContains(t, attrs, "jitsu.message_id")
+	require.Equal(t, "dst1", attrs["jitsu.destination.id"])
+
+	// dead-letter record with {payload, error} body; unknown level falls back to info
+	r = b.mapLogRecord(&OtlpEnvelope{
+		EventId:     "ev3",
+		WorkspaceId: "ws1",
+		MessageId:   "msg3",
+		Type:        "dead-letter",
+		Level:       "unknown-level",
+		Timestamp:   1700000000002,
+		ActorId:     "con2",
+		Body:        map[string]any{"payload": `{"event":"x"}`, "error": map[string]any{"functionId": "f2"}},
+	})
+	require.Equal(t, 9, r.severityNumber)
+	require.Equal(t, "INFO", r.severityText)
+}
+
+func TestOtlpBuildRequestWireFormat(t *testing.T) {
+	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
+	envelope := `{"eventId":"ev1","workspaceId":"ws1","type":"function","level":"info","timestamp":1700000000000,"actorId":"con1","body":{"hello":"world"}}`
+	gzipped, records, err := b.buildRequest(strings.NewReader(envelope + "\n"))
+	require.NoError(t, err)
+	require.Equal(t, 1, records)
+
+	gz, err := gzip.NewReader(bytes.NewReader(gzipped))
+	require.NoError(t, err)
+	payload, err := io.ReadAll(gz)
+	require.NoError(t, err)
+
+	hexPayload := hex.EncodeToString(payload)
+	// ExportLogsServiceRequest.resource_logs: field 1, length-delimited
+	require.Equal(t, byte(0x0a), payload[0])
+	// Resource attribute KeyValue{key="service.name", value{string_value="jitsu-live-events"}}
+	require.Contains(t, hexPayload, hex.EncodeToString([]byte("service.name")))
+	require.Contains(t, hexPayload, hex.EncodeToString([]byte(otlpServiceName)))
+	// LogRecord.time_unix_nano: field 1 fixed64 of 1700000000000 ms in ns
+	nanos := make([]byte, 8)
+	binary.LittleEndian.PutUint64(nanos, uint64(1700000000000)*1_000_000)
+	require.Contains(t, hexPayload, "09"+hex.EncodeToString(nanos))
+	// severity_number: field 2 varint 9
+	require.Contains(t, hexPayload, "1009")
+	// severity_text: field 3 "INFO"
+	require.Contains(t, hexPayload, "1a04"+hex.EncodeToString([]byte("INFO")))
+	// body kvlist contains the customer payload
+	require.Contains(t, hexPayload, hex.EncodeToString([]byte("hello")))
+	require.Contains(t, hexPayload, hex.EncodeToString([]byte("world")))
+	// attributes present
+	require.Contains(t, hexPayload, hex.EncodeToString([]byte("jitsu.workspace.id")))
+	require.Contains(t, hexPayload, hex.EncodeToString([]byte("jitsu.live_event.id")))
+}
+
+func TestOtlpBuildRequestSkipsMalformedLines(t *testing.T) {
+	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
+	input := "not-json\n" +
+		`{"eventId":"ev1","workspaceId":"ws1","type":"function","level":"info","timestamp":1,"actorId":"a","body":{}}` + "\n"
+	_, records, err := b.buildRequest(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Equal(t, 1, records)
+}
+
+func TestOtlpBuildRequestSkipsOversizedLines(t *testing.T) {
+	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
+	// a single line over the cap must be skipped without wedging the batch —
+	// records before and after it must survive
+	oversized := `{"eventId":"big","body":{"x":"` + strings.Repeat("a", maxEnvelopeBytes+1024) + `"}}`
+	input := `{"eventId":"ev1","workspaceId":"ws1","type":"function","level":"info","timestamp":1,"actorId":"a","body":{}}` + "\n" +
+		oversized + "\n" +
+		`{"eventId":"ev2","workspaceId":"ws1","type":"function","level":"info","timestamp":2,"actorId":"a","body":{}}` + "\n"
+	_, records, err := b.buildRequest(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Equal(t, 2, records)
+}
+
+func TestOtlpBuildRequestFinalLineWithoutNewline(t *testing.T) {
+	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
+	input := `{"eventId":"ev1","workspaceId":"ws1","type":"function","level":"info","timestamp":1,"actorId":"a","body":{}}`
+	_, records, err := b.buildRequest(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Equal(t, 1, records)
+}
+
+func otlpEnvelopeLine() string {
+	return `{"eventId":"ev1","workspaceId":"ws1","type":"function","level":"info","timestamp":1700000000000,"actorId":"con1","body":{"k":"v"}}` + "\n"
+}
+
+func TestOtlpUploadSuccess(t *testing.T) {
+	var gotContentType, gotEncoding, gotApiKey string
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		gotContentType = r.Header.Get("Content-Type")
+		gotEncoding = r.Header.Get("Content-Encoding")
+		gotApiKey = r.Header.Get("dd-api-key")
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	b := newTestOtlpBulker(t, server.URL)
+	status, _, err := b.Upload(strings.NewReader(otlpEnvelopeLine()), "live_events", 1, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+	require.Equal(t, int32(1), requests.Load())
+	require.Equal(t, "application/x-protobuf", gotContentType)
+	require.Equal(t, "gzip", gotEncoding)
+	require.Equal(t, "test-key", gotApiKey)
+}
+
+func TestOtlpUploadRetriesTransientThenSucceeds(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) <= 2 {
+			w.WriteHeader(503)
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	b := newTestOtlpBulker(t, server.URL)
+	status, _, err := b.Upload(strings.NewReader(otlpEnvelopeLine()), "live_events", 1, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+	require.Equal(t, int32(3), requests.Load())
+}
+
+func TestOtlpUploadPermanentErrorNoRetry(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(401)
+	}))
+	defer server.Close()
+
+	b := newTestOtlpBulker(t, server.URL)
+	status, _, err := b.Upload(strings.NewReader(otlpEnvelopeLine()), "live_events", 1, nil)
+	require.Error(t, err)
+	require.Equal(t, 401, status)
+	require.Equal(t, int32(1), requests.Load())
+}
+
+func TestOtlpUploadTransientExhaustsRetries(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(429)
+	}))
+	defer server.Close()
+
+	b := newTestOtlpBulker(t, server.URL)
+	_, _, err := b.Upload(strings.NewReader(otlpEnvelopeLine()), "live_events", 1, nil)
+	require.Error(t, err)
+	require.Equal(t, int32(len(retryDelaysMs)), requests.Load())
+}
+
+func TestOtlpUploadEmptyBatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("no request expected for an empty batch")
+	}))
+	defer server.Close()
+
+	b := newTestOtlpBulker(t, server.URL)
+	status, _, err := b.Upload(strings.NewReader(""), "live_events", 0, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+}
+
+func TestOtlpStreamModesRejected(t *testing.T) {
+	b := newTestOtlpBulker(t, "https://example.com/v1/logs")
+	for _, mode := range []bulker.BulkMode{bulker.Stream, bulker.ReplaceTable, bulker.ReplacePartition} {
+		_, err := b.CreateStream("id", "live_events", mode)
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
Part 3 of `JITSU-138` (stacked on #1456). New `api_based` bulkerlib destination type `otlp`: consumes live-events export envelopes from the workspace's synthesized connection topic (batch mode only) and posts them to the configured OTLP/HTTP logs endpoint as gzipped protobuf.

- `otlp_protobuf.go`: dependency-free OTLP logs encoder mirroring the console's `lib/server/otlp-logs.ts` (frozen v1 data model; deterministic map ordering; wire format asserted byte-level in tests).
- Mapping per the OTel logs data model: severity `debug/info/warn/error` → 5/9/13/17; Resource `service.name=jitsu-live-events` + `service.version` from `$VERSION`; `jitsu.*` ids as **log** attributes (never resource attributes); full record content as structured body.
- `Upload`: 2xx success; 429/500/502/503 + network errors retried in-process then surfaced to the batch consumer's retry-topic machinery; other statuses permanent (server-side log only in V1).
- Poison-pill guards: malformed **and** oversized (>20MB) envelope lines are consumed and skipped, never batch-failing — `bufio.Scanner`'s `ErrTooLong` would have wedged the export forever through retry redelivery.
- `topic_manager`: `special=otlp` pre-creates the single `live_events` batch topic (backup/metrics pattern).

Producers land in part 4 — nothing produces into the topic yet. 12 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)