### PR TITLE
JITSU-200: exclusive currentPeriod.end in billing UI (console half)

### DIFF
--- a/webapps/console/components/Billing/BillingManager.tsx
+++ b/webapps/console/components/Billing/BillingManager.tsx
@@ -87,8 +87,10 @@ const EventsUsageSection: React.FC<{}> = () => {
         <div>
           {formatNumber(Math.round(usage?.events))} / {formatNumber(usage.maxAllowedDestinatonEvents)} destination
           events used from <i>{dayjs(usage.periodStart).utc().format("MMM DD, YYYY")}</i> to{" "}
-          <i>{dayjs(usage.periodEnd).utc().format("MMM DD, YYYY")}</i>. The quota will be reset on{" "}
-          <i>{dayjs(usage.periodEnd).add(1, "day").utc().format("MMM DD")}</i>.
+          {/* periodEnd is the exclusive end of the period (= the reset instant); the
+              usage window's last included day is one millisecond before it */}
+          <i>{dayjs(usage.periodEnd).subtract(1, "millisecond").utc().format("MMM DD, YYYY")}</i>. The quota will be
+          reset on <i>{dayjs(usage.periodEnd).utc().format("MMM DD")}</i>.
           <br />
           {billing?.settings?.overagePricePer100k && (
             <div className="text-textLight text-xs">
@@ -97,9 +99,11 @@ const EventsUsageSection: React.FC<{}> = () => {
           )}
         </div>
         <Link
-          href={`/${
-            workspace.slugOrId
-          }/settings/billing/details?start=${usage.periodStart.toISOString()}&end=${usage.periodEnd.toISOString()}`}
+          href={`/${workspace.slugOrId}/settings/billing/details?start=${usage.periodStart.toISOString()}&end=${dayjs(
+            usage.periodEnd
+          )
+            .subtract(1, "millisecond")
+            .toISOString()}`}
           className="flex items-center text-primary"
         >
           View detailed stat
@@ -158,7 +162,9 @@ const ConnectorUsageSection: React.FC<{}> = () => {
     periodStart = new Date(billing.settings?.currentPeriod.start);
   } else {
     periodStart = dayjs().utc().startOf("month").toDate();
-    periodEnd = dayjs().utc().endOf("month").add(-1, "millisecond").toDate();
+    // Exclusive end (start of next month), matching the billing API's convention
+    // so this fallback path renders the same way as a real currentPeriod.
+    periodEnd = dayjs().utc().startOf("month").add(1, "month").toDate();
   }
   const { isLoading, error, data } = useQuery(
     ["connector usage", workspace.id],
@@ -190,8 +196,9 @@ const ConnectorUsageSection: React.FC<{}> = () => {
         <div>
           {activeSyncs} / {maxActiveSyncs} monthly active syncs from{" "}
           <i>{dayjs(periodStart).utc().format("MMM DD, YYYY")}</i> to{" "}
-          <i>{dayjs(periodEnd).utc().format("MMM DD, YYYY")}</i>. The quota will be reset on{" "}
-          <i>{dayjs(periodEnd).add(1, "day").utc().format("MMM DD")}</i>.
+          {/* periodEnd is exclusive (= the reset instant); the last included day is 1ms before */}
+          <i>{dayjs(periodEnd).subtract(1, "millisecond").utc().format("MMM DD, YYYY")}</i>. The quota will be reset on{" "}
+          <i>{dayjs(periodEnd).utc().format("MMM DD")}</i>.
           {billing?.settings?.dailyActiveSyncsOverage && (
             <div className="text-textLight text-xs">
               Overage fee: ${billing?.settings?.dailyActiveSyncsOverage} per extra daily active sync

--- a/webapps/console/components/Billing/use-events-usage.ts
+++ b/webapps/console/components/Billing/use-events-usage.ts
@@ -50,7 +50,9 @@ export function useEventsUsage(opts?: { skipSubscribed?: boolean; cacheSeconds?:
     periodStart = new Date(billing.settings?.currentPeriod.start);
   } else {
     periodStart = dayjs().utc().startOf("month").toDate();
-    periodEnd = dayjs().utc().endOf("month").add(-1, "millisecond").toDate();
+    // Exclusive end (start of next month), matching the billing API's convention
+    // so this fallback path agrees with a real currentPeriod.
+    periodEnd = dayjs().utc().startOf("month").add(1, "month").toDate();
   }
 
   const { isLoading, error, data } = useQuery(

--- a/webapps/console/lib/schema/index.ts
+++ b/webapps/console/lib/schema/index.ts
@@ -128,7 +128,15 @@ const BillingSettingsShape = z.object({
    */
   currentPeriod: z
     .object({
+      /**
+       * Exclusive end of the period: the instant the next period begins and the
+       * quota resets, so it renders directly as the reset date and equals
+       * `expiresAt` for a plan renewing on the boundary. The usage window's last
+       * included instant is one millisecond before it (usage queries and the
+       * "…to X" label subtract 1ms).
+       */
       end: z.string(),
+      /** Inclusive start of the period (a UTC instant). */
       start: z.string(),
     })
     .optional(),


### PR DESCRIPTION
Fixes a one-day disagreement on the billing settings page, where "Renews at" and "The quota will be reset on" could differ by a day. This is the console half of the fix; the billing half is jitsucom/jitsu-cloud-billing#42, and this must ship first (see Deploy order).

## What changed

The billing API's `currentPeriod.end` becomes the **exclusive** end of the period: the instant the next period begins and the quota resets, equal to `expiresAt` for a plan renewing on the boundary. It was previously the inclusive last instant (e.g. `Sep 30 23:59:59.999`); it is now the boundary (`Oct 1 00:00:00.000`).

The console adapts (`BillingManager.tsx`, `use-events-usage.ts`, `lib/schema/index.ts`):

- **Reset date renders `currentPeriod.end` directly**, dropping the `+1 day` the old inclusive convention needed. Under the new convention `+1 day` would render the reset a day late.
- **The "used from X to Y" window label and the "View detailed stat" link's `end`** render/pass `end - 1ms` (the last included instant), so the shown range and the detail chart stay a whole ~30-day period instead of spilling into a 31st day. The detail page rounds its `end` with `endOf("day")`, so the raw exclusive boundary would pull an extra day.
- **The no-`currentPeriod` fallbacks are exclusive too** (start of next month), so the fallback path and a real `currentPeriod` render identically.
- The usage query already subtracts 1ms from the end, which is exactly right under an exclusive bound, so it is unchanged. For plain monthly plans it is now slightly more accurate (it no longer counts a sliver of the neighbouring cycles).

## Deploy order

Console first, then billing #42. For plain monthly plans, shipping billing alone changes nothing visible (both the old and new end format to the same day) — this console change is what fixes them. For contract-month and `customBilling` plans, billing-first would make dates that are correct today read a day late; console-first instead leaves those plans reading a day **early** for the short window between the two deploys, which self-heals the moment #42 lands. So: this merges first, then #42 promptly after.

## Testing

`pnpm typecheck` clean; console unit tests pass. Verified by hand against the detail page's `roundDay("end")` that `end - 1ms` keeps the chart on the correct last day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARxaC6w4JJ8Xw4b8Pr6b5Q
