### PR TITLE
ci: switch security-fix to gpt-5.6-terra; pin ai-review to 1.32.20260826

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -20,7 +20,7 @@ jobs:
     # are reviewed too: the reusable workflow passes allow-bots: true to codex-action,
     # so its write-access check no longer aborts on the bot actor. Draft PRs are
     # skipped inside the reusable workflow.
-    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.30.20260821
+    uses: jitsucom/github-workflows/.github/workflows/ai-review.yml@1.32.20260826
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       AI_CODE_REVIEW_APP_ID: ${{ secrets.AI_CODE_REVIEW_APP_ID }}

--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -475,7 +475,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .github/codex/security-fix.prompt.md
           output-file: .github/codex/security-fix.output.md
-          model: gpt-5.3-codex
+          model: gpt-5.6-terra
           effort: high
           # Same CLI release as ai-review.yml in jitsucom/github-workflows —
           # verified clean with v1.11; keeps a CLI release from changing


### PR DESCRIPTION
## Summary

Follow-up to #1482 (merged before this could be folded in).

- `security-fix.yml`: `gpt-5.3-codex` → `gpt-5.6-terra` (`effort: high` unchanged), matching the ai-review model switch released as github-workflows `1.32.20260826` (jitsucom/github-workflows#10). Terra is in the pinned codex CLI 0.149.0 preset list; 5.3-codex no longer is.
- `ai-review.yml`: bump the pinned `jitsucom/github-workflows` release from `1.30.20260821` to `1.32.20260826`. (An earlier revision of this PR used a floating `current` tag; that approach is rolled back in jitsucom/github-workflows#11 and the tag is removed.)

## Test plan

- [x] YAML parses; diff reviewed
- [ ] The AI Review check on this PR runs on Terra (job summary shows `Model: gpt-5.6-terra`)
- [ ] Next `security-fix` run (Monday 08:00 UTC, or `workflow_dispatch` with `dry_run: true`) completes the Codex step on Terra

🤖 Generated with [Claude Code](https://claude.com/claude-code)