### PR TITLE
JITSU-182: canonical row hashing — breaker survives serializer key reorder

### DIFF
--- a/bulker/config-keeper/breaker.go
+++ b/bulker/config-keeper/breaker.go
@@ -316,6 +316,10 @@ func writeCanonical(h hash.Hash64, v any) {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
+			// separator makes the encoding uniquely decodable: without it the
+			// object-close '}' can collide with the first byte of a key's
+			// length prefix (reviewer-constructed collision, pathological keys)
+			_, _ = h.Write([]byte{','})
 			writeCanonicalString(h, k)
 			_, _ = h.Write([]byte{':'})
 			writeCanonical(h, t[k])
@@ -349,7 +353,7 @@ func writeCanonicalString(h hash.Hash64, s string) {
 	var lenBuf [8]byte
 	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(s)))
 	_, _ = h.Write(lenBuf[:])
-	_, _ = h.Write([]byte(s))
+	_, _ = io.WriteString(h, s)
 }
 
 // diffRows counts rows present in both generations (common) and how many of

--- a/bulker/config-keeper/breaker.go
+++ b/bulker/config-keeper/breaker.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"hash/fnv"
 	"io"
 	"os"
 	"path"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -265,12 +269,13 @@ func (b *BreakerRepositoryData) Status() map[string]any {
 // purposes (they can neither trip nor suppress it); duplicate ids collapse to
 // the last occurrence.
 //
-// Hashing raw row bytes (not canonicalized JSON) is a deliberate trade-off: a
-// console deploy that changes row serialization (key order, materialized
-// defaults) without semantic changes reads as a mass change and trips the
-// breaker. That is the operator-confirmation case — such deploys are rare,
-// fleet-wide, and exactly when a human should be watching; canonicalizing
-// every row on every refresh isn't worth dodging that one confirmation
+// Rows are hashed CANONICALLY (object keys sorted, structure-tagged), not by
+// raw bytes: a console deploy that merely changes row serialization (key
+// order) must not read as a fleet-wide mass change. That exact false positive
+// tripped the breaker on every guarded repo the day it shipped (jitsu#1478's
+// zod parse reordering keys, 2026-08-24). Numbers hash by their literal (via
+// json.Number), so value precision is preserved; the producer is always the
+// console's JSON.stringify, so literal formatting is stable across refreshes.
 func hashRows(payload []byte) (hashes map[string]uint64, noId int, err error) {
 	var rows []json.RawMessage
 	if err = json.Unmarshal(payload, &rows); err != nil {
@@ -278,18 +283,73 @@ func hashRows(payload []byte) (hashes map[string]uint64, noId int, err error) {
 	}
 	hashes = make(map[string]uint64, len(rows))
 	for _, row := range rows {
-		var idHolder struct {
-			Id string `json:"id"`
+		dec := json.NewDecoder(bytes.NewReader(row))
+		dec.UseNumber()
+		var obj map[string]any
+		if err := dec.Decode(&obj); err != nil {
+			noId++
+			continue
 		}
-		if err := json.Unmarshal(row, &idHolder); err != nil || idHolder.Id == "" {
+		id, _ := obj["id"].(string)
+		if id == "" {
 			noId++
 			continue
 		}
 		h := fnv.New64a()
-		_, _ = h.Write(row)
-		hashes[idHolder.Id] = h.Sum64()
+		writeCanonical(h, obj)
+		hashes[id] = h.Sum64()
 	}
 	return hashes, noId, nil
+}
+
+// writeCanonical feeds a decoded JSON value into the hasher in a
+// deterministic, structure-tagged form: object keys sorted, strings
+// length-prefixed (so {"a":"bc"} and {"ab":"c"} cannot collide), values
+// tagged by type.
+func writeCanonical(h hash.Hash64, v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		_, _ = h.Write([]byte{'{'})
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			writeCanonicalString(h, k)
+			_, _ = h.Write([]byte{':'})
+			writeCanonical(h, t[k])
+		}
+		_, _ = h.Write([]byte{'}'})
+	case []any:
+		_, _ = h.Write([]byte{'['})
+		for _, e := range t {
+			writeCanonical(h, e)
+			_, _ = h.Write([]byte{','})
+		}
+		_, _ = h.Write([]byte{']'})
+	case string:
+		_, _ = h.Write([]byte{'s'})
+		writeCanonicalString(h, t)
+	case json.Number:
+		_, _ = h.Write([]byte{'#'})
+		writeCanonicalString(h, t.String())
+	case bool:
+		if t {
+			_, _ = h.Write([]byte{'T'})
+		} else {
+			_, _ = h.Write([]byte{'F'})
+		}
+	default: // nil
+		_, _ = h.Write([]byte{'N'})
+	}
+}
+
+func writeCanonicalString(h hash.Hash64, s string) {
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(s)))
+	_, _ = h.Write(lenBuf[:])
+	_, _ = h.Write([]byte(s))
 }
 
 // diffRows counts rows present in both generations (common) and how many of

--- a/bulker/config-keeper/breaker_test.go
+++ b/bulker/config-keeper/breaker_test.go
@@ -336,3 +336,42 @@ func TestBreakerRejectionsFireSystemError(t *testing.T) {
 	require.Contains(t, errs[0], "tripped")
 	require.Contains(t, errs[0], "/breaker/")
 }
+
+// A serializer change that only reorders JSON keys (jitsu#1478's zod parse,
+// 2026-08-24: __debug moved last in every row → 100% "changed" → fleet-wide
+// trip) must be invisible to the breaker.
+func TestBreakerSurvivesKeyReorder(t *testing.T) {
+	b := testBreaker()
+	var v1, v2 []string
+	for i := 0; i < 100; i++ {
+		// same content, different key order at both root and nested levels
+		v1 = append(v1, fmt.Sprintf(`{"__debug":{"x":1,"y":"z"},"id":"conn%03d","options":{"mode":"batch","deduplicate":true},"n":42}`, i))
+		v2 = append(v2, fmt.Sprintf(`{"id":"conn%03d","options":{"deduplicate":true,"mode":"batch"},"n":42,"__debug":{"y":"z","x":1}}`, i))
+	}
+	require.NoError(t, breakerInit(b, "["+strings.Join(v1, ",")+"]"))
+	require.NoError(t, breakerInitNetwork(b, "["+strings.Join(v2, ",")+"]"))
+	require.False(t, b.Held())
+	// and a real value change under the reordered layout still counts
+	changed := strings.ReplaceAll("["+strings.Join(v2, ",")+"]", `"mode":"batch"`, `"mode":"stream"`)
+	err := b.Init(strings.NewReader(changed), time.Now())
+	require.Error(t, err)
+	require.True(t, b.Held())
+}
+
+// Canonical hashing must still distinguish genuinely different values that
+// raw-byte hashing would also catch: strings vs numbers, ambiguous string
+// boundaries, number literals.
+func TestCanonicalHashDistinguishesValues(t *testing.T) {
+	h := func(s string) uint64 {
+		hashes, _, err := hashRows([]byte(fmt.Sprintf(`[{"id":"a","v":%s}]`, s)))
+		require.NoError(t, err)
+		return hashes["a"]
+	}
+	require.NotEqual(t, h(`"1"`), h(`1`))
+	require.NotEqual(t, h(`{"a":"bc"}`), h(`{"ab":"c"}`))
+	require.NotEqual(t, h(`[1,2]`), h(`[12]`))
+	require.NotEqual(t, h(`true`), h(`"true"`))
+	require.NotEqual(t, h(`null`), h(`0`))
+	require.NotEqual(t, h(`9007199254740993`), h(`9007199254740992`)) // beyond float64 integer precision
+	require.Equal(t, h(`{"a":1,"b":2}`), h(`{"b":2,"a":1}`))
+}

--- a/bulker/config-keeper/breaker_test.go
+++ b/bulker/config-keeper/breaker_test.go
@@ -356,6 +356,11 @@ func TestBreakerSurvivesKeyReorder(t *testing.T) {
 	err := b.Init(strings.NewReader(changed), time.Now())
 	require.Error(t, err)
 	require.True(t, b.Held())
+	// a reordered rendering of the known-good payload clears the held state:
+	// lastRejected short-circuits on bytes, so this exercises the full
+	// canonical re-hash path
+	require.NoError(t, breakerInitNetwork(b, "["+strings.Join(v1, ",")+"]"))
+	require.False(t, b.Held())
 }
 
 // Canonical hashing must still distinguish genuinely different values that
@@ -374,4 +379,10 @@ func TestCanonicalHashDistinguishesValues(t *testing.T) {
 	require.NotEqual(t, h(`null`), h(`0`))
 	require.NotEqual(t, h(`9007199254740993`), h(`9007199254740992`)) // beyond float64 integer precision
 	require.Equal(t, h(`{"a":1,"b":2}`), h(`{"b":2,"a":1}`))
+	// escape style is normalized by the decoder — a serializer switching
+	// escaping must not read as a change
+	require.Equal(t, h(`"\u0041"`), h(`"A"`))
+	// number literals are compared verbatim (single stable producer; the
+	// failure mode of a literal-format switch is a trip, not a miss)
+	require.NotEqual(t, h(`1`), h(`1.0`))
 }


### PR DESCRIPTION
Follow-up to the config-keeper circuit breaker (#1476), from today's prod field experience. Linear: `JITSU-182`.

## Why
Within hours of the breaker going live, #1478's deploy reordered JSON keys in every export row (zod `parse` emits schema keys first). Content was byte-for-byte identical after key normalization — but the breaker hashes raw row bytes, so it read 100% mass change and tripped fleet-wide on both replicas (correctly per its design, but the "serializer changes are rare" trade-off documented in the code did not survive day one). The breaker is currently disabled in prod pending this fix — all repos must survive field reorders.

## What
- `hashRows` now hashes each row **canonically**: object keys sorted, ',' separator + length-prefixed keys (uniquely decodable — an encoding-collision construction from review is closed), type-tagged values, numbers by literal via `json.Number` (no float64 precision loss), decoder-normalized string escapes.
- Key-order changes at any nesting depth are invisible to the breaker; real value changes still trip. Number-literal formatting changes (`1` vs `1.0`) still trip by design — single stable producer, and that failure mode is a confirmation, not a miss.
- **No baseline migration needed**: seeding re-hashes the cached payload with the new function, so deploying this cannot itself trip — even onto a payload that byte-changed since the cache was written.
- The whole-payload `lastRejected` short-circuit deliberately stays byte-based (it only suppresses re-parsing of a byte-identical rejected generation).

Tests: reorder-immunity end-to-end (incl. clearing a held state with a reordered good payload), collision-resistance of the encoding (string/number/boundary/precision cases), escape normalization, literal sensitivity. 25 config-keeper tests green.

After deploy, re-enable with `CFGKPR_BREAKER_ENABLED=true` in jitsu-cloud-infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)