### PR TITLE
JITSU-191: bulker live repository-size gauge

### DIFF
--- a/bulker/bulkerapp/app/repository.go
+++ b/bulker/bulkerapp/app/repository.go
@@ -89,6 +89,9 @@ func (r *Repository) init() error {
 	metrics.RepositoryDestinations("added").Add(float64(len(repositoryChange.AddedDestinations)))
 	metrics.RepositoryDestinations("changed").Add(float64(len(repositoryChange.ChangedDestinations)))
 	metrics.RepositoryDestinations("removed").Add(float64(len(repositoryChange.RemovedDestinationIds)))
+	// live repository size (JITSU-191): internal.destinations is the full set
+	// just stored — unchanged copies + added + changed, minus removed.
+	metrics.RepositoryDestinationsCurrent.Set(float64(len(internal.destinations)))
 	select {
 	case r.changesChan <- repositoryChange:
 	default:

--- a/bulker/bulkerapp/app/repository_test.go
+++ b/bulker/bulkerapp/app/repository_test.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/jitsucom/bulker/bulkerapp/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// The live repository-size gauge (JITSU-191) must equal the number of
+// destinations the repository loaded, and drop when destinations disappear.
+func TestRepositoryDestinationsCurrentGauge(t *testing.T) {
+	src, err := NewYamlConfigurationSource([]byte("destinations:\n  d1: {}\n  d2: {}\n  d3: {}\n"))
+	require.NoError(t, err)
+	_, err = NewRepository(nil, src)
+	require.NoError(t, err)
+	require.Equal(t, 3.0, testutil.ToFloat64(metrics.RepositoryDestinationsCurrent))
+
+	// a shrunk config re-inits the gauge downward — the config-loss signal
+	shrunk, err := NewYamlConfigurationSource([]byte("destinations:\n  d1: {}\n"))
+	require.NoError(t, err)
+	_, err = NewRepository(nil, shrunk)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.RepositoryDestinationsCurrent))
+}

--- a/bulker/bulkerapp/metrics/metrics.go
+++ b/bulker/bulkerapp/metrics/metrics.go
@@ -166,6 +166,17 @@ var (
 		return repositoryDestinations.WithLabelValues(status)
 	}
 
+	// RepositoryDestinationsCurrent is the live count of destinations the
+	// repository currently holds — a gauge, unlike the add/change/remove event
+	// counter above. A drop signals config loss (JITSU-191 post-rollout
+	// baselines); the counter can't express current size (it only ever goes up).
+	RepositoryDestinationsCurrent = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "bulkerapp",
+		Subsystem: "repository",
+		Name:      "destinations_current",
+		Help:      "Current number of destinations loaded in the repository.",
+	})
+
 	repositoryDestinationInitError = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bulkerapp",
 		Subsystem: "repository",


### PR DESCRIPTION
Deliverable B of JITSU-191 (post-rollout deployment-health baselines).

Adds **`bulkerapp_repository_destinations_current`** — a Prometheus gauge of the number of destinations the bulker repository currently holds, set on every refresh from `len(internal.destinations)` (the full set just stored: unchanged + added + changed, minus removed).

Bulker previously exposed only `bulkerapp_repository_destinations{status}`, an add/change/remove **event counter** — which can't express *current* size (it only ever goes up; the Aug-24 "mass removal" alert had to be a rate detector because of exactly this). This gauge is the droppable live-size signal — the bulker-side analog of `cfgkpr_repository_rows` (jitsu#1481) — so a mass config-row disappearance shows as a gauge drop.

Bulker's `:9091` is already scraped by Prometheus, so no infra wiring is needed — the series appears on next deploy.

Tests: new `TestRepositoryDestinationsCurrentGauge` (gauge reads 3, then 1 after a shrink); build + vet clean. Reviewed — no correctness findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)