### PR TITLE
JITSU-138: serialize export envelopes with jsonorder — OrderedMap bodies were {}

### DIFF
--- a/bulker/eventslog/kafka_events_log.go
+++ b/bulker/eventslog/kafka_events_log.go
@@ -3,10 +3,10 @@ package eventslog
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/jitsucom/bulker/jitsubase/jsonorder"
 	"github.com/jitsucom/bulker/jitsubase/logging"
 )
 
@@ -120,7 +120,11 @@ func (k *KafkaEventsLogService) PostAsync(event *ActorEvent) {
 	if timestamp.IsZero() {
 		timestamp = time.Now()
 	}
-	body, err := json.Marshal(event.Event)
+	// jsonorder, NOT encoding/json: event bodies carry OrderedMap values
+	// (lastMappedRow, representation.schema, statistics.states) that only the
+	// jsonorder codec can serialize — encoding/json renders them as {} (the
+	// ClickHouse events log uses jsonorder for the same reason)
+	body, err := jsonorder.Marshal(event.Event)
 	if err != nil {
 		logging.Errorf("[kafka-export] failed to marshal event body for %s/%s: %v", event.WorkspaceId, event.ActorId, err)
 		return
@@ -141,7 +145,7 @@ func (k *KafkaEventsLogService) PostAsync(event *ActorEvent) {
 	case EventTypeBatch, EventTypeProcessed:
 		envelope.DestinationId = event.ActorId
 	}
-	payload, err := json.Marshal(&envelope)
+	payload, err := jsonorder.Marshal(&envelope)
 	if err != nil {
 		logging.Errorf("[kafka-export] failed to marshal export envelope for %s/%s: %v", event.WorkspaceId, event.ActorId, err)
 		return
@@ -177,7 +181,7 @@ func (k *KafkaEventsLogService) produceBillingRecord(envelope *ExportEnvelope, t
 		WorkspaceId: envelope.WorkspaceId,
 		MessageId:   key,
 	}
-	payload, err := json.Marshal(&record)
+	payload, err := jsonorder.Marshal(&record)
 	if err != nil {
 		return
 	}

--- a/bulker/eventslog/kafka_events_log.go
+++ b/bulker/eventslog/kafka_events_log.go
@@ -62,6 +62,18 @@ func ExportEventId(actorId string, timestamp time.Time, payload []byte) string {
 	return hex.EncodeToString(h.Sum(nil)[:16])
 }
 
+// jsonCanonical serializes the eventId hash input: sorted map keys make the
+// bytes deterministic for plain map bodies (ConfigDefault preserves Go's
+// random map iteration order, which would break hash stability); OrderedMap
+// values are already deterministic via insertion order. The envelope itself
+// still uses ConfigDefault so exported bodies keep their natural field order
+var jsonCanonical = jsonorder.Config{
+	EscapeHTML:                    false,
+	UseNumber:                     true,
+	ObjectFieldMustBeSimpleString: true,
+	SortMapKeys:                   true,
+}.Froze()
+
 // ExportProduceFunc produces one message to a Kafka topic. Implementations must
 // be async/non-blocking — export must never delay events-log writes. The
 // returned error reports synchronous enqueue failure (queue full, unknown
@@ -124,7 +136,7 @@ func (k *KafkaEventsLogService) PostAsync(event *ActorEvent) {
 	// (lastMappedRow, representation.schema, statistics.states) that only the
 	// jsonorder codec can serialize — encoding/json renders them as {} (the
 	// ClickHouse events log uses jsonorder for the same reason)
-	body, err := jsonorder.Marshal(event.Event)
+	body, err := jsonCanonical.Marshal(event.Event)
 	if err != nil {
 		logging.Errorf("[kafka-export] failed to marshal event body for %s/%s: %v", event.WorkspaceId, event.ActorId, err)
 		return

--- a/bulker/eventslog/kafka_events_log_test.go
+++ b/bulker/eventslog/kafka_events_log_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jitsucom/bulker/jitsubase/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -183,6 +184,23 @@ func TestKafkaEventsLogBillingDisabled(t *testing.T) {
 	// export still publishes; only the billing record is skipped
 	require.Len(t, *produced, 1)
 	require.Equal(t, "in.id.ws1_otlp.m.batch.t.live_events", (*produced)[0].topic)
+}
+
+func TestKafkaEventsLogOrderedMapBodyFidelity(t *testing.T) {
+	// regression: event bodies carry OrderedMap values (lastMappedRow,
+	// representation.schema); encoding/json silently rendered them as {}
+	service, produced := newTestKafkaService("", map[string]bool{"ws1": true})
+	row := types.NewJson(2)
+	row.Set("message_id", "m1")
+	nested := types.NewJson(1)
+	nested.Set("a", 1)
+	row.Set("nested", nested)
+	event := testActorEvent()
+	event.Event = map[string]any{"status": "COMPLETED", "lastMappedRow": row}
+	service.PostAsync(event)
+	require.Len(t, *produced, 2)
+	payload := string((*produced)[0].payload)
+	require.Contains(t, payload, `"lastMappedRow":{"message_id":"m1","nested":{"a":1}}`)
 }
 
 func TestKafkaEventsLogNoBillingOnEnqueueFailure(t *testing.T) {


### PR DESCRIPTION
Follow-up to `JITSU-138` (#1458), found during end-to-end testing against Datadog.

## Problem

Exported `bulker_batch` records were missing `lastMappedRow`, `representation.schema`, and `statistics.states`; `bulker_stream` record bodies were entirely empty.

Root cause: the export producer marshaled envelopes with `encoding/json`, but those three values are OrderedMap-typed (`jsonorder.OrderedMap` — unexported fields, no `MarshalJSON`), so they silently serialized as `{}`. The ClickHouse events log marshals with `jsonorder` (`ch_events_log.go`), which is why Live Events showed them while the export didn't. Datadog's OTLP intake then drops empty-map values keylessly (verified with controlled probe payloads), which made it look like intake-side filtering.

## Fix

`kafka_events_log.go` now uses `jsonorder.Marshal` for the eventId-hash input, the export envelope, and the billing record — the same codec as the ClickHouse path. Regression test `TestKafkaEventsLogOrderedMapBodyFidelity` asserts OrderedMap fidelity end-to-end through `PostAsync`.

Note: this changes the eventId hash input bytes for affected records; harmless pre-launch (no billed dedup keys exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)