### PR TITLE
JITSU-27: fix(ingest): sanitize __sql_type hint values on s2s ingest

### DIFF
--- a/bulker/ingest/router.go
+++ b/bulker/ingest/router.go
@@ -434,7 +434,7 @@ func patchEvent(c *gin.Context, messageId string, ev types.Json, tp string, inge
 		// remove any jitsu special properties from ingested events
 		// it is only allowed to be set via functions
 		types.FilterEvent(ev)
-	} else if ingestType == IngestTypeS2S {
+	} else {
 		// server-to-server: capture the (forwarding) request headers, but let the caller
 		// override allow-listed headers via the event body to forward the original
 		// device's headers. When capture is disabled, a body-provided context.headers is
@@ -442,6 +442,9 @@ func patchEvent(c *gin.Context, messageId string, ev types.Json, tp string, inge
 		if stream != nil && stream.CaptureHeaders {
 			ctx.Set("headers", buildContextHeaders(c, ctx.GetN("headers"), ctx))
 		}
+		// s2s callers may use __sql_type* hints (unlike browser, where FilterEvent
+		// drops them), but hint values reach SQL DDL — keep only type-shaped ones
+		types.SanitizeSqlTypes(ev)
 	}
 	nowIsoDate := time.Now().UTC().Format(timestamp.JsonISO)
 	ev.Set("receivedAt", nowIsoDate)

--- a/bulker/ingest/router_classic_handler.go
+++ b/bulker/ingest/router_classic_handler.go
@@ -232,6 +232,10 @@ func patchClassicEvent(c *gin.Context, messageId string, ev types.Json, _ string
 		// remove any jitsu special properties from ingested events
 		// it is only allowed to be set via functions
 		types.FilterEvent(ev)
+	} else {
+		// s2s callers may use __sql_type* hints, but hint values reach SQL DDL —
+		// keep only type-shaped ones
+		types.SanitizeSqlTypes(ev)
 	}
 	nowIsoDate := time.Now().UTC().Format(timestamp.JsonISO)
 	ev.Set("_timestamp", nowIsoDate)

--- a/bulker/jitsubase/types/json.go
+++ b/bulker/jitsubase/types/json.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/jitsucom/bulker/jitsubase/jsonorder"
@@ -9,12 +8,23 @@ import (
 
 const SqlTypePrefix = "__sql_type"
 
-// sqlTypeHintValue is the shape a __sql_type* hint value must have to survive
-// s2s ingest: a plain SQL type name, e.g. "JSON", "VARCHAR(255)",
-// "TIMESTAMP WITH TIME ZONE", "Nullable(String)", "ARRAY<STRING>".
-// Quotes, semicolons, dashes and slashes are excluded so a hint cannot break
-// out of the type position in generated DDL.
-var sqlTypeHintValue = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9 _,()<>]{0,127}$`)
+// sqlTypeHintAllowlist enumerates the __sql_type* hint values allowed through
+// s2s ingest, compared case-insensitively (the original casing is passed
+// through, which matters for case-sensitive drivers like ClickHouse). The
+// hint's only supported use at ingest is mapping a (nested) object to a JSON-
+// or string-typed column, so only bare object/string type names are allowed —
+// no parameters, no expressions, nothing that could alter generated DDL.
+// Richer hints can still be produced by transformation functions downstream.
+var sqlTypeHintAllowlist = map[string]bool{
+	"json":    true, // Postgres, MySQL, ClickHouse, BigQuery
+	"jsonb":   true, // Postgres
+	"string":  true, // ClickHouse, BigQuery
+	"text":    true,
+	"varchar": true,
+	"variant": true, // Snowflake
+	"object":  true, // Snowflake
+	"super":   true, // Redshift
+}
 
 type Json = *jsonorder.OrderedMap[string, any]
 
@@ -73,13 +83,12 @@ func FilterEvent(event Json) {
 	filterEvent(event, nil)
 }
 
-// SanitizeSqlTypes keeps well-formed __sql_type* hints and deletes the rest.
+// SanitizeSqlTypes keeps allowlisted __sql_type* hints and deletes the rest.
 // Used on the s2s path, where hints are a supported feature but their values
-// end up in SQL DDL: a hint must be a single type-shaped string. The
-// [castType, ddlType] array form accepted by extractSQLTypesHints in bulkerlib
-// is deliberately not allowed through ingest — a separate ddlType is a wider
-// DDL surface with no known external user. The event itself is never rejected
-// over a bad hint.
+// end up in SQL DDL: a hint must be a single string from
+// sqlTypeHintAllowlist. The [castType, ddlType] array form accepted by
+// extractSQLTypesHints in bulkerlib is deliberately not allowed through
+// ingest. The event itself is never rejected over a bad hint.
 func SanitizeSqlTypes(event Json) {
 	filterEvent(event, isValidSqlTypeHint)
 }
@@ -116,5 +125,5 @@ func filterEvent(event any, keepHint func(any) bool) {
 
 func isValidSqlTypeHint(v any) bool {
 	s, ok := v.(string)
-	return ok && sqlTypeHintValue.MatchString(s)
+	return ok && sqlTypeHintAllowlist[strings.ToLower(s)]
 }

--- a/bulker/jitsubase/types/json.go
+++ b/bulker/jitsubase/types/json.go
@@ -75,9 +75,11 @@ func FilterEvent(event Json) {
 
 // SanitizeSqlTypes keeps well-formed __sql_type* hints and deletes the rest.
 // Used on the s2s path, where hints are a supported feature but their values
-// end up in SQL DDL: a hint must be a type-shaped string (or a 1-2 element
-// array of such strings, [castType, ddlType] — see extractSQLTypesHints in
-// bulkerlib). The event itself is never rejected over a bad hint.
+// end up in SQL DDL: a hint must be a single type-shaped string. The
+// [castType, ddlType] array form accepted by extractSQLTypesHints in bulkerlib
+// is deliberately not allowed through ingest — a separate ddlType is a wider
+// DDL surface with no known external user. The event itself is never rejected
+// over a bad hint.
 func SanitizeSqlTypes(event Json) {
 	filterEvent(event, isValidSqlTypeHint)
 }
@@ -113,21 +115,6 @@ func filterEvent(event any, keepHint func(any) bool) {
 }
 
 func isValidSqlTypeHint(v any) bool {
-	switch val := v.(type) {
-	case string:
-		return sqlTypeHintValue.MatchString(val)
-	case []any:
-		if len(val) == 0 || len(val) > 2 {
-			return false
-		}
-		for _, e := range val {
-			s, ok := e.(string)
-			if !ok || !sqlTypeHintValue.MatchString(s) {
-				return false
-			}
-		}
-		return true
-	default:
-		return false
-	}
+	s, ok := v.(string)
+	return ok && sqlTypeHintValue.MatchString(s)
 }

--- a/bulker/jitsubase/types/json.go
+++ b/bulker/jitsubase/types/json.go
@@ -1,12 +1,20 @@
 package types
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/jitsucom/bulker/jitsubase/jsonorder"
 )
 
 const SqlTypePrefix = "__sql_type"
+
+// sqlTypeHintValue is the shape a __sql_type* hint value must have to survive
+// s2s ingest: a plain SQL type name, e.g. "JSON", "VARCHAR(255)",
+// "TIMESTAMP WITH TIME ZONE", "Nullable(String)", "ARRAY<STRING>".
+// Quotes, semicolons, dashes and slashes are excluded so a hint cannot break
+// out of the type position in generated DDL.
+var sqlTypeHintValue = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9 _,()<>]{0,127}$`)
 
 type Json = *jsonorder.OrderedMap[string, any]
 
@@ -62,10 +70,21 @@ func FilterEvent(event Json) {
 	_ = event.Delete("SALESFORCE_MATCHERS_OPERATOR")
 	_ = event.Delete("SALESFORCE_MATCHERS")
 	_ = event.Delete("SALESFORCE_PAYLOAD")
-	filterEvent(event)
+	filterEvent(event, nil)
 }
 
-func filterEvent(event any) {
+// SanitizeSqlTypes keeps well-formed __sql_type* hints and deletes the rest.
+// Used on the s2s path, where hints are a supported feature but their values
+// end up in SQL DDL: a hint must be a type-shaped string (or a 1-2 element
+// array of such strings, [castType, ddlType] — see extractSQLTypesHints in
+// bulkerlib). The event itself is never rejected over a bad hint.
+func SanitizeSqlTypes(event Json) {
+	filterEvent(event, isValidSqlTypeHint)
+}
+
+// keepHint == nil deletes every __sql_type* key; otherwise keys whose value
+// fails keepHint are deleted.
+func filterEvent(event any, keepHint func(any) bool) {
 	switch v := event.(type) {
 	case Json:
 		for el := v.Front(); el != nil; {
@@ -73,11 +92,13 @@ func filterEvent(event any) {
 			// move to the next element before deleting the current one. otherwise iteration will be broken
 			el = el.Next()
 			if strings.HasPrefix(curEl.Key, SqlTypePrefix) {
-				v.DeleteElement(curEl)
+				if keepHint == nil || !keepHint(curEl.Value) {
+					v.DeleteElement(curEl)
+				}
 			} else {
 				switch v2 := curEl.Value.(type) {
 				case Json, []any:
-					filterEvent(v2)
+					filterEvent(v2, keepHint)
 				}
 			}
 		}
@@ -85,8 +106,28 @@ func filterEvent(event any) {
 		for _, a := range v {
 			switch v2 := a.(type) {
 			case Json, []any:
-				filterEvent(v2)
+				filterEvent(v2, keepHint)
 			}
 		}
+	}
+}
+
+func isValidSqlTypeHint(v any) bool {
+	switch val := v.(type) {
+	case string:
+		return sqlTypeHintValue.MatchString(val)
+	case []any:
+		if len(val) == 0 || len(val) > 2 {
+			return false
+		}
+		for _, e := range val {
+			s, ok := e.(string)
+			if !ok || !sqlTypeHintValue.MatchString(s) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
 	}
 }

--- a/bulker/jitsubase/types/json_test.go
+++ b/bulker/jitsubase/types/json_test.go
@@ -103,13 +103,13 @@ func TestEventFilter(t *testing.T) {
 const jHints = `{
   "type": "track",
   "event": "test",
-  "__sql_type_type": "VARCHAR(255)",
+  "__sql_type_type": "String",
   "__sql_type_bad": "TEXT); DROP TABLE users;--",
   "properties": {
     "__sql_type_": "JSON",
-    "__sql_type_ts": "TIMESTAMP WITH TIME ZONE",
+    "__sql_type_param": "VARCHAR(255)",
     "__sql_type_arr": ["DateTime64(3)", "Nullable(DateTime64(3))"],
-    "__sql_type_arr1": ["DateTime64(3)"],
+    "__sql_type_arr1": ["JSON"],
     "__sql_type_quoted": "Enum8('a'=1)",
     "__sql_type_num": 42,
     "__sql_type_long_arr": ["a", "b", "c"],
@@ -117,14 +117,14 @@ const jHints = `{
   },
   "context": {
     "nested": [{
-      "__sql_type_ok": "ARRAY<STRING>",
+      "__sql_type_ok": "jsonb",
       "__sql_type_comment": "TEXT /* x */",
       "a": 1
     }]
   }
 }`
 
-const jHintsSanitized = `{"type":"track","event":"test","__sql_type_type":"VARCHAR(255)","properties":{"__sql_type_":"JSON","__sql_type_ts":"TIMESTAMP WITH TIME ZONE","title":"Jitsu"},"context":{"nested":[{"__sql_type_ok":"ARRAY<STRING>","a":1}]}}`
+const jHintsSanitized = `{"type":"track","event":"test","__sql_type_type":"String","properties":{"__sql_type_":"JSON","title":"Jitsu"},"context":{"nested":[{"__sql_type_ok":"jsonb","a":1}]}}`
 
 func TestSanitizeSqlTypes(t *testing.T) {
 	var obj *jsonorder.OrderedMap[string, any]
@@ -139,24 +139,36 @@ func TestSanitizeSqlTypes(t *testing.T) {
 func TestIsValidSqlTypeHint(t *testing.T) {
 	valid := []any{
 		"JSON",
-		"VARCHAR(255)",
-		"NUMERIC(10,2)",
-		"TIMESTAMP WITH TIME ZONE",
-		"TIMESTAMP_NTZ",
-		"LowCardinality(String)",
-		"ARRAY<STRING>",
+		"json",
+		"jsonb",
+		"String",
+		"STRING",
+		"text",
+		"varchar",
+		"VARIANT",
+		"OBJECT",
+		"super",
 	}
 	for _, v := range valid {
 		require.True(t, isValidSqlTypeHint(v), "expected valid: %v", v)
 	}
 	invalid := []any{
+		// only bare allowlisted object/string type names pass — no
+		// parameters, no other types, no expressions
+		"VARCHAR(255)",
+		"NUMERIC(10,2)",
+		"TIMESTAMP WITH TIME ZONE",
+		"LowCardinality(String)",
+		"ARRAY<STRING>",
 		"TEXT); DROP TABLE users;--",
 		"Enum8('a'=1)",
 		`STRING"`,
 		"TEXT /* comment */",
 		"TEXT; SELECT 1",
+		"TEXT, evil_col TEXT",
+		"TEXT DEFAULT currentUser()",
 		" JSON",
-		"1NT",
+		"JSON ",
 		"",
 		strings.Repeat("A", 129),
 		42,
@@ -164,8 +176,8 @@ func TestIsValidSqlTypeHint(t *testing.T) {
 		nil,
 		// the [castType, ddlType] array form is not allowed through ingest
 		[]any{},
-		[]any{"DateTime64(3)"},
-		[]any{"DateTime64(3)", "Nullable(DateTime64(3))"},
+		[]any{"JSON"},
+		[]any{"JSON", "jsonb"},
 		[]any{"JSON", "JSON", "JSON"},
 		[]any{42},
 		[]any{"JSON", 42},
@@ -173,6 +185,4 @@ func TestIsValidSqlTypeHint(t *testing.T) {
 	for _, v := range invalid {
 		require.False(t, isValidSqlTypeHint(v), "expected invalid: %v", v)
 	}
-	// boundary: exactly 128 chars is allowed
-	require.True(t, isValidSqlTypeHint(strings.Repeat("A", 128)))
 }

--- a/bulker/jitsubase/types/json_test.go
+++ b/bulker/jitsubase/types/json_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jitsucom/bulker/jitsubase/jsonorder"
@@ -97,4 +98,79 @@ func TestEventFilter(t *testing.T) {
 	t.Logf("JSON: %s", ja)
 	require.Equal(t, expectedJson, string(ja))
 	require.JSONEq(t, j, string(ja))
+}
+
+const jHints = `{
+  "type": "track",
+  "event": "test",
+  "__sql_type_type": "VARCHAR(255)",
+  "__sql_type_bad": "TEXT); DROP TABLE users;--",
+  "properties": {
+    "__sql_type_": "JSON",
+    "__sql_type_ts": "TIMESTAMP WITH TIME ZONE",
+    "__sql_type_arr": ["DateTime64(3)", "Nullable(DateTime64(3))"],
+    "__sql_type_quoted": "Enum8('a'=1)",
+    "__sql_type_num": 42,
+    "__sql_type_long_arr": ["a", "b", "c"],
+    "title": "Jitsu"
+  },
+  "context": {
+    "nested": [{
+      "__sql_type_ok": "ARRAY<STRING>",
+      "__sql_type_comment": "TEXT /* x */",
+      "a": 1
+    }]
+  }
+}`
+
+const jHintsSanitized = `{"type":"track","event":"test","__sql_type_type":"VARCHAR(255)","properties":{"__sql_type_":"JSON","__sql_type_ts":"TIMESTAMP WITH TIME ZONE","__sql_type_arr":["DateTime64(3)","Nullable(DateTime64(3))"],"title":"Jitsu"},"context":{"nested":[{"__sql_type_ok":"ARRAY<STRING>","a":1}]}}`
+
+func TestSanitizeSqlTypes(t *testing.T) {
+	var obj *jsonorder.OrderedMap[string, any]
+	require.NoError(t, jsonorder.Unmarshal([]byte(jHints), &obj))
+	SanitizeSqlTypes(obj)
+	ja, err := jsonorder.Marshal(obj)
+	require.NoError(t, err)
+	t.Logf("JSON: %s", ja)
+	require.Equal(t, jHintsSanitized, string(ja))
+}
+
+func TestIsValidSqlTypeHint(t *testing.T) {
+	valid := []any{
+		"JSON",
+		"VARCHAR(255)",
+		"NUMERIC(10,2)",
+		"TIMESTAMP WITH TIME ZONE",
+		"TIMESTAMP_NTZ",
+		"LowCardinality(String)",
+		"ARRAY<STRING>",
+		[]any{"DateTime64(3)"},
+		[]any{"DateTime64(3)", "Nullable(DateTime64(3))"},
+	}
+	for _, v := range valid {
+		require.True(t, isValidSqlTypeHint(v), "expected valid: %v", v)
+	}
+	invalid := []any{
+		"TEXT); DROP TABLE users;--",
+		"Enum8('a'=1)",
+		`STRING"`,
+		"TEXT /* comment */",
+		"TEXT; SELECT 1",
+		" JSON",
+		"1NT",
+		"",
+		strings.Repeat("A", 129),
+		42,
+		true,
+		nil,
+		[]any{},
+		[]any{"JSON", "JSON", "JSON"},
+		[]any{42},
+		[]any{"JSON", 42},
+	}
+	for _, v := range invalid {
+		require.False(t, isValidSqlTypeHint(v), "expected invalid: %v", v)
+	}
+	// boundary: exactly 128 chars is allowed
+	require.True(t, isValidSqlTypeHint(strings.Repeat("A", 128)))
 }

--- a/bulker/jitsubase/types/json_test.go
+++ b/bulker/jitsubase/types/json_test.go
@@ -109,6 +109,7 @@ const jHints = `{
     "__sql_type_": "JSON",
     "__sql_type_ts": "TIMESTAMP WITH TIME ZONE",
     "__sql_type_arr": ["DateTime64(3)", "Nullable(DateTime64(3))"],
+    "__sql_type_arr1": ["DateTime64(3)"],
     "__sql_type_quoted": "Enum8('a'=1)",
     "__sql_type_num": 42,
     "__sql_type_long_arr": ["a", "b", "c"],
@@ -123,7 +124,7 @@ const jHints = `{
   }
 }`
 
-const jHintsSanitized = `{"type":"track","event":"test","__sql_type_type":"VARCHAR(255)","properties":{"__sql_type_":"JSON","__sql_type_ts":"TIMESTAMP WITH TIME ZONE","__sql_type_arr":["DateTime64(3)","Nullable(DateTime64(3))"],"title":"Jitsu"},"context":{"nested":[{"__sql_type_ok":"ARRAY<STRING>","a":1}]}}`
+const jHintsSanitized = `{"type":"track","event":"test","__sql_type_type":"VARCHAR(255)","properties":{"__sql_type_":"JSON","__sql_type_ts":"TIMESTAMP WITH TIME ZONE","title":"Jitsu"},"context":{"nested":[{"__sql_type_ok":"ARRAY<STRING>","a":1}]}}`
 
 func TestSanitizeSqlTypes(t *testing.T) {
 	var obj *jsonorder.OrderedMap[string, any]
@@ -144,8 +145,6 @@ func TestIsValidSqlTypeHint(t *testing.T) {
 		"TIMESTAMP_NTZ",
 		"LowCardinality(String)",
 		"ARRAY<STRING>",
-		[]any{"DateTime64(3)"},
-		[]any{"DateTime64(3)", "Nullable(DateTime64(3))"},
 	}
 	for _, v := range valid {
 		require.True(t, isValidSqlTypeHint(v), "expected valid: %v", v)
@@ -163,7 +162,10 @@ func TestIsValidSqlTypeHint(t *testing.T) {
 		42,
 		true,
 		nil,
+		// the [castType, ddlType] array form is not allowed through ingest
 		[]any{},
+		[]any{"DateTime64(3)"},
+		[]any{"DateTime64(3)", "Nullable(DateTime64(3))"},
 		[]any{"JSON", "JSON", "JSON"},
 		[]any{42},
 		[]any{"JSON", 42},


### PR DESCRIPTION
## Summary

Implements the s2s action item of `JITSU-27` (browser sanitization was already done; the Bulker-side defense-in-depth items moved to `JITSU-179`).

The s2s ingest path passed `__sql_type*` type hints through verbatim, and hint values end up interpolated into SQL DDL by bulker. The feature stays available to authenticated s2s callers — prod `events_log` shows one active customer relying on `\"__sql_type_\": \"JSON\"` — but hints are now restricted at ingest to their supported use case, mapping a (nested) object to a JSON- or string-typed column:

- A hint survives only if its value is a **single string from a case-insensitive allowlist of bare object/string type names**: `json`, `jsonb`, `string`, `text`, `varchar`, `variant`, `object`, `super`. Original casing is passed through (ClickHouse types are case-sensitive, e.g. `String`).
- No parameters, commas, or expressions — there is no grammar left to abuse in generated DDL.
- The `[castType, ddlType]` array form accepted by bulkerlib's `extractSQLTypesHints` is not allowed through ingest.
- Malformed hints are dropped silently; **the event itself always lands** — a bad hint never stalls a pipeline. This also removes a pre-existing s2s crash vector (`[]` hint → `val[0]` index-out-of-range panic in `processor.go`).
- Browser paths are unchanged (`FilterEvent` still drops all hints); `filterEvent` is refactored to a shared predicate walk with identical browser semantics.
- Wired into both s2s patch sites: `patchEvent` (modern/batch/pixel/funcs handlers — now a catch-all `else` so it fails closed) and the classic handler.
- Richer hints (parameterized types, arrays) can still be produced by transformation functions downstream; `JITSU-179` tracks bulker-side filtering/whitelisting as defense in depth for those paths.

## Tests

New unit tests in `jitsubase/types`: sanitizer walk (real customer shape + injection payloads) and validator table (allowlist across casings; rejects for parameterized types, quotes/semicolons/comments, comma injection, arrays, non-strings). `go test ./ingest/... ./jitsubase/types/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)