### PR TITLE
ci: bump ai-review workflow to 1.30.20260821 (codex-action pin)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -20,7 +20,7 @@ jobs:
     # are reviewed too: the reusable workflow passes allow-bots: true to codex-action,
     # so its write-access check no longer aborts on the bot actor. Draft PRs are
     # skipped inside the reusable workflow.
-    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.29.20260622
+    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.30.20260821
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       AI_CODE_REVIEW_APP_ID: ${{ secrets.AI_CODE_REVIEW_APP_ID }}


### PR DESCRIPTION
Bumps the shared AI Review workflow to `1.30.20260821`, which pins `openai/codex-action` to the v1.11 commit and the Codex CLI to `0.149.0`.

**Why:** the floating `v1` tag moved to v1.12 on 2026-08-20 23:38Z. On Linux, v1.12 never returns after a heavy turn — Codex writes its result, then the step idles until the job timeout kills it, with no logs uploaded ([openai/codex-action#150](https://github.com/openai/codex-action/issues/150)). Every AI Review run across jitsucom repos on 2026-08-21 died this way.

Fix: jitsucom/github-workflows@e3144b9. The AI Review run on this PR is itself the verification — it should complete in a few minutes instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)