### PR TITLE
console: session-cookie → Firebase SDK bridge for canary subdomain SSO (JITSU-159)

### DIFF
--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -169,13 +169,20 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<FirebaseAuth
   }
   const idToken = await currentUser.getIdToken(shouldRefreshToken);
   const decodedIdToken = await currentUser.getIdTokenResult(false);
-  const csrfToken = getCSRFToken("fb-csrfToken");
-  await rpc(`/api/fb-auth/create-session`, {
-    body: {
-      csrfToken,
-      idToken,
-    },
-  });
+  // JITSU-159: a bridged session (signed in via /api/fb-auth/custom-token)
+  // exists BECAUSE a valid session cookie was already presented — re-minting
+  // the cookie here would silently extend the 5-day session on every page
+  // load of a bridged host, and the server refuses bridge tokens anyway
+  // (create-session 403).
+  if (decodedIdToken.claims.bridge !== true) {
+    const csrfToken = getCSRFToken("fb-csrfToken");
+    await rpc(`/api/fb-auth/create-session`, {
+      body: {
+        csrfToken,
+        idToken,
+      },
+    });
+  }
   const expirationTime = new Date(decodedIdToken.expirationTime);
   const expirationMs = expirationTime.getTime() - Date.now();
   log.atDebug().log(`Firebase token expires in ${expirationMs / (1000 * 60)}min, at ${expirationTime.toISOString()}`);
@@ -210,7 +217,9 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<FirebaseAuth
  */
 async function trySessionCookieBridge(): Promise<auth.User | null> {
   try {
-    const { token } = await rpc(`/api/fb-auth/custom-token`);
+    // POST: SameSite=lax withholds the cookie from cross-site POSTs, which is
+    // what makes the endpoint unreachable by cross-site navigation.
+    const { token } = await rpc(`/api/fb-auth/custom-token`, { body: {} });
     const credential = await auth.signInWithCustomToken(auth.getAuth(), token);
     return credential.user;
   } catch (e) {
@@ -335,12 +344,13 @@ export function useFirebaseSession(): FirebaseSession {
         let unregister = auth.onAuthStateChanged(
           auth.getAuth(),
           async user => {
-            // Unregister before any async work: the bridge below signs in via
-            // custom token, which would re-fire this listener and double-run
-            // getUserFromFirebase for the same resolution.
-            unregister();
             log.atDebug().log(`Firebase auth result`, user);
             try {
+              // Unregister before any async work: the bridge below signs in via
+              // custom token, which would re-fire this listener and double-run
+              // getUserFromFirebase. Inside the try so a throwing unsubscribe
+              // rejects instead of leaving the promise pending forever.
+              unregister();
               if (!user && !token) {
                 // No per-origin SDK state and no explicit ?token= — the session
                 // cookie may still be valid (subdomain carryover, JITSU-159).

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -195,6 +195,31 @@ async function getUserFromFirebase(currentUser: auth.User): Promise<FirebaseAuth
 }
 
 /**
+ * Session-cookie → Firebase SDK bridge (JITSU-159). The `jitsu-auth` session
+ * cookie is scoped to AUTH_COOKIE_DOMAIN (e.g. jitsu.com) and so carries over
+ * to sibling hosts like pr<N>.use.jitsu.com — but the Firebase JS SDK persists
+ * its auth state in per-origin IndexedDB, so on a host the user never signed
+ * in on, onAuthStateChanged yields null despite the valid cookie (and a fresh
+ * sign-in there would fail Firebase's authorized-domains check). Exchange the
+ * cookie for a custom token server-side and establish SDK state with it.
+ *
+ * Best-effort: any failure (401 = no/revoked cookie, network) returns null and
+ * the caller falls through to the sign-in screen. The cookie is httpOnly, so
+ * its presence can't be probed client-side — on signed-out page loads this
+ * costs one 401 roundtrip.
+ */
+async function trySessionCookieBridge(): Promise<auth.User | null> {
+  try {
+    const { token } = await rpc(`/api/fb-auth/custom-token`);
+    const credential = await auth.signInWithCustomToken(auth.getAuth(), token);
+    return credential.user;
+  } catch (e) {
+    log.atDebug().withCause(e).log(`Session-cookie bridge not available, proceeding signed-out`);
+    return null;
+  }
+}
+
+/**
  * Records a Firebase sign-in audit event. Called only from the explicit
  * sign-in entry points (signIn / signInWith) — the implicit cookie-mint
  * path on every page load deliberately doesn't, otherwise the audit log
@@ -310,8 +335,17 @@ export function useFirebaseSession(): FirebaseSession {
         let unregister = auth.onAuthStateChanged(
           auth.getAuth(),
           async user => {
+            // Unregister before any async work: the bridge below signs in via
+            // custom token, which would re-fire this listener and double-run
+            // getUserFromFirebase for the same resolution.
+            unregister();
             log.atDebug().log(`Firebase auth result`, user);
             try {
+              if (!user && !token) {
+                // No per-origin SDK state and no explicit ?token= — the session
+                // cookie may still be valid (subdomain carryover, JITSU-159).
+                user = await trySessionCookieBridge();
+              }
               const result = user ? await getUserFromFirebase(user) : null;
               // Record the login only for an explicit sign-in (recordLogin) and only after
               // getUserFromFirebase has minted/linked internalId — otherwise a first-time
@@ -326,8 +360,6 @@ export function useFirebaseSession(): FirebaseSession {
               // promise — without this catch the throw escapes the async callback
               // as an unhandled rejection and the caller hangs.
               reject(e);
-            } finally {
-              unregister();
             }
           },
           error => {

--- a/webapps/console/lib/firebase-client.tsx
+++ b/webapps/console/lib/firebase-client.tsx
@@ -2,13 +2,13 @@ import { createContext, PropsWithChildren, useContext } from "react";
 import { getApps, initializeApp } from "firebase/app";
 import * as auth from "firebase/auth";
 import { AppConfig, ContextApiResponse, CreateUserResult } from "./schema";
-import { getLog, randomId, requireDefined, rpc } from "juava";
+import { ApiResponseError, getLog, randomId, requireDefined, rpc } from "juava";
 import { useJitsu } from "@jitsu/jitsu-react";
 
 type FirebaseClientSettings = Record<string, any>;
 export type FirebaseProviderInstance =
-  | { enabled: false; settings?: never }
-  | { enabled: true; settings: FirebaseClientSettings };
+  | { enabled: false; settings?: never; sessionBridge?: never }
+  | { enabled: true; settings: FirebaseClientSettings; sessionBridge?: boolean };
 
 /**
  * Outcome of resolving the current Firebase user into a Jitsu session. Returned
@@ -35,7 +35,7 @@ export const FirebaseProvider: React.FC<PropsWithChildren<{ appConfig: AppConfig
     <FirebaseContext.Provider
       value={
         appConfig.auth?.firebasePublic
-          ? { enabled: true, settings: appConfig.auth?.firebasePublic }
+          ? { enabled: true, settings: appConfig.auth?.firebasePublic, sessionBridge: appConfig.auth?.sessionBridge }
           : { enabled: false }
       }
     >
@@ -229,6 +229,34 @@ async function trySessionCookieBridge(): Promise<auth.User | null> {
 }
 
 /**
+ * A persisted bridged session can outlive its authorizing cookie: the SDK
+ * refresh token keeps renewing client-side state after the cookie has expired,
+ * been revoked, or started belonging to a different account (switch on the
+ * main origin) — the UI would then show one identity while cookie-backed API
+ * calls act as another (or 401). Re-run the exchange on every load of a
+ * bridged session: success re-signs with a token for the cookie's CURRENT
+ * user (idempotent for the same user, corrects a switch); a definitive server
+ * rejection (ApiResponseError — expired/revoked cookie, bridge disabled)
+ * drops the stale SDK state. Transient failures (network) keep the session —
+ * same best-effort stance as the initial bridge.
+ */
+async function revalidateBridgedSession(current: auth.User): Promise<auth.User | null> {
+  try {
+    const { token } = await rpc(`/api/fb-auth/custom-token`, { body: {} });
+    const credential = await auth.signInWithCustomToken(auth.getAuth(), token);
+    return credential.user;
+  } catch (e) {
+    if (e instanceof ApiResponseError) {
+      log.atInfo().log(`Bridged session is no longer backed by a valid cookie, signing out`);
+      await auth.signOut(auth.getAuth());
+      return null;
+    }
+    log.atWarn().withCause(e).log(`Bridged session revalidation failed transiently, keeping current session`);
+    return current;
+  }
+}
+
+/**
  * Records a Firebase sign-in audit event. Called only from the explicit
  * sign-in entry points (signIn / signInWith) — the implicit cookie-mint
  * path on every page load deliberately doesn't, otherwise the audit log
@@ -351,10 +379,16 @@ export function useFirebaseSession(): FirebaseSession {
               // getUserFromFirebase. Inside the try so a throwing unsubscribe
               // rejects instead of leaving the promise pending forever.
               unregister();
-              if (!user && !token) {
-                // No per-origin SDK state and no explicit ?token= — the session
-                // cookie may still be valid (subdomain carryover, JITSU-159).
-                user = await trySessionCookieBridge();
+              if (!token && config.sessionBridge) {
+                if (!user) {
+                  // No per-origin SDK state and no explicit ?token= — the session
+                  // cookie may still be valid (subdomain carryover, JITSU-159).
+                  user = await trySessionCookieBridge();
+                } else if ((await user.getIdTokenResult()).claims.bridge === true) {
+                  // Persisted bridged state must stay in lockstep with the
+                  // cookie that authorized it — see revalidateBridgedSession.
+                  user = await revalidateBridgedSession(user);
+                }
               }
               const result = user ? await getUserFromFirebase(user) : null;
               // Record the login only for an explicit sign-in (recordLogin) and only after

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -182,6 +182,9 @@ export const AppConfig = z.object({
   auth: z
     .object({
       firebasePublic: z.any(),
+      // JITSU-159: server has AUTH_SESSION_BRIDGE_ENABLED — the client may
+      // attempt the session-cookie -> Firebase-SDK bridge on page load.
+      sessionBridge: z.boolean().optional(),
       nextauth: z
         .object({
           github: z.boolean().optional(),

--- a/webapps/console/lib/server/firebase-server.ts
+++ b/webapps/console/lib/server/firebase-server.ts
@@ -230,7 +230,10 @@ export async function getFirebaseUser(req: NextApiRequest, checkRevoked?: boolea
   let decodedIdToken;
   try {
     decodedIdToken = authToken.idToken
-      ? await firebase().auth().verifyIdToken(authToken.idToken)
+      ? // Pass checkRevoked on both branches — previously the idToken branch
+        // silently dropped it, so callers requesting a revocation check (e.g.
+        // /api/me) only got one for cookie-authenticated requests.
+        await firebase().auth().verifyIdToken(authToken.idToken, checkRevoked)
       : await firebase()
           .auth()
           .verifySessionCookie(authToken.cookieToken as string, checkRevoked);

--- a/webapps/console/lib/server/serverEnv.ts
+++ b/webapps/console/lib/server/serverEnv.ts
@@ -134,6 +134,12 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   // Enable email/password login
   ENABLE_CREDENTIALS_LOGIN: z.string().default("false").transform(isTruish),
 
+  // JITSU-159: enables POST /api/fb-auth/custom-token — the session-cookie →
+  // Firebase-SDK bridge used for subdomain SSO onto canary hosts
+  // (pr<N>.use.jitsu.com). Off by default: production doesn't need the bridge,
+  // and keeping it off also spares signed-out page loads the probe roundtrip.
+  AUTH_SESSION_BRIDGE_ENABLED: z.string().default("false").transform(isTruish),
+
   // Firebase authentication configuration (JSON)
   FIREBASE_AUTH: z.string().optional(),
 

--- a/webapps/console/pages/api/app-config.ts
+++ b/webapps/console/pages/api/app-config.ts
@@ -35,6 +35,7 @@ export default createRoute()
       ...(isFirebaseEnabled()
         ? {
             firebasePublic: requireFirebaseOptions().client,
+            ...(serverEnv.AUTH_SESSION_BRIDGE_ENABLED ? { sessionBridge: true } : {}),
           }
         : {}),
       ...(nextAuth

--- a/webapps/console/pages/api/fb-auth/create-session.ts
+++ b/webapps/console/pages/api/fb-auth/create-session.ts
@@ -45,6 +45,15 @@ export const api: Api = {
       if (isUnverifiedPasswordAccount(decodedIdToken)) {
         throw new ApiError("Email address is not verified", { status: 403 });
       }
+      // JITSU-159: an ID token descending from a session-cookie bridge token
+      // (/api/fb-auth/custom-token) must never mint a NEW session cookie —
+      // otherwise credentials lifted from a bridged (e.g. canary) origin could
+      // be laundered into a fresh 5-day session that outlives the cookie they
+      // came from. Bridge sessions ride the existing cookie; only a real
+      // Firebase sign-in mints one.
+      if (decodedIdToken.bridge === true) {
+        throw new ApiError("Bridge sessions cannot mint session cookies", { status: 403 });
+      }
       const { cookie, expiresIn } = await createSessionCookie(idToken);
 
       // Audit logging lives in /api/fb-auth/audit-login which the client

--- a/webapps/console/pages/api/fb-auth/custom-token.ts
+++ b/webapps/console/pages/api/fb-auth/custom-token.ts
@@ -1,0 +1,50 @@
+import { createRoute } from "../../../lib/api";
+import { z } from "zod";
+import { firebase, getFirebaseUser, isFirebaseEnabled } from "../../../lib/server/firebase-server";
+import { ApiError } from "../../../lib/shared/errors";
+
+/**
+ * Exchanges the `jitsu-auth` session cookie for a Firebase custom token, so a
+ * sibling host that receives the cookie (Domain=AUTH_COOKIE_DOMAIN, e.g.
+ * jitsu.com) can establish client-side Firebase SDK state without a fresh
+ * sign-in. The SDK persists auth state in per-origin IndexedDB, so a session
+ * signed in on use.jitsu.com does not exist on pr<N>.use.jitsu.com even though
+ * the cookie is delivered there — this endpoint bridges that gap (JITSU-159,
+ * canary deployments).
+ *
+ * Security: the caller must already hold a valid session cookie — the token is
+ * minted for that same user, so this grants no privileges the cookie doesn't
+ * already carry. The cookie is re-verified with checkRevoked so a revoked
+ * (signed-out) session can't mint fresh credentials even before the cookie
+ * expires. GET keeps it exempt from the mutating-request maintenance gate, so
+ * the bridge works on read-only canaries.
+ */
+export default createRoute()
+  .GET({
+    auth: true,
+    result: z.object({
+      token: z.string(),
+    }),
+  })
+  .handler(async ({ req, user }) => {
+    if (!isFirebaseEnabled()) {
+      throw new ApiError("Firebase auth is not enabled", { status: 404 });
+    }
+    if (user.authType !== "firebase") {
+      throw new ApiError("Session bridge is only available for firebase auth", { status: 400 });
+    }
+    // auth:true has already established the user; re-verify with checkRevoked
+    // (the framework check doesn't) before minting sign-in-capable credentials.
+    const fbUser = await getFirebaseUser(req, true);
+    if (!fbUser) {
+      throw new ApiError("Session is revoked or expired", { status: 401 });
+    }
+    // Same claim shape as /api/admin/become: carry internalId so the client
+    // skips the create-user roundtrip. Omit the claim when it's not set (a
+    // first-login race) — firebase-admin rejects undefined claim values.
+    const token = await firebase()
+      .auth()
+      .createCustomToken(fbUser.externalId, fbUser.internalId ? { internalId: fbUser.internalId } : undefined);
+    return { token };
+  })
+  .toNextApiHandler();

--- a/webapps/console/pages/api/fb-auth/custom-token.ts
+++ b/webapps/console/pages/api/fb-auth/custom-token.ts
@@ -12,21 +12,30 @@ import { ApiError } from "../../../lib/shared/errors";
  * the cookie is delivered there — this endpoint bridges that gap (JITSU-159,
  * canary deployments).
  *
- * Security: the caller must already hold a valid session cookie — the token is
- * minted for that same user, so this grants no privileges the cookie doesn't
- * already carry. The cookie is re-verified with checkRevoked so a revoked
- * (signed-out) session can't mint fresh credentials even before the cookie
- * expires. GET keeps it exempt from the mutating-request maintenance gate, so
- * the bridge works on read-only canaries.
+ * Security model:
+ * - Same-principal: the token is minted for the cookie's own user, so it
+ *   grants nothing the cookie doesn't already carry. The cookie is re-verified
+ *   with checkRevoked so a revoked (signed-out) session can't mint fresh
+ *   credentials before the cookie expires.
+ * - POST, not GET: SameSite=lax never attaches the cookie to cross-site POSTs,
+ *   so the endpoint is unreachable via cross-site navigation — the same reason
+ *   create-session is safe. allowDuringMaintenance keeps the bridge working on
+ *   read-only canaries (create-session uses the same exemption).
+ * - The token is tagged `bridge: true`, and create-session REFUSES bridge
+ *   tokens: a bridged session can establish client SDK state, but can never
+ *   mint a fresh 5-day session cookie from it. This caps what in-page script
+ *   on a canary host can do with the bridged credentials — they expire with
+ *   the underlying session instead of compounding into new cookies.
  */
 export default createRoute()
-  .GET({
+  .POST({
     auth: true,
+    allowDuringMaintenance: true,
     result: z.object({
       token: z.string(),
     }),
   })
-  .handler(async ({ req, user }) => {
+  .handler(async ({ req, res, user }) => {
     if (!isFirebaseEnabled()) {
       throw new ApiError("Firebase auth is not enabled", { status: 404 });
     }
@@ -39,12 +48,17 @@ export default createRoute()
     if (!fbUser) {
       throw new ApiError("Session is revoked or expired", { status: 401 });
     }
-    // Same claim shape as /api/admin/become: carry internalId so the client
-    // skips the create-user roundtrip. Omit the claim when it's not set (a
-    // first-login race) — firebase-admin rejects undefined claim values.
+    // A bearer-equivalent credential must never be cached by any intermediary.
+    res.setHeader("Cache-Control", "no-store");
+    // internalId claim as in /api/admin/become (skips the create-user roundtrip
+    // client-side); omitted when unset — firebase-admin rejects undefined claim
+    // values. `bridge: true` marks the token for the create-session refusal.
     const token = await firebase()
       .auth()
-      .createCustomToken(fbUser.externalId, fbUser.internalId ? { internalId: fbUser.internalId } : undefined);
+      .createCustomToken(fbUser.externalId, {
+        ...(fbUser.internalId ? { internalId: fbUser.internalId } : {}),
+        bridge: true,
+      });
     return { token };
   })
   .toNextApiHandler();

--- a/webapps/console/pages/api/fb-auth/custom-token.ts
+++ b/webapps/console/pages/api/fb-auth/custom-token.ts
@@ -1,6 +1,7 @@
 import { createRoute } from "../../../lib/api";
 import { z } from "zod";
 import { firebase, getFirebaseUser, isFirebaseEnabled } from "../../../lib/server/firebase-server";
+import { getServerEnv } from "../../../lib/server/serverEnv";
 import { ApiError } from "../../../lib/shared/errors";
 
 /**
@@ -36,8 +37,11 @@ export default createRoute()
     }),
   })
   .handler(async ({ req, res, user }) => {
-    if (!isFirebaseEnabled()) {
-      throw new ApiError("Firebase auth is not enabled", { status: 404 });
+    // Deploy-time opt-in (AUTH_SESSION_BRIDGE_ENABLED): the bridge only exists
+    // on deployments that need subdomain SSO (canaries). Production keeps the
+    // endpoint dark.
+    if (!isFirebaseEnabled() || !getServerEnv().AUTH_SESSION_BRIDGE_ENABLED) {
+      throw new ApiError("Session bridge is not enabled", { status: 404 });
     }
     if (user.authType !== "firebase") {
       throw new ApiError("Session bridge is only available for firebase auth", { status: 400 });


### PR DESCRIPTION
## What

Canary deployments (`pr<N>.use.jitsu.com`, JITSU-159) receive the production `jitsu-auth` session cookie (`Domain=jitsu.com` via `AUTH_COOKIE_DOMAIN`) — but still showed the login screen, because the Firebase JS SDK persists auth state in **per-origin** IndexedDB, and a fresh sign-in on a canary host is blocked by Firebase's authorized-domains check (no wildcard support).

This adds a bridge, the same mechanism the admin `become` flow already uses:

- **`POST /api/fb-auth/custom-token`** — exchanges the (carried-over) session cookie for a Firebase custom token, same-principal, `checkRevoked`-verified.
- **`resolveUser`** — when the SDK has no per-origin user and no explicit `?token=`, it attempts the exchange and completes `signInWithCustomToken`. Failures fall through to the sign-in screen.

## Security model

- **Same-principal only**: the token is minted for the cookie's own user; the cookie already authorizes the full API, so no new authority is granted.
- **POST + `allowDuringMaintenance`**: SameSite=lax never attaches the cookie to cross-site POSTs (closes the top-level-navigation vector); the flag keeps the bridge working on read-only canaries — both per the existing `create-session` pattern. `Cache-Control: no-store` on the response.
- **Bridge tokens are tagged `bridge: true` and `create-session` refuses them**: bridged credentials can establish SDK state but can never mint a fresh 5-day session cookie — cutting the chain where credentials lifted from a canary could be laundered into a durable production session. Bridged sessions also skip the client-side cookie re-mint (which would otherwise silently extend the cookie on every canary page load).
- **Adjacent fix**: `getFirebaseUser` now passes `checkRevoked` through `verifyIdToken` (the idToken branch silently dropped it, weakening `/api/me`'s revocation check).

Accepted residual (consistent with the documented canary trust boundary — maintainer-gated, same-repo-only images): in-page script on a bridged origin can read the SDK credentials; with the cookie-mint refusal above, exposure is capped at the underlying session's lifetime.

## Deployment gating & session lifecycle (added in review round 2)

- The entire bridge is gated behind **`AUTH_SESSION_BRIDGE_ENABLED`** (default **off**): the endpoint 404s and the client never probes. Only canary deployments set it (infra: `k8s/canary-console/values.yaml`). Production keeps the endpoint dark and signed-out page loads make no extra roundtrip.
- **Persisted bridged sessions revalidate against the cookie on every load**: same user → re-signed transparently; account switched on the main origin → re-bridged to the new identity; cookie expired/revoked → SDK state signed out (cookie untouched, so a later valid session re-bridges). Transient network errors keep the session.
- Accepted low-severity edges (canary-only feature): a 5xx during a redeploy counts as a definitive rejection and costs one sign-in-screen load before self-healing; turning the flag off doesn't proactively sign out origins bridged while it was on.

## Test notes

- Console typecheck clean (the `libs/jitsu-js` `jsondiffpatch` error is pre-existing on `newjitsu`).
- Explicit sign-in, `?token=` (become), and sign-out flows verified unaffected by review (bridge only runs when the SDK has no user AND no token param).
- Live verification once merged: build a canary from a rebased PR, log in on `use.jitsu.com`, open `pr<N>.use.jitsu.com` → should authorize without a login screen.

Linear: JITSU-159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
