### PR TITLE
JITSU-11: fix(ingest): stop reflecting Origin with allow-credentials on CORS responses

### DIFF
--- a/bulker/ingest/router.go
+++ b/bulker/ingest/router.go
@@ -216,23 +216,25 @@ func NewRouter(appContext *Context, partitionSelector kafkabase.PartitionSelecto
 	return router
 }
 
+// CorsMiddleware serves the ingest API as an intentionally open, credential-less
+// endpoint: a constant wildcard origin and no Access-Control-Allow-Credentials.
+// Reflecting the Origin together with allow-credentials would let any site read
+// credentialed responses (JITSU-11); no supported client sends cookies here.
 func (r *Router) CorsMiddleware(c *gin.Context) {
 	origin := c.GetHeader("Origin")
 	if c.Request.Method == "OPTIONS" {
-		c.Header("Access-Control-Allow-Origin", utils.NvlString(origin, "*"))
+		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "GET,POST,HEAD,OPTIONS")
 		// x-jitsu-custom - in case client want to add some custom payload via header
 		c.Header("Access-Control-Allow-Headers", "x-enable-debug, x-write-key, authorization, content-type, x-ip-policy, cache-control, x-jitsu-custom")
-		c.Header("Access-Control-Allow-Credentials", "true")
 		c.Header("Access-Control-Max-Age", "86400")
 		c.AbortWithStatus(http.StatusOK)
 		return
 	} else if origin != "" {
-		c.Header("Access-Control-Allow-Origin", origin)
+		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "GET,POST,HEAD,OPTIONS")
 		// x-jitsu-custom - in case client want to add some custom payload via header
 		c.Header("Access-Control-Allow-Headers", "x-enable-debug, x-write-key, authorization, content-type, x-ip-policy, cache-control, x-jitsu-custom")
-		c.Header("Access-Control-Allow-Credentials", "true")
 		c.Header("Access-Control-Max-Age", "86400")
 	}
 	c.Next()


### PR DESCRIPTION
## Summary

Fixes the CORS origin-reflection-with-credentials misconfiguration on the ingest API (`JITSU-11`, CVSS 8.2). `CorsMiddleware` in `bulker/ingest/router.go` previously reflected the request `Origin` into `Access-Control-Allow-Origin` and set `Access-Control-Allow-Credentials: true` — allowing any site to read credentialed cross-origin responses. It now serves a constant `Access-Control-Allow-Origin: *` and omits the allow-credentials header. The wildcard is browser-enforced as incompatible with credentialed requests, so cross-origin reads are guaranteed to be cookie-less.

No supported client is affected:
- The jitsu-js event POST uses fetch without a `credentials` option (defaults to `same-origin` — no cookies were ever sent cross-origin); the anonymous id travels in the JSON payload.
- The pixel endpoint (`<img>` GET) and `/p.js` script loads are not CORS-governed.
- The SDK's only `credentials: "include"` call is the `idEndpoint`, which is same-origin by documented contract and not served by ingest.

## Verify

After deploy, a request with a third-party `Origin` gets `Access-Control-Allow-Origin: *` and no `Access-Control-Allow-Credentials` header:

```
curl -si -X OPTIONS -H 'Origin: https://evil.example' https://t.jitsu.com/api/s/track | grep -i access-control
```

Known adjacent (out of scope, follow-up): `bulker/admin/router.go` and `webapps/console/pages/api/destinations.ts` have the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)