### PR TITLE
JITSU-164: throttle-resilient Redshift Data API driver

### DIFF
--- a/bulker/bulkerlib/implementations/sql/redshift_driver/connection.go
+++ b/bulker/bulkerlib/implementations/sql/redshift_driver/connection.go
@@ -311,15 +311,29 @@ func (c *redshiftConnection) wait(ctx context.Context, id *string) (output *reds
 		_, _ = c.client.CancelStatement(ctx, &redshiftdata.CancelStatementInput{Id: id})
 	}
 
-	// describeOutput describes the query and returns true if the query is finished or an error occurred
+	// describeOutput describes the query and returns true if the query is finished
+	// or polling should stop. A transient DescribeStatement failure (e.g. Data API
+	// throttling after the SDK retryer gave up) must NOT abandon a query that is
+	// still running server-side — keep polling and only give up after several
+	// consecutive failures
+	const maxConsecutiveDescribeErrors = 5
+	consecutiveErrors := 0
 	describeOutput := func() bool {
-		output, err = c.client.DescribeStatement(ctx, &redshiftdata.DescribeStatementInput{
+		var describeErr error
+		output, describeErr = c.client.DescribeStatement(ctx, &redshiftdata.DescribeStatementInput{
 			Id: id,
 		})
-		if err != nil {
+		if describeErr != nil {
 			output = nil
-			return true
+			consecutiveErrors++
+			if ctx.Err() != nil || consecutiveErrors >= maxConsecutiveDescribeErrors {
+				err = describeErr
+				return true
+			}
+			return false
 		}
+		consecutiveErrors = 0
+		err = nil
 		if isFinishedStatus(output.Status) {
 			return true
 		}

--- a/bulker/bulkerlib/implementations/sql/redshift_driver/connection_test.go
+++ b/bulker/bulkerlib/implementations/sql/redshift_driver/connection_test.go
@@ -1,10 +1,70 @@
 package driver
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/redshiftdata"
+	"github.com/aws/aws-sdk-go-v2/service/redshiftdata/types"
 	"github.com/stretchr/testify/require"
 )
+
+type mockRedshiftClient struct {
+	describeErrors    int // fail this many DescribeStatement calls before succeeding
+	describeCallCount int
+}
+
+func (m *mockRedshiftClient) ExecuteStatement(_ context.Context, _ *redshiftdata.ExecuteStatementInput, _ ...func(*redshiftdata.Options)) (*redshiftdata.ExecuteStatementOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockRedshiftClient) BatchExecuteStatement(_ context.Context, _ *redshiftdata.BatchExecuteStatementInput, _ ...func(*redshiftdata.Options)) (*redshiftdata.BatchExecuteStatementOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockRedshiftClient) CancelStatement(_ context.Context, _ *redshiftdata.CancelStatementInput, _ ...func(*redshiftdata.Options)) (*redshiftdata.CancelStatementOutput, error) {
+	return &redshiftdata.CancelStatementOutput{}, nil
+}
+
+func (m *mockRedshiftClient) GetStatementResult(_ context.Context, _ *redshiftdata.GetStatementResultInput, _ ...func(*redshiftdata.Options)) (*redshiftdata.GetStatementResultOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockRedshiftClient) DescribeStatement(_ context.Context, _ *redshiftdata.DescribeStatementInput, _ ...func(*redshiftdata.Options)) (*redshiftdata.DescribeStatementOutput, error) {
+	m.describeCallCount++
+	if m.describeCallCount <= m.describeErrors {
+		return nil, errors.New("ThrottlingException: rate exceeded")
+	}
+	hasResultSet := false
+	return &redshiftdata.DescribeStatementOutput{Status: types.StatusStringFinished, HasResultSet: &hasResultSet}, nil
+}
+
+func waitTestConnection(client RedshiftClient) *redshiftConnection {
+	return newConnection(client, &RedshiftConfig{
+		MinPolling: time.Millisecond,
+		MaxPolling: 2 * time.Millisecond,
+	})
+}
+
+func TestWaitToleratesTransientDescribeErrors(t *testing.T) {
+	client := &mockRedshiftClient{describeErrors: 3}
+	c := waitTestConnection(client)
+	output, err := c.wait(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, types.StatusStringFinished, output.Status)
+	require.Equal(t, 4, client.describeCallCount)
+}
+
+func TestWaitGivesUpAfterConsecutiveDescribeErrors(t *testing.T) {
+	client := &mockRedshiftClient{describeErrors: 100}
+	c := waitTestConnection(client)
+	_, err := c.wait(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ThrottlingException")
+	require.Equal(t, 5, client.describeCallCount)
+}
 
 func TestRewriteQuery(t *testing.T) {
 	cases := []struct {

--- a/bulker/bulkerlib/implementations/sql/redshift_driver/dsn.go
+++ b/bulker/bulkerlib/implementations/sql/redshift_driver/dsn.go
@@ -45,6 +45,7 @@ type RedshiftConfig struct {
 	MinPolling          time.Duration `json:"polling"`          // default: 10ms
 	MaxPolling          time.Duration `json:"maxPolling"`       // default: 5s
 	RetryMaxAttempts    int           `json:"retryMaxAttempts"` // default: 20
+	RetryMode           string        `json:"retryMode"`        // standard | adaptive (default). Data API TPS quotas are account-wide; adaptive self-throttles on ThrottlingException
 
 	// S3Config
 	AccessKeyID     string `mapstructure:"accessKeyId,omitempty" json:"accessKeyId,omitempty" yaml:"accessKeyId,omitempty"`
@@ -156,6 +157,12 @@ func (cfg *RedshiftConfig) LoadOpts(ctx context.Context) ([]func(*config.LoadOpt
 		}))
 	}
 	opts = append(opts, config.WithRetryMaxAttempts(cfg.GetRetryMaxAttempts()))
+	// Data API TPS quotas (ExecuteStatement 30/s, GetStatementResult 20/s, …) are
+	// account-wide per region and non-adjustable: under concurrent load the
+	// standard retryer's token bucket fails fast, while adaptive mode rate-limits
+	// the client until throttling clears. Per-client (i.e. per-connection) only —
+	// no cross-process coordination, but each connection backs off on its own
+	opts = append(opts, config.WithRetryMode(cfg.GetRetryMode()))
 	return opts, nil
 }
 
@@ -197,6 +204,11 @@ func (cfg *RedshiftConfig) String() string {
 		params.Add("retryMaxAttempts", strconv.Itoa(cfg.RetryMaxAttempts))
 	} else {
 		params.Del("retryMaxAttempts")
+	}
+	if cfg.RetryMode != "" {
+		params.Add("retryMode", cfg.RetryMode)
+	} else {
+		params.Del("retryMode")
 	}
 	if cfg.Region != "" {
 		params.Add("region", cfg.Region)
@@ -275,6 +287,14 @@ func (cfg *RedshiftConfig) setParams(params url.Values) error {
 			return fmt.Errorf("parse retry max attempts as int: %w", err)
 		}
 		cfg.Params.Del("retryMaxAttempts")
+	}
+	if params.Has("retryMode") {
+		mode := params.Get("retryMode")
+		if mode != string(aws.RetryModeStandard) && mode != string(aws.RetryModeAdaptive) {
+			return fmt.Errorf("retryMode must be %q or %q, got %q", aws.RetryModeStandard, aws.RetryModeAdaptive, mode)
+		}
+		cfg.RetryMode = mode
+		cfg.Params.Del("retryMode")
 	}
 	if params.Has("region") {
 		cfg.Region = params.Get("region")
@@ -355,6 +375,13 @@ func (cfg *RedshiftConfig) GetRetryMaxAttempts() int {
 		return 20
 	}
 	return cfg.RetryMaxAttempts
+}
+
+func (cfg *RedshiftConfig) GetRetryMode() aws.RetryMode {
+	if cfg.RetryMode == string(aws.RetryModeStandard) {
+		return aws.RetryModeStandard
+	}
+	return aws.RetryModeAdaptive
 }
 
 func ParseDSN(dsn string) (*RedshiftConfig, error) {

--- a/bulker/bulkerlib/implementations/sql/redshift_driver/dsn_test.go
+++ b/bulker/bulkerlib/implementations/sql/redshift_driver/dsn_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,6 +128,19 @@ func TestRedshiftDataConfig__String(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRedshiftConfigRetryMode(t *testing.T) {
+	// default is adaptive: Data API TPS quotas are account-wide
+	require.Equal(t, aws.RetryModeAdaptive, (&RedshiftConfig{}).GetRetryMode())
+	require.Equal(t, aws.RetryModeStandard, (&RedshiftConfig{RetryMode: "standard"}).GetRetryMode())
+
+	cfg, err := ParseDSN("admin@cluster(default)/dev?retryMode=standard")
+	require.NoError(t, err)
+	require.Equal(t, "standard", cfg.RetryMode)
+
+	_, err = ParseDSN("admin@cluster(default)/dev?retryMode=aggressive")
+	require.Error(t, err)
 }
 
 func TestRedshiftConfigSanitize(t *testing.T) {


### PR DESCRIPTION
Follow-up to the CI sharding work (`JITSU-164`): concurrent runs now saturate the Redshift Data API's account-wide TPS quotas (`ExecuteStatement` 30/s, `GetStatementResult` 20/s, `DescribeStatement` 100/s — per region, non-adjustable, shared by every shard and every run). Two driver-level changes in `bulkerlib/implementations/sql/redshift_driver`:

- **Adaptive SDK retry mode by default** (`retryMode` DSN/config override: `standard` | `adaptive`). The standard retryer's client-side token bucket fails fast under sustained throttling; adaptive mode rate-limits the client until throttling clears, and has no throughput penalty when no throttling is observed. Applies per client/connection (no cross-process coordination), which still converges since every connection backs off on its own.
- **`wait()` no longer abandons a running query on a transient `DescribeStatement` failure.** Previously any describe error (e.g. throttling after the SDK gave up) aborted the wait even though the query was still running server-side. Now it keeps polling with the existing backoff and only gives up after 5 consecutive failures; context cancellation still aborts immediately.

Unit tests: retry-mode DSN round-trip + validation, transient-describe tolerance, consecutive-failure cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)