### PR TITLE
ci(security-fix): pin codex-action and CLI to the ai-review versions

### DIFF
--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -447,18 +447,23 @@ jobs:
         # (@openai/codex-linux-x64) sometimes gets skipped, producing:
         #   "Missing optional dependency @openai/codex-linux-x64"
         # Force a clean reinstall with --include=optional before the action.
+        # Pinned to the same CLI release as `codex-version` below (and as
+        # ai-review.yml in jitsucom/github-workflows) so the workaround can't
+        # pull a newer CLI than the action itself installs.
         run: |
           set -euo pipefail
           npm uninstall -g @openai/codex >/dev/null 2>&1 || true
-          npm install -g --include=optional @openai/codex@latest
+          npm install -g --include=optional @openai/codex@0.149.0
           codex --version
 
       - name: 🔒 Fix vulnerabilities with Codex
         id: run-codex
-        # openai is a major vendor with a controlled release process; @v1 is a
-        # sufficient pin. SHA-pinning every OpenAI action update would be more
-        # overhead than the risk warrants.
-        uses: openai/codex-action@v1
+        # Pinned to the v1.11 commit, not the floating v1 tag — same pin as
+        # ai-review.yml in jitsucom/github-workflows: v1.12 (2026-08-20)
+        # rewrote the Linux launch path and the step never returns after a
+        # heavy turn (openai/codex-action#150). Bump both places together
+        # once upstream ships a fix.
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -472,6 +477,10 @@ jobs:
           output-file: .github/codex/security-fix.output.md
           model: gpt-5.3-codex
           effort: high
+          # Same CLI release as ai-review.yml in jitsucom/github-workflows —
+          # verified clean with v1.11; keeps a CLI release from changing
+          # behaviour under us.
+          codex-version: 0.149.0
           # danger-full-access: no approval gating — required because the agent
           # needs to run `pnpm install`, `go get`, `git commit`, `gh pr create`
           # without waiting for a human to approve each one.


### PR DESCRIPTION
## Summary

Aligns `.github/workflows/security-fix.yml` with the codex pins in [`jitsucom/github-workflows` `ai-review.yml`](https://github.com/jitsucom/github-workflows/blob/main/.github/workflows/ai-review.yml) (pinned there in jitsucom/github-workflows@e3144b9d8):

| | before | after |
|---|---|---|
| `uses:` | `openai/codex-action@v1` (floating) | `openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11` |
| `codex-version:` | unset → npm `latest` | `0.149.0` |
| "Reinstall Codex CLI" workaround | `@openai/codex@latest` | `@openai/codex@0.149.0` |
| `model` / `effort` | `gpt-5.3-codex` / `high` | unchanged (already matched) |

Why the third row: codex-action v1.11 runs `npm install -g @openai/codex@${codex-version}` itself, so the pre-existing workaround step (kept for its `--include=optional` platform-dep fix) would otherwise keep pulling `@latest` right before the action and defeat the pin.

Rationale for the SHA pin (same as upstream): codex-action v1.12 (2026-08-20) rewrote the Linux launch path and the step never returns after a heavy turn — openai/codex-action#150. Bump both files together once upstream ships a fix.

## Test plan

- [x] YAML parses
- [x] SHA `52fe01ec…` is exactly what tag `v1.11` points to; `codex-version` is a real input at that commit; `@openai/codex@0.149.0` and `@openai/codex-responses-api-proxy@0.149.0` exist on npm
- [ ] Next Monday's scheduled run (or a `workflow_dispatch` with `dry_run: true`) completes the "Fix vulnerabilities with Codex" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)