### PR TITLE
fix(console): 404 instead of 500 for unknown types on the public schema endpoint

### DIFF
--- a/webapps/console/__tests__/unit/json-schema-404.test.ts
+++ b/webapps/console/__tests__/unit/json-schema-404.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from "vitest";
+
+// config-objects.ts transitively imports the custom-domains server machinery
+// (and through it half the app, incl. packages vite can't resolve in the unit
+// project). None of it participates in schema generation — stub the boundary.
+vi.mock("../../lib/server/custom-domains", () => ({
+  checkDomain: vi.fn(),
+  checkOrAddToIngress: vi.fn(),
+  isDomainAvailable: vi.fn(),
+}));
+vi.mock("../../pages/api/[workspaceId]/domain-check", () => ({
+  getWildcardDomains: vi.fn(() => []),
+}));
+import { getResourceJsonSchema } from "../../lib/schema/json-schema";
+import { ApiError } from "../../lib/shared/errors";
+
+// The public, unauthenticated /api/schema/[...type] route (and the MCP
+// get_resource_schema tool) feed arbitrary input here. Unknown types used to
+// escape as bare assertion errors -> HTTP 500; they must be a clean 404
+// (crawlers resolving JSON-escaped hrefs against the route hit this daily).
+describe("getResourceJsonSchema unknown types", () => {
+  function expect404(fn: () => unknown) {
+    let err: unknown;
+    try {
+      fn();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+  }
+
+  test("known types still resolve", () => {
+    expect(getResourceJsonSchema("destination", "postgres")).toHaveProperty("$schema");
+    expect(getResourceJsonSchema("destination")).toHaveProperty("$schema");
+    expect(getResourceJsonSchema("link", "sync")).toHaveProperty("$schema");
+    expect(getResourceJsonSchema("link", "clickhouse")).toHaveProperty("$schema");
+  });
+
+  test("unknown destination subtype is 404", () => {
+    // the literal shape crawlers produce from JSON-escaped hrefs
+    expect404(() => getResourceJsonSchema("destination", '\\"https:/help.mixpanel.com/hc\\"'));
+  });
+
+  test("unknown top-level resource type is 404", () => {
+    expect404(() => getResourceJsonSchema("no-such-type"));
+  });
+
+  test("unknown link subtype is 404", () => {
+    expect404(() => getResourceJsonSchema("link", "no-such-destination"));
+  });
+});

--- a/webapps/console/__tests__/unit/json-schema-404.test.ts
+++ b/webapps/console/__tests__/unit/json-schema-404.test.ts
@@ -49,4 +49,14 @@ describe("getResourceJsonSchema unknown types", () => {
   test("unknown link subtype is 404", () => {
     expect404(() => getResourceJsonSchema("link", "no-such-destination"));
   });
+
+  test("prototype-inherited names are 404, not a lookup hit", () => {
+    // plain-object registries inherit Object.prototype; a truthiness check
+    // would resolve these to functions and crash downstream with a 500
+    for (const name of ["toString", "constructor", "hasOwnProperty", "__proto__"]) {
+      expect404(() => getResourceJsonSchema(name));
+      expect404(() => getResourceJsonSchema("destination", name));
+      expect404(() => getResourceJsonSchema("link", name));
+    }
+  });
 });

--- a/webapps/console/lib/schema/config-objects.ts
+++ b/webapps/console/lib/schema/config-objects.ts
@@ -119,6 +119,8 @@ export const getAllConfigObjectTypeNames = (): string[] => {
   return Object.keys(configObjectTypes);
 };
 
+export const getConfigObjectTypeNonStrict = (type: string): ConfigObjectType | undefined => configObjectTypes[type];
+
 export const getConfigObjectType: (type: string) => Required<ConfigObjectType> = type => {
   const configType = configObjectTypes[type];
   assertDefined(configType, `Unknown config object type ${type}`);

--- a/webapps/console/lib/schema/config-objects.ts
+++ b/webapps/console/lib/schema/config-objects.ts
@@ -119,7 +119,10 @@ export const getAllConfigObjectTypeNames = (): string[] => {
   return Object.keys(configObjectTypes);
 };
 
-export const getConfigObjectTypeNonStrict = (type: string): ConfigObjectType | undefined => configObjectTypes[type];
+// Own-key lookup: a plain-object registry inherits Object.prototype, so a bare
+// index would resolve e.g. "toString" to a function and defeat the 404 guards.
+export const getConfigObjectTypeNonStrict = (type: string): ConfigObjectType | undefined =>
+  Object.prototype.hasOwnProperty.call(configObjectTypes, type) ? configObjectTypes[type] : undefined;
 
 export const getConfigObjectType: (type: string) => Required<ConfigObjectType> = type => {
   const configType = configObjectTypes[type];

--- a/webapps/console/lib/schema/destinations.tsx
+++ b/webapps/console/lib/schema/destinations.tsx
@@ -278,7 +278,11 @@ export function getCoreDestinationType(typeId: string): DestinationType {
 }
 
 export function getCoreDestinationTypeNonStrict(typeId: string | undefined): DestinationType | undefined {
-  return typeId ? coreDestinationsMap[typeId] : undefined;
+  // Own-key lookup — see getConfigObjectTypeNonStrict: prototype-inherited names
+  // like "toString" must not resolve to a destination type.
+  return typeId && Object.prototype.hasOwnProperty.call(coreDestinationsMap, typeId)
+    ? coreDestinationsMap[typeId]
+    : undefined;
 }
 
 export const ClickhouseCredentials = z.object({

--- a/webapps/console/lib/schema/json-schema.ts
+++ b/webapps/console/lib/schema/json-schema.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import zodToJsonSchema from "zod-to-json-schema";
-import { getConfigObjectType } from "./config-objects";
-import { getCoreDestinationType } from "./destinations";
+import { getConfigObjectType, getConfigObjectTypeNonStrict } from "./config-objects";
+import { getCoreDestinationTypeNonStrict } from "./destinations";
+import { ApiError } from "../shared/errors";
 import { BaseLinkType, SyncOptionsType } from "./index";
 
 /**
@@ -26,10 +27,23 @@ export function getResourceJsonSchema(type: string, subType?: string): any {
         // (upsertLink defaults a missing `type` to "push").
         return zodToJsonSchema(BaseLinkType.merge(z.object({ type: z.literal("sync"), data: SyncOptionsType })));
       }
-      const opts = getCoreDestinationType(subType).connectionOptions;
-      return zodToJsonSchema(BaseLinkType.merge(z.object({ type: z.literal("push"), data: opts })));
+      const destinationType = getCoreDestinationTypeNonStrict(subType);
+      if (!destinationType) {
+        // The public /api/schema route feeds arbitrary crawler input here — an
+        // unknown destination type is the caller's mistake, not a server error.
+        throw new ApiError(`Unknown destination type '${subType}'`, { status: 404 });
+      }
+      return zodToJsonSchema(
+        BaseLinkType.merge(z.object({ type: z.literal("push"), data: destinationType.connectionOptions }))
+      );
     }
     return zodToJsonSchema(BaseLinkType.merge(z.object({ data: z.any() })));
+  }
+  if (!getConfigObjectTypeNonStrict(type)) {
+    throw new ApiError(`Unknown resource type '${type}'`, { status: 404 });
+  }
+  if (subType && type === "destination" && !getCoreDestinationTypeNonStrict(subType)) {
+    throw new ApiError(`Unknown destination type '${subType}'`, { status: 404 });
   }
   const objectType = getConfigObjectType(type);
   const zodType = subType


### PR DESCRIPTION
`/api/schema/[...type]` is public (`auth: false`) and crawlers feed it garbage daily — most notably JSON-escaped hrefs scraped out of the schema output itself and resolved as relative URLs (`/api/schema/destination/%5C%22https:/help.mixpanel.com/...%5C%22` — three crawler IPs hit exactly that within 8 seconds on 2026-08-26). Unknown resource/destination types escaped `getResourceJsonSchema` as bare assertion errors → **HTTP 500** (and leaked a stack trace to the unauthenticated route).

## Changes

- `getResourceJsonSchema` now throws `ApiError(..., { status: 404 })` for: an unknown top-level resource type, an unknown destination subtype (guard scoped to `type === "destination"` — the only config type whose `narrowSchema` reads `destinationType`), and an unknown `link`/`connection` destination subtype. Known types are untouched (return paths unchanged).
- `getConfigObjectTypeNonStrict` added next to the strict lookup, mirroring the existing `getCoreDestinationTypeNonStrict`.
- Unit test covering the four cases, including the literal crawler-shaped input; the heavy transitive server imports (`custom-domains`, `domain-check`) are `vi.mock`ed — they play no part in schema generation.

Side effects: bad input no longer returns `stack`/`stackArray` in the response body; the MCP `get_resource_schema` tool (same shared function) surfaces the same clean 404.

Ops motivation: infra's new distinct-client-IP 5xx monitor (jitsu-cloud-infra#95, JITSU-203) would page on crawler fleets sharing these URLs — with this fix the endpoint leaves the 5xx signal entirely.

Tests: 86/86 unit project green; `tsc` clean on the touched files (the `libs/jitsu-js` `jsondiffpatch` typecheck failure is pre-existing at `origin/newjitsu`, unbuilt workspace package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
