### PR TITLE
JITSU-164: isolate cloud-storage test runs, fail cleanly on bad downloads

### DIFF
--- a/bulker/bulkerlib/implementations/file_storage/bulker_test.go
+++ b/bulker/bulkerlib/implementations/file_storage/bulker_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"io"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -44,14 +45,36 @@ var configRegistry = map[string]any{}
 
 var minioContainer *testcontainers.MinioContainer
 
+// isolatedRunConfig gives an env-provided cloud-storage config a per-run folder.
+// Unlike the per-run minio containers, the aws/gcs buckets are shared across CI
+// runs, and object names are deterministic (test fixture timestamps) — without
+// isolation, concurrent runs write/read/delete the same keys and race
+func isolatedRunConfig(rawJSON string) any {
+	cfg := map[string]any{}
+	if err := json.Unmarshal([]byte(rawJSON), &cfg); err != nil {
+		// let the adapter surface the parse error with the original config
+		return rawJSON
+	}
+	runId := os.Getenv("GITHUB_RUN_ID")
+	if runId == "" {
+		runId = fmt.Sprintf("local-%d", time.Now().UnixMilli())
+	}
+	if attempt := os.Getenv("GITHUB_RUN_ATTEMPT"); attempt != "" {
+		runId += "-" + attempt
+	}
+	folder, _ := cfg["folder"].(string)
+	cfg["folder"] = path.Join(folder, "run-"+runId)
+	return cfg
+}
+
 func init() {
 	gcsConfig := os.Getenv("BULKER_TEST_GCS")
 	if gcsConfig != "" {
-		configRegistry[implementations.GCSBulkerTypeId] = TestConfig{BulkerType: implementations.GCSBulkerTypeId, Config: gcsConfig}
+		configRegistry[implementations.GCSBulkerTypeId] = TestConfig{BulkerType: implementations.GCSBulkerTypeId, Config: isolatedRunConfig(gcsConfig)}
 	}
 	s3Config := os.Getenv("BULKER_TEST_S3")
 	if s3Config != "" {
-		configRegistry[implementations.S3BulkerTypeId+"_aws"] = TestConfig{BulkerType: implementations.S3BulkerTypeId, Config: s3Config}
+		configRegistry[implementations.S3BulkerTypeId+"_aws"] = TestConfig{BulkerType: implementations.S3BulkerTypeId, Config: isolatedRunConfig(s3Config)}
 	}
 	var err error
 	minioContainer, err = testcontainers.NewMinioContainer(context.Background(), "bulkertests")
@@ -427,10 +450,14 @@ func testStream(t *testing.T, testConfig bulkerTestConfig, mode bulker.BulkMode)
 		expectedRowCount := utils.Ternary(testConfig.expectedRows != nil, any(len(testConfig.expectedRows)), testConfig.expectedRowsCount).(int)
 		//Check rows count and rows data when provided
 		rowBytes, err := fileAdapter.Download(expectedFileName)
+		PostStep("download_result_file", testConfig, mode, reqr, err)
 		rows := []map[string]any{}
 		var reader io.Reader
 		if expectedRowCount > 0 && fileAdapter.Compression() == types.FileCompressionGZIP {
-			reader, _ = gzip.NewReader(bytes.NewReader(rowBytes))
+			// a failed/racy download yields non-gzip bytes; asserting here turns a
+			// nil-reader segfault into a readable test failure
+			reader, err = gzip.NewReader(bytes.NewReader(rowBytes))
+			PostStep("gzip_reader", testConfig, mode, reqr, err)
 		} else {
 			reader = bytes.NewReader(rowBytes)
 		}


### PR DESCRIPTION
Follow-up to `JITSU-164`, prompted by [this app-shard failure](https://github.com/jitsucom/jitsu/actions/runs/31815242541): the `file_storage` package SIGSEGV'd with no diagnostics.

**Root cause chain:** the aws/gcs file-storage tests share one bucket across CI runs while object names are deterministic (fixture timestamps like `repeated_ids_pk_batch_2022_08_18T14_17_22.ndjson.gz`), so concurrent runs race on the same keys. A racy download returns non-gzip bytes; `testStream` discarded both the `Download` error and `gzip.NewReader`'s error, then `bufio.Scanner` dereferenced the nil reader — segfaulting the whole test binary.

**Fix:**
- env-provided S3/GCS test configs get a **per-run folder** (`run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT`, `local-<ts>` fallback) — same isolation philosophy `JITSU-164` applied to the warehouses; the per-run minio containers were already isolated
- `testStream` asserts the `Download` and `gzip.NewReader` errors via `PostStep`, so a bad download reads as a proper test failure instead of a SIGSEGV

Housekeeping note: per-run folders accumulate leftover objects from failed runs — worth an S3/GCS lifecycle rule on the test buckets' prefix (infra-side, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)