### PR TITLE
JITSU-214 refactor(bulker): centralize batch consumer lifecycle

### DIFF
--- a/bulker/bulkerapp/app/abstract_batch_consumer.go
+++ b/bulker/bulkerapp/app/abstract_batch_consumer.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -24,17 +25,9 @@ const streamOptionsKeyHeader = "stream_options"
 const originalTopicHeader = "original_topic"
 const errorHeader = "error"
 
-const pauseHeartBeatInterval = 120 * time.Second
-
-// assignmentFailuresBeforeRestart - consecutive runs a retry consumer may end
-// without a partition assignment before it is treated as having lost its group
-// membership. More than one, so an ordinary rebalance is not mistaken for a
-// zombie (see ConsumeAll).
-const assignmentFailuresBeforeRestart = 3
-
 type BatchSizesFunction func(*bulker.StreamOptions) (batchSize int, batchSizeBytes int, retryBatchSize int)
-type BatchFunction func(destination *Destination, batchNum, batchSize, batchSizeBytes, retryBatchSize int, highOffset int64, updatedHighOffset int) (counters BatchCounters, state bulker.State, nextBatch bool, err error)
-type ShouldConsumeFunction func(partitionId int32, committedOffset, highOffset int64) bool
+type BatchFunction func(destination *Destination, batchNum, batchSize, batchSizeBytes, retryBatchSize int, highOffset int64, updatedHighOffset int, consumerEpoch uint64) (counters BatchCounters, state bulker.State, nextBatch bool, err error)
+type ShouldConsumeFunction func(partitionId int32, committedOffset, highOffset int64, consumerEpoch uint64) bool
 
 type BatchConsumer interface {
 	Consumer
@@ -54,13 +47,14 @@ type AbstractBatchConsumer struct {
 	batchPeriodSec  int
 	kafkaConfig     *kafka.ConfigMap
 	consumerConfig  kafka.ConfigMap
-	consumer        atomic.Pointer[kafka.Consumer]
+	consumer        *consumerRuntime
 	producerConfig  kafka.ConfigMap
 	mode            string
 	tableName       string
 	waitForMessages time.Duration
 
-	closed chan struct{}
+	closed    chan struct{}
+	closeOnce sync.Once
 
 	running           atomic.Bool
 	extraRunScheduled atomic.Bool
@@ -68,43 +62,7 @@ type AbstractBatchConsumer struct {
 	//AbstractBatchConsumer marked as no longer needed. We cannot close it immediately because it can be in the middle of processing batch
 	retired atomic.Bool
 	//idle AbstractBatchConsumer that is not running any batch jobs. retired idle consumer automatically closes itself
-	idle atomic.Bool
-	//consumer can be paused between batches(idle) and also can be paused during loading batch to destination(not idle)
-	paused        atomic.Bool
-	resumeChannel chan struct{}
-	//stopChannel signals the pause heartbeat loop to exit for suspend (vs.
-	//resume). It is unbuffered on purpose: _unpause() must block until the
-	//heartbeat has actually left its loop, so pauseOrSuspend can close the
-	//consumer without racing an in-flight ReadMessage (see _unpause).
-	stopChannel chan struct{}
-	//restarting guards against piling up overlapping restartConsumer calls
-	//from the pause heartbeat loop (see restartConsumerAsync).
-	restarting atomic.Bool
-	//restartMu serializes restartConsumer (see there).
-	restartMu sync.Mutex
-	//consumerCreatedAt is when the current kafka consumer was created (unix
-	//nanos). A consumer needs a poll to join the group and get its assignment,
-	//so membership checks only apply once it is older than a grace period.
-	consumerCreatedAt atomic.Int64
-	//restartGeneration counts restarts, which suffix the static
-	//group.instance.id so a replacement is never fenced against the consumer
-	//it replaces (see newConsumer).
-	restartGeneration atomic.Int64
-	//lastRestartAt is when a restart last published a replacement consumer
-	//(unix nanos; zero before the first one). Only a replacement is subject to
-	//the restart cooldown — see restartConsumer.
-	lastRestartAt atomic.Int64
-	//assignmentFailures counts consecutive runs that ended without a partition
-	//assignment (retry mode). One is a rebalance; several in a row is a zombie.
-	assignmentFailures atomic.Int64
-	//closedConsumers records every *kafka.Consumer this object has closed.
-	//Several paths may hold the same pointer (suspend, restart quarantine,
-	//close), and confluent-kafka-go panics on a second Close, so all closes go
-	//through closeConsumer. One entry per restart; restarts are rare, so the
-	//set is never pruned.
-	closedMu        sync.Mutex
-	closedConsumers map[*kafka.Consumer]struct{}
-
+	idle              atomic.Bool
 	batchSizeFunc     BatchSizesFunction
 	batchFunc         BatchFunction
 	shouldConsumeFunc ShouldConsumeFunction
@@ -123,16 +81,16 @@ func NewAbstractBatchConsumer(repository *Repository, destinationId string, batc
 	}
 
 	consumerConfig := kafka.ConfigMap(utils.MapPutAll(kafka.ConfigMap{
-		"group.id":                      topicId,
-		"auto.offset.reset":             "earliest",
-		"allow.auto.create.topics":      false,
-		"group.instance.id":             abstract.GetInstanceId(),
-		"enable.auto.commit":            false,
-		"partition.assignment.strategy": config.KafkaConsumerPartitionsAssigmentStrategy,
-		"isolation.level":               "read_committed",
-		"session.timeout.ms":            config.KafkaSessionTimeoutMs,
-		"fetch.message.max.bytes":       config.KafkaFetchMessageMaxBytes,
-		"max.poll.interval.ms":          config.KafkaMaxPollIntervalMs,
+		"group.id":                        topicId,
+		"auto.offset.reset":               "earliest",
+		"allow.auto.create.topics":        false,
+		"enable.auto.commit":              false,
+		"go.application.rebalance.enable": true,
+		"partition.assignment.strategy":   config.KafkaConsumerPartitionsAssigmentStrategy,
+		"isolation.level":                 "read_committed",
+		"session.timeout.ms":              config.KafkaSessionTimeoutMs,
+		"fetch.message.max.bytes":         config.KafkaFetchMessageMaxBytes,
+		"max.poll.interval.ms":            config.KafkaMaxPollIntervalMs,
 	}, *kafkaConfig))
 
 	producerConfig := kafka.ConfigMap(utils.MapPutAll(kafka.ConfigMap{
@@ -155,14 +113,13 @@ func NewAbstractBatchConsumer(repository *Repository, destinationId string, batc
 		producerConfig:   producerConfig,
 		waitForMessages:  time.Duration(config.BatchRunnerWaitForMessagesSec) * time.Second,
 		closed:           make(chan struct{}),
-		//buffered size 1: resume() can deposit the signal even if the
-		//heartbeat goroutine is mid-iteration (e.g. blocked in
-		//restartConsumer); the heartbeat picks it up on the next pass.
-		resumeChannel: make(chan struct{}, 1),
-		//unbuffered: suspend must rendezvous with the heartbeat (see field doc).
-		stopChannel:     make(chan struct{}),
-		closedConsumers: map[*kafka.Consumer]struct{}{},
 	}
+	bc.consumer = newConsumerRuntime(consumerConfig, topicId, consumerRuntimeHooks{
+		debugf:       bc.Debugf,
+		infof:        bc.Infof,
+		errorf:       bc.Errorf,
+		onKafkaError: bc.onConsumerError,
+	}, time.Duration(config.KafkaMaxPollIntervalMs)*time.Millisecond)
 	bc.idle.Store(true)
 	return bc, nil
 }
@@ -306,54 +263,35 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 	}
 
 	maxBatchSize, maxBatchSizeBytes, retryBatchSize := bc.batchSizeFunc(streamOptions)
-	consumer, created, err := bc.initConsumer()
+	created, err := bc.initConsumer()
 	if err != nil {
 		bc.errorMetric("resume_error")
 		return BatchCounters{}, bc.NewError("Failed to resume kafka consumer: %v", err)
 	}
-	var partition int32 = 0
-	if bc.mode == "retry" {
-		var ass []kafka.TopicPartition
-		var err error
-		for i := 0; i < 10; i++ {
-			ass, err = consumer.Assignment()
-			if err == nil && len(ass) == 1 {
-				break
-			}
-			// rebalance events are served only during poll calls:
-			// poll the consumer so it can join the group and obtain its assignment
-			message, _ := consumer.ReadMessage(time.Second * time.Duration(i+1))
-			if message != nil {
-				// a message slipped through before batch processing started - rollback the position
-				_, seekErr := consumer.SeekPartitions([]kafka.TopicPartition{message.TopicPartition})
-				if seekErr != nil {
-					bc.SystemErrorf("Failed to seek back a message received while waiting for assignment: %v", seekErr)
-				}
-			}
-		}
-		if err != nil || len(ass) != 1 {
-			bc.errorMetric("assignment_error")
-			//A single failure is not treated as lost membership (JITSU-214):
-			//retry consumers of one topic share a group across the fleet, one
-			//partition each, so missing an assignment in this window is routine
-			//during a rebalance, and restarting would rejoin under a new
-			//instance id and force another fleet-wide rebalance. A rebalance
-			//settles within a session timeout, so several runs in a row without
-			//an assignment is a zombie rather than churn.
-			if !created && bc.assignmentFailures.Add(1) >= assignmentFailuresBeforeRestart {
-				bc.membershipLost(fmt.Sprintf("no partition assignment in %d consecutive runs", assignmentFailuresBeforeRestart))
-				bc.assignmentFailures.Store(0)
-				bc.restartConsumer(nil)
-			}
-			return BatchCounters{}, bc.NewError("Failed to get consumer assignment (%d): %v", len(ass), err)
-		}
-		bc.assignmentFailures.Store(0)
-		partition = ass[0].Partition
-		bc.Infof("Assigned partition: %d", partition)
+	assignmentWait := time.Duration(0)
+	if created {
+		assignmentWait = time.Duration(bc.config.KafkaSessionTimeoutMs) * time.Millisecond
 	}
-	_, highOffset, err = consumer.QueryWatermarkOffsets(bc.topicId, partition, 10_000)
+	assignments, consumerEpoch, err := bc.consumer.assignment(assignmentWait)
+	if err != nil {
+		bc.errorMetric("assignment_error")
+		return BatchCounters{}, bc.NewError("Failed to get consumer assignment: %v", err)
+	}
+	if len(assignments) == 0 {
+		//An empty assignment is valid in a shared consumer group. The runtime
+		//continues polling and will receive work after a later rebalance.
+		bc.Debugf("No partitions assigned to this healthy group member")
+		return BatchCounters{}, nil
+	}
+	if len(assignments) != 1 {
+		bc.errorMetric("assignment_error")
+		return BatchCounters{}, bc.NewError("Expected one assigned partition, got %d", len(assignments))
+	}
+	partition := assignments[0].Partition
+	bc.Debugf("Using assigned partition %d at epoch %d", partition, consumerEpoch)
+	_, highOffset, err = bc.consumer.queryWatermarkOffsets(bc.topicId, partition, 10_000, consumerEpoch)
 	updatedHighOffset = highOffset
-	offsets, erro := consumer.Committed([]kafka.TopicPartition{{Topic: &bc.topicId, Partition: partition}}, 10_000)
+	offsets, erro := bc.consumer.committed([]kafka.TopicPartition{{Topic: &bc.topicId, Partition: partition}}, 10_000, consumerEpoch)
 	if erro != nil {
 		bc.errorMetric("query_committed_failed")
 		bc.Errorf("Failed to query committed offsets: %v", erro)
@@ -361,32 +299,14 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 		commitedOffset = int64(offsets[0].Offset)
 	} else {
 		//Not an error by itself: a brand-new topic has no committed offset until
-		//its first batch. It is also what a consumer whose group was deleted
-		//sees — that case is caught by the membership check below.
+		//its first batch.
 		bc.Infof("No committed offset for the consumer group yet. High watermark: %d", highOffset)
 	}
 	if err != nil {
 		bc.errorMetric("query_watermark_failed")
 		return BatchCounters{}, bc.NewError("Failed to query watermark offsets: %v", err)
 	}
-	if !created && bc.mode != "retry" && hasLag(commitedOffset, highOffset) {
-		//Self-heal (JITSU-214). Topics are sharded, so this consumer is the
-		//group's only member for its partition: if it has been alive long enough
-		//to have joined and still owns nothing while messages are waiting, it
-		//has dropped out of the group (max.poll.interval exceeded, fenced by a
-		//restart, or the empty group was garbage-collected by the broker) and
-		//would otherwise poll nothing every period forever, looking idle.
-		if reason := bc.assignmentLost(consumer); reason != "" {
-			bc.membershipLost(reason)
-			bc.restartConsumer(nil)
-			consumer = bc.consumer.Load()
-			if consumer == nil {
-				bc.errorMetric("resume_error")
-				return BatchCounters{}, bc.NewError("Failed to recreate kafka consumer after losing group membership")
-			}
-		}
-	}
-	if !bc.shouldConsume(partition, commitedOffset, highOffset) {
+	if !bc.shouldConsume(partition, commitedOffset, highOffset, consumerEpoch) {
 		bc.Debugf("Consumer should not consume. offsets: %d-%d", commitedOffset, highOffset)
 		return BatchCounters{}, nil
 	}
@@ -404,7 +324,7 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 				return
 			}
 		}
-		batchCounters, batchState, nextBatch, err2 := bc.processBatch(destination, batchNumber, maxBatchSize, maxBatchSizeBytes, retryBatchSize, highOffset, int(updatedHighOffset))
+		batchCounters, batchState, nextBatch, err2 := bc.processBatch(destination, batchNumber, maxBatchSize, maxBatchSizeBytes, retryBatchSize, highOffset, int(updatedHighOffset), consumerEpoch)
 		if err2 != nil {
 			if nextBatch {
 				bc.Errorf("Batch finished with error: %v stats: %s nextBatch: %t", err2, batchCounters, nextBatch)
@@ -416,8 +336,7 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 		if batchCounters.consumed > 0 {
 			if time.Since(lastOffsetQueryTime) > 1*time.Minute || !nextBatch {
 				var err1 error
-				consumer = bc.consumer.Load()
-				_, updatedHighOffset, err1 = consumer.QueryWatermarkOffsets(bc.topicId, partition, 10_000)
+				_, updatedHighOffset, err1 = bc.consumer.queryWatermarkOffsets(bc.topicId, partition, 10_000, consumerEpoch)
 				if err1 != nil {
 					bc.Errorf("Failed to query watermark offsets: %v", err1)
 					bc.errorMetric("query_watermark_failed")
@@ -436,513 +355,91 @@ func (bc *AbstractBatchConsumer) ConsumeAll() (counters BatchCounters, err error
 }
 
 func (bc *AbstractBatchConsumer) close() error {
-	select {
-	case <-bc.closed:
-	default:
+	var err error
+	bc.closeOnce.Do(func() {
 		close(bc.closed)
-	}
-	consumer := bc.consumer.Swap(nil)
-	if consumer != nil {
-		return bc.closeConsumer(consumer)
-	}
-	return nil
-}
-
-// closeConsumer closes a kafka consumer exactly once, however many paths hold
-// its pointer (see closedConsumers). Returns the Close error, or nil when the
-// consumer was already closed by another path.
-func (bc *AbstractBatchConsumer) closeConsumer(consumer *kafka.Consumer) error {
-	bc.closedMu.Lock()
-	if _, done := bc.closedConsumers[consumer]; done {
-		bc.closedMu.Unlock()
-		return nil
-	}
-	bc.closedConsumers[consumer] = struct{}{}
-	bc.closedMu.Unlock()
-	e1 := consumer.Unsubscribe()
-	e2 := consumer.Close()
-	bc.Infof("Consumer closed: %s unsubscribe: %v close: %v", consumer.String(), e1, e2)
-	return e2
-}
-
-// quarantineClose closes a consumer that has just been replaced, after a delay
-// long enough for anything that loaded the old pointer before the swap — the
-// paused heartbeat mid-ReadMessage, most importantly — to return from it.
-// librdkafka is not safe against a poll racing a Close on the same instance.
-//
-// The delay also bounds how long a replaced static member stays registered:
-// it is deregistered a session timeout after this close, and only then is its
-// base group.instance.id free again. Keep
-// BATCH_RUNNER_WAIT_FOR_MESSAGES_SEC + 5s + KAFKA_SESSION_TIMEOUT_MS under the
-// 60s minimum gap that pauseOrSuspend requires before suspending, so a
-// suspended consumer recreated with the base id never collides with it.
-func (bc *AbstractBatchConsumer) quarantineClose(consumer *kafka.Consumer) {
-	safego.RunWithRestart(func() {
-		time.Sleep(bc.waitForMessages + 5*time.Second)
-		_ = bc.closeConsumer(consumer)
+		err = bc.consumer.close()
 	})
+	return err
 }
 
-func (bc *AbstractBatchConsumer) processBatch(destination *Destination, batchNum, batchSize, batchSizeBytes, retryBatchSize int, highOffset int64, updatedHighOffset int) (counters BatchCounters, state bulker.State, nextBath bool, err error) {
+func (bc *AbstractBatchConsumer) processBatch(destination *Destination, batchNum, batchSize, batchSizeBytes, retryBatchSize int, highOffset int64, updatedHighOffset int, consumerEpoch uint64) (counters BatchCounters, state bulker.State, nextBath bool, err error) {
 	bc.resume()
-	return bc.batchFunc(destination, batchNum, batchSize, batchSizeBytes, retryBatchSize, highOffset, updatedHighOffset)
+	return bc.batchFunc(destination, batchNum, batchSize, batchSizeBytes, retryBatchSize, highOffset, updatedHighOffset, consumerEpoch)
 }
 
-func (bc *AbstractBatchConsumer) shouldConsume(partitionId int32, committedOffset, highOffset int64) bool {
+func (bc *AbstractBatchConsumer) shouldConsume(partitionId int32, committedOffset, highOffset int64, consumerEpoch uint64) bool {
 	if highOffset == 0 || committedOffset == highOffset {
 		return false
 	}
 	if bc.shouldConsumeFunc != nil {
 		bc.resume()
-		return bc.shouldConsumeFunc(partitionId, committedOffset, highOffset)
+		return bc.shouldConsumeFunc(partitionId, committedOffset, highOffset, consumerEpoch)
 	}
 	return true
 }
 
 func (bc *AbstractBatchConsumer) pauseOrSuspend(startedAt time.Time) {
 	if bc.idle.Load() && bc.retired.Load() {
-		// Close retired idling consumer
 		bc.Infof("Consumer is retired. Closing")
 		_ = bc.close()
-		return
-	}
-	consumer := bc.consumer.Load()
-	if consumer == nil {
 		return
 	}
 	batchPeriodSec := bc.BatchPeriodSec()
 	timeToNextBatch := time.Duration(batchPeriodSec)*time.Second - time.Since(startedAt)
 	if bc.config.SuspendConsumers && timeToNextBatch >= 60*time.Second {
-		bc.Infof("Suspending consumer %s for %s", consumer.String(), timeToNextBatch)
-		bc._unpause()
-		//only suspend the consumer we looked at: a restart may have swapped in
-		//a new one meanwhile, and storing nil over it would leak a live group
-		//member. That one stays up and is used by the next period.
-		if bc.consumer.CompareAndSwap(consumer, nil) {
-			_ = bc.closeConsumer(consumer)
-		} else {
-			bc.Infof("Consumer was replaced while suspending. Keeping the new one")
+		bc.Infof("Suspending consumer %s for %s", bc.consumer.description(), timeToNextBatch)
+		if err := bc.consumer.suspend(); err != nil && !errors.Is(err, errConsumerNotStarted) {
+			bc.Errorf("Failed to suspend Kafka consumer: %v", err)
 		}
 	} else {
 		bc.pause(false)
 	}
 }
 
-// pause consumer.
-func (bc *AbstractBatchConsumer) pause(immediatePoll bool) {
-	if !bc.paused.CompareAndSwap(false, true) {
-		return
+func (bc *AbstractBatchConsumer) pause(_ bool) {
+	if err := bc.consumer.pause(); err != nil && !errors.Is(err, errConsumerNotStarted) {
+		bc.errorMetric("pause_error")
+		bc.SystemErrorf("Failed to pause Kafka consumer: %v", err)
 	}
-	//drain any stale resume signal left over from a prior cycle so the new
-	//heartbeat goroutine doesn't break out of its loop on the first pass.
-	select {
-	case <-bc.resumeChannel:
-	default:
-	}
-	bc.pauseKafkaConsumer()
-
-	safego.RunWithRestart(func() {
-		errorReported := false
-		firstPoll := immediatePoll
-		//this loop keeps heatbeating consumer to prevent it from being kicked out from group
-		pauseTicker := time.NewTicker(bc.heartbeatInterval())
-		defer pauseTicker.Stop()
-	loop:
-		for {
-			if bc.idle.Load() && bc.retired.Load() {
-				// Close retired idling consumer
-				bc.Infof("Consumer is retired. Closing")
-				_ = bc.close()
-				return
-			}
-			if !firstPoll {
-				select {
-				case <-bc.resumeChannel:
-					bc.paused.CompareAndSwap(true, false)
-					//Defensive: resume() may have called consumer.Resume on
-					//a consumer that was since replaced (e.g. by an in-flight
-					//restartConsumer). Re-resume the current one so the kafka
-					//state matches paused=false even after that race.
-					if currentConsumer := bc.consumer.Load(); currentConsumer != nil {
-						if parts, perr := currentConsumer.Assignment(); perr == nil {
-							_ = currentConsumer.Resume(parts)
-						}
-					}
-					bc.Debugf("Consumer resumed.")
-					break loop
-				case <-bc.stopChannel:
-					//Suspend path: the caller (pauseOrSuspend) is about to close
-					//the consumer, so we only stop heartbeating — no Resume.
-					//Because stopChannel is unbuffered, _unpause is still blocked
-					//on the send here, guaranteeing the consumer is no longer in
-					//ReadMessage when Close runs.
-					bc.paused.CompareAndSwap(true, false)
-					bc.Debugf("Consumer heartbeat stopped for suspend.")
-					break loop
-				case <-pauseTicker.C:
-				}
-			}
-			firstPoll = false
-			consumer := bc.consumer.Load()
-			if consumer == nil {
-				bc.Errorf("Paused Consumer is nil.")
-				continue
-			}
-			message, err := consumer.ReadMessage(bc.waitForMessages)
-			if err != nil {
-				kafkaErr := err.(kafka.Error)
-				if kafkaErr.Code() == kafka.ErrTimedOut {
-					bc.Debugf("Consumer paused. Heartbeat sent.")
-					continue
-				}
-				bc.errorMetric("error_while_paused")
-				if !errorReported {
-					bc.Errorf("Error on paused consumer: %v", kafkaErr)
-					errorReported = true
-				}
-				if reason := membershipLossReason(kafkaErr); reason != "" {
-					//left the group: waiting does not bring it back (that is the
-					//zombie this fix is about), so rejoin with a new consumer
-					bc.membershipLost(reason)
-					bc.restartConsumerAsync()
-				} else if kafkaErr.IsRetriable() && !kafkaErr.IsFatal() {
-					time.Sleep(10 * time.Second)
-				} else {
-					//restartConsumer can block for KafkaSessionTimeoutMs + 15s per
-					//failed creation attempt (broker unreachable); running it
-					//synchronously here would starve the resumeChannel select and
-					//trip "Resume timeout" in resume() once 5 min elapses.
-					bc.restartConsumerAsync()
-				}
-			} else if message != nil {
-				bc.Debugf("Unexpected message on paused consumer: %v", message)
-				//If message slipped through pause, rollback offset and make sure consumer is paused
-				_, err = consumer.SeekPartitions([]kafka.TopicPartition{message.TopicPartition})
-				if err != nil {
-					bc.errorMetric("ROLLBACK_ON_PAUSE_ERR")
-					bc.SystemErrorf("Failed to rollback offset on paused consumer: %v", err)
-					bc.restartConsumerAsync()
-				}
-				bc.pauseKafkaConsumer()
-			}
-		}
-	})
 }
 
-// initConsumer returns the current kafka consumer, creating one when there is
-// none. `created` reports whether this call made it: a new consumer has not
-// polled yet, so it has no assignment and no group membership to check.
-func (bc *AbstractBatchConsumer) initConsumer() (consumer *kafka.Consumer, created bool, err error) {
-	consumer = bc.consumer.Load()
-	if consumer != nil {
-		return consumer, false, nil
-	}
-	consumer, err = bc.newConsumer(false)
-	if err != nil {
-		return nil, false, err
-	}
-	//this consumer replaces nothing (first run, or a start after a suspend), so
-	//it is not covered by the restart cooldown — clear any stamp an earlier
-	//restart left behind, or a fatal error on it would be skipped
-	bc.lastRestartAt.Store(0)
-	bc.consumer.Store(consumer)
-	return consumer, true, nil
-}
-
-// newConsumer creates and subscribes a kafka consumer without publishing it.
-//
-// A restart gets a "-rN" suffix on the static group.instance.id, because the
-// consumer it replaces is still a live group member for up to a session
-// timeout and two members sharing an instance id fence each other. Any other
-// creation — the first one, or one after a suspend, where the previous member
-// is long gone — keeps the base id, so a pod restart resumes as the same
-// static member and the partition assignment order across instances holds.
-func (bc *AbstractBatchConsumer) newConsumer(restart bool) (*kafka.Consumer, error) {
-	config := kafka.ConfigMap(utils.MapPutAll(kafka.ConfigMap{}, bc.consumerConfig))
-	instanceId := bc.GetInstanceId()
-	if restart {
-		instanceId = fmt.Sprintf("%s-r%d", instanceId, bc.restartGeneration.Add(1))
-		config["group.instance.id"] = instanceId
-	}
-	consumer, err := kafka.NewConsumer(&config)
+func (bc *AbstractBatchConsumer) initConsumer() (bool, error) {
+	created, err := bc.consumer.init()
 	if err != nil {
 		bc.errorMetric("consumer_error:" + metrics.KafkaErrorCode(err))
-		bc.Errorf("Error creating kafka consumer: %v", err)
-		return nil, err
+		bc.Errorf("Error creating Kafka consumer: %v", err)
 	}
-	err = consumer.SubscribeTopics([]string{bc.topicId}, bc.rebalanceCallback)
-	if err != nil {
-		bc.errorMetric("consumer_error:" + metrics.KafkaErrorCode(err))
-		_ = consumer.Close()
-		bc.Errorf("Failed to subscribe to topic: %v", err)
-		return nil, err
-	}
-	//if bc.mode == "retry" && bc.topicId == bc.config.KafkaDestinationsRetryTopicName {
-	//	consumer.Assign([]kafka.TopicPartition{kafka.TopicPartition{Topic: &bc.topicId, Offset: kafka.OffsetStored, Partition: int32(bc.config.InstanceIndex)}})
-	//}
-	bc.consumerCreatedAt.Store(time.Now().UnixNano())
-	bc.Infof("Consumer created: %s (group.instance.id: %s)", consumer.String(), instanceId)
-	return consumer, nil
+	return created, err
 }
 
-// heartbeatInterval is how often a paused consumer is polled to stay in the
-// group. It must leave a real margin under max.poll.interval.ms: at exactly
-// half, one poll that waits its full timeout plus any scheduling delay is
-// enough to overshoot, and librdkafka then leaves the group (JITSU-214).
-func (bc *AbstractBatchConsumer) heartbeatInterval() time.Duration {
-	return time.Duration(bc.config.KafkaMaxPollIntervalMs) * time.Millisecond / 3
-}
-
-// membershipGrace is how long a consumer gets to join the group before an
-// empty assignment counts as lost membership: the paused heartbeat first
-// polls it after one heartbeatInterval, and joining takes up to a session.
-func (bc *AbstractBatchConsumer) membershipGrace() time.Duration {
-	return bc.heartbeatInterval() + time.Duration(bc.config.KafkaSessionTimeoutMs)*time.Millisecond
-}
-
-// assignmentLost reports why the current consumer no longer looks like a group
-// member, or "" while it does. Only meaningful once the consumer is past the
-// grace period — before that an empty assignment is just "not joined yet".
-func (bc *AbstractBatchConsumer) assignmentLost(consumer *kafka.Consumer) string {
-	age := time.Since(time.Unix(0, bc.consumerCreatedAt.Load()))
-	if age < bc.membershipGrace() {
-		return ""
-	}
-	partitions, err := consumer.Assignment()
-	if err != nil {
-		return fmt.Sprintf("assignment query failed after %s: %v", age.Round(time.Second), err)
-	}
-	if len(partitions) == 0 {
-		return fmt.Sprintf("no partition assignment after %s while messages are waiting", age.Round(time.Second))
-	}
-	return ""
-}
-
-// membershipLost records that this consumer dropped out of its group — the
-// condition behind topics that silently stop being consumed (JITSU-214). It is
-// an error-level log and a dedicated metric label so it can be alerted on.
-// Every caller follows it with a restart, which logs its own progress.
 func (bc *AbstractBatchConsumer) membershipLost(reason string) {
 	bc.errorMetric("membership_lost")
 	bc.Errorf("Consumer group membership lost: %s", reason)
 }
 
-// onReadError handles a non-timeout error from ReadMessage during batch
-// processing. A fatal error leaves the librdkafka instance permanently
-// inoperable and a non-retriable one is not going to clear on its own; either
-// way every later poll on this object just times out and the topic looks idle,
-// so the consumer is recreated (asynchronously — the caller is inside a batch
-// and holds the consumer lock).
-func (bc *AbstractBatchConsumer) onReadError(kafkaErr kafka.Error) {
+func (bc *AbstractBatchConsumer) onConsumerError(kafkaErr kafka.Error) {
 	bc.errorMetric("consumer_error:" + metrics.KafkaErrorCode(kafkaErr))
 	if reason := membershipLossReason(kafkaErr); reason != "" {
 		bc.membershipLost(reason)
 	}
-	if kafkaErr.IsFatal() || !kafkaErr.IsRetriable() {
-		bc.restartConsumerAsync()
-	}
 }
 
-// restartConsumerAsync schedules restartConsumer to run in a separate
-// goroutine, returning immediately. Re-entry is suppressed: if a restart
-// is already in flight, the call is a no-op. Use from contexts that must
-// not block — notably the pause heartbeat loop, where a synchronous
-// restartConsumer can starve the resumeChannel select for longer than
-// KafkaMaxPollIntervalMs and cause "Resume timeout" in resume().
-func (bc *AbstractBatchConsumer) restartConsumerAsync() {
-	if !bc.restarting.CompareAndSwap(false, true) {
-		return
-	}
-	go func() {
-		defer bc.restarting.Store(false)
-		bc.restartConsumer(nil)
-	}()
-}
-
-// restartConsumer replaces the kafka consumer with a fresh one.
-//
-// The new consumer is created and published FIRST; the old one is closed
-// afterwards, in quarantine (see quarantineClose). Two things make that safe:
-//   - the new consumer joins under a different group.instance.id (see
-//     newConsumer), so the broker never fences one static member with the
-//     other — the FENCED_INSTANCE_ID fatal error that killed consumers when
-//     an old member was still alive while its replacement joined (JITSU-214).
-//     The old member's assignment is released by the broker once its session
-//     times out, at which point the new one is assigned the partition;
-//   - nothing ever closes a consumer another goroutine may still be polling:
-//     the pointer swap happens before the close, and the close waits out any
-//     in-flight poll.
-//
-// Restarts are serialized, and a consumer younger than a session timeout is
-// not restarted again: whoever asked for it was looking at the previous one.
 func (bc *AbstractBatchConsumer) restartConsumer(beforeInit func()) {
 	if bc.retired.Load() {
 		return
 	}
-	bc.restartMu.Lock()
-	defer bc.restartMu.Unlock()
-	if bc.retired.Load() {
-		return
-	}
-	sessionTimeout := time.Duration(bc.config.KafkaSessionTimeoutMs) * time.Millisecond
-	//Only a consumer that a restart installed is subject to the cooldown: it
-	//means a concurrent restart already replaced the one this caller was
-	//looking at. A consumer created by initConsumer (the first one, or one
-	//started after a suspend) is nobody's replacement, so a fatal error on it
-	//must still force a restart rather than leave an unusable handle in place.
-	lastRestart := bc.lastRestartAt.Load()
-	if lastRestart > 0 && bc.consumer.Load() != nil && time.Since(time.Unix(0, lastRestart)) < sessionTimeout {
-		bc.Infof("Consumer was restarted less than %s ago. Skipping restart", sessionTimeout)
-		//beforeInit still runs: it is the caller's own recovery work (an offset
-		//fix-up via the admin client), and skipping it because someone else
-		//restarted the consumer would silently drop that repair
-		if beforeInit != nil {
-			beforeInit()
-		}
-		return
-	}
 	bc.Infof("Restarting consumer")
-	// for faster reaction on retiring
-	pauseTicker := time.NewTicker(1 * time.Second)
-	defer pauseTicker.Stop()
-	retry := time.NewTicker(sessionTimeout + 15*time.Second)
-	defer retry.Stop()
-	for {
-		//beforeInit runs before every attempt, as it always did: callers pass
-		//idempotent work (an offset fix-up via the admin client) that must run
-		//right before the consumer that will use its result
-		if beforeInit != nil {
-			beforeInit()
-		}
-		consumer, err := bc.newConsumer(true)
-		if err == nil {
-			//creating a consumer takes seconds; the object may have been retired
-			//and closed meanwhile. Publishing now would leave a live, subscribed
-			//group member nobody ever closes.
-			if bc.retired.Load() && bc.idle.Load() {
-				bc.Infof("Consumer was retired while restarting. Discarding the new consumer")
-				_ = bc.closeConsumer(consumer)
-				return
-			}
-			bc.lastRestartAt.Store(time.Now().UnixNano())
-			if old := bc.consumer.Swap(consumer); old != nil {
-				bc.quarantineClose(old)
-			}
-			//Retirement can also land between the check above and this swap,
-			//with close() running in between: it would have taken the old
-			//consumer out and closed it, and nothing would ever close the one
-			//just published. Withdraw it — unless someone already took it out,
-			//in which case they close it.
-			if bc.retired.Load() && bc.idle.Load() && bc.consumer.CompareAndSwap(consumer, nil) {
-				bc.Infof("Consumer was retired while restarting. Discarding the new consumer")
-				_ = bc.closeConsumer(consumer)
-			}
-			return
-		}
-		//creation failed (broker unreachable?): retry after a session timeout,
-		//polling for retirement in between. Retirement alone ends the loop —
-		//this runs synchronously from ConsumeAll too, where idle is false for
-		//the whole run, so waiting for idle would never let a retired consumer
-		//out (and it holds bc.Mutex and restartMu while it waits).
-		for {
-			select {
-			case <-pauseTicker.C:
-				if bc.retired.Load() {
-					return
-				}
-				continue
-			case <-retry.C:
-			}
-			break
-		}
-	}
-}
-
-func (bc *AbstractBatchConsumer) pauseKafkaConsumer() {
-	consumer := bc.consumer.Load()
-	if consumer == nil {
-		//a restart is replacing the consumer; rebalanceCallback pauses the new
-		//one on assignment while paused is set
-		return
-	}
-	partitions, err := consumer.Assignment()
-	if len(partitions) > 0 {
-		err = consumer.Pause(partitions)
-	}
-	if err != nil {
-		bc.errorMetric("pause_error")
-		bc.SystemErrorf("Failed to pause kafka consumer: %v", err)
-		bc.restartConsumer(nil)
-	} else {
-		if len(partitions) > 0 {
-			bc.Debugf("Consumer paused.")
-		}
-		// otherwise rebalanceCallback will handle pausing
-	}
-}
-
-func (bc *AbstractBatchConsumer) rebalanceCallback(consumer *kafka.Consumer, event kafka.Event) error {
-	assignedParts, ok := event.(kafka.AssignedPartitions)
-	bc.Debugf("Rebalance event: %v . Paused: %t", event, bc.paused.Load())
-	if ok && bc.paused.Load() {
-		err := consumer.Pause(assignedParts.Partitions)
-		if err != nil {
-			bc.errorMetric("pause_error")
-			bc.SystemErrorf("Failed to pause kafka consumer: %v", err)
-			return err
-		} else {
-			bc.Debugf("Consumer paused.")
-		}
-	}
-	return nil
-}
-
-// _unpause stops the pause heartbeat for the suspend path. It sends on the
-// unbuffered stopChannel so the send only completes once the heartbeat has
-// received it and is leaving its loop — i.e. it is no longer inside
-// ReadMessage. That rendezvous lets pauseOrSuspend close the consumer right
-// after without racing the heartbeat into a non-retriable ReadMessage error
-// (which would spuriously trigger restartConsumerAsync and recreate the
-// consumer we intended to suspend).
-func (bc *AbstractBatchConsumer) _unpause() {
-	if !bc.paused.Load() {
-		return
-	}
-	select {
-	case bc.stopChannel <- struct{}{}:
-		return
-	case <-time.After(time.Duration(bc.config.KafkaMaxPollIntervalMs) * time.Millisecond):
-		bc.errorMetric("resume_error")
-		bc.SystemErrorf("failed to unpause kafka consumer.")
+	if err := bc.consumer.restart(beforeInit); err != nil {
+		bc.errorMetric("consumer_error:" + metrics.KafkaErrorCode(err))
+		bc.Errorf("Failed to restart Kafka consumer: %v", err)
 	}
 }
 
 func (bc *AbstractBatchConsumer) resume() {
-	if !bc.paused.Load() {
-		return
-	}
-	consumer := bc.consumer.Load()
-	var err error
-	defer func() {
-		if err != nil {
-			bc.errorMetric("resume_error")
-			bc.SystemErrorf("failed to resume kafka consumer.: %v", err)
-		}
-	}()
-	if consumer == nil {
-		err = bc.NewError("no kafka consumer (restart in progress?)")
-		return
-	}
-	partitions, err := consumer.Assignment()
-	if err != nil {
-		return
-	}
-	select {
-	case bc.resumeChannel <- struct{}{}:
-		err = consumer.Resume(partitions)
-	case <-time.After(time.Duration(bc.config.KafkaMaxPollIntervalMs) * time.Millisecond):
-		err = bc.NewError("Resume timeout.")
-		//return bc.consumer.Resume(partitions)
+	if err := bc.consumer.resume(); err != nil && !errors.Is(err, errConsumerNotStarted) {
+		bc.errorMetric("resume_error")
+		bc.SystemErrorf("Failed to resume Kafka consumer: %v", err)
 	}
 }
 
@@ -951,6 +448,9 @@ func (bc *AbstractBatchConsumer) resume() {
 func (bc *AbstractBatchConsumer) Retire() {
 	bc.Infof("Retiring %s consumer", bc.mode)
 	bc.retired.Store(true)
+	if bc.idle.Load() {
+		_ = bc.close()
+	}
 }
 func (bc *AbstractBatchConsumer) errorMetric(errorType string) {
 	metrics.ConsumerErrors(bc.topicId, bc.mode, bc.destinationId, bc.tableName, errorType).Inc()
@@ -990,16 +490,6 @@ func (bc *AbstractBatchConsumer) countersMetric(counters BatchCounters) {
 			}
 		}
 	}
-}
-
-// hasLag reports whether the topic holds messages this consumer has not
-// committed: either nothing was ever committed (OffsetBeginning/invalid) or the
-// committed offset trails the high watermark.
-func hasLag(committedOffset, highOffset int64) bool {
-	if highOffset <= 0 {
-		return false
-	}
-	return committedOffset < 0 || committedOffset < highOffset
 }
 
 // membershipLossReason maps a kafka error to a human-readable reason when it

--- a/bulker/bulkerapp/app/abstract_batch_consumer_test.go
+++ b/bulker/bulkerapp/app/abstract_batch_consumer_test.go
@@ -7,26 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHasLag(t *testing.T) {
-	testCases := []struct {
-		desc      string
-		committed int64
-		high      int64
-		expected  bool
-	}{
-		{"empty topic, nothing committed", int64(kafka.OffsetBeginning), 0, false},
-		{"empty topic, stale commit", 10, 0, false},
-		{"messages but no committed offset (new topic or deleted group)", int64(kafka.OffsetBeginning), 262_072, true},
-		{"committed behind the watermark", 100, 150, true},
-		{"fully consumed", 150, 150, false},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			assert.Equal(t, tc.expected, hasLag(tc.committed, tc.high))
-		})
-	}
-}
-
 func TestMembershipLossReason(t *testing.T) {
 	testCases := []struct {
 		desc     string

--- a/bulker/bulkerapp/app/batch_consumer.go
+++ b/bulker/bulkerapp/app/batch_consumer.go
@@ -75,7 +75,7 @@ func (bc *BatchConsumerImpl) batchSizes(streamOptions *bulker.StreamOptions) (ma
 	return
 }
 
-func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum, batchSize, batchSizeBytes, retryBatchSize int, highOffset int64, updatedHighOffset int) (counters BatchCounters, state bulker.State, nextBatch bool, err error) {
+func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum, batchSize, batchSizeBytes, retryBatchSize int, highOffset int64, updatedHighOffset int, consumerEpoch uint64) (counters BatchCounters, state bulker.State, nextBatch bool, err error) {
 	bc.Debugf("Starting batch #%d", batchNum)
 	counters.firstOffset = int64(kafka.OffsetBeginning)
 	startTime := time.Now()
@@ -103,7 +103,7 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 				bc.SendMetrics(metricsMeta, "retry_error", counters.retried)
 			}
 			if failedPosition != nil {
-				cnts, err2 := bc.processFailed(firstPosition, failedPosition, err)
+				cnts, err2 := bc.processFailed(firstPosition, failedPosition, err, consumerEpoch)
 				counters.deadLettered = cnts.deadLettered
 				counters.retryScheduled = cnts.retryScheduled
 				if err2 != nil {
@@ -123,7 +123,6 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 	processed := 0
 	maxMessageSize := 0
 	consumedBytes := 0
-	consumer := bc.consumer.Load()
 	for i := 0; i < batchSize; i++ {
 		if bc.retired.Load() {
 			if bulkerStream != nil {
@@ -142,18 +141,17 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 			bc.Debugf("Reached batch size %d of %d. Stopping batch", consumedBytes, batchSizeBytes)
 			break
 		}
-		message, err := consumer.ReadMessage(bc.waitForMessages)
+		message, err := bc.consumer.readMessage(bc.waitForMessages, consumerEpoch)
 		if err != nil {
-			kafkaErr := err.(kafka.Error)
-			if kafkaErr.Code() == kafka.ErrTimedOut {
+			var kafkaErr kafka.Error
+			if errors.As(err, &kafkaErr) && kafkaErr.Code() == kafka.ErrTimedOut {
 				// waitForMessages period is over. it's ok. considering batch as full
 				break
 			}
-			bc.onReadError(kafkaErr)
 			if bulkerStream != nil {
 				_ = bulkerStream.Abort(ctx)
 			}
-			return counters, state, false, bc.NewError("Failed to consume event from topic. Retryable: %t: %v", kafkaErr.IsRetriable(), kafkaErr)
+			return counters, state, false, bc.NewError("Failed to consume event from topic: %v", err)
 		}
 		messageSize := len(message.Value)
 		maxMessageSize = max(maxMessageSize, messageSize)
@@ -224,15 +222,13 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 		if processed == batchSize {
 			nextBatch = true
 		}
-		pauseTimer := time.AfterFunc(bc.heartbeatInterval(), func() {
-			// we need to pause consumer to avoid kafka session timeout while loading huge batches to slow destinations
-			bc.pause(true)
-		})
+		//No more records are needed while the destination commits. Pause now so
+		//the owner runtime can keep polling group events throughout a slow load.
+		bc.pause(true)
 
 		bc.Debugf("Batch #%d Committing %d events to %s", batchNum, processed, destination.config.BulkerType)
 		//TODO: do we need to interrupt commit if consumer is retired?
 		state, err = bulkerStream.Complete(ctx)
-		pauseTimer.Stop()
 		state.ProcessedBytes = consumedBytes
 		state.ProcessingTimeSec = time.Since(startTime).Seconds()
 		if err != nil {
@@ -270,19 +266,15 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 		}
 		counters.processed = processed
 		counters.processedBytes = consumedBytes
-		//re-read the pointer: loading a batch into a slow destination can outlast
-		//a consumer restart (the pause heartbeat may have replaced the consumer
-		//this batch was read with), and committing on the retired handle would
-		//fail after it is closed
-		consumer = bc.consumer.Load()
-		if consumer == nil {
-			err = bc.NewError("no kafka consumer to commit the batch with")
-		} else {
-			_, err = consumer.CommitMessage(latestMessage)
-		}
+		_, err = bc.consumer.commitMessage(latestMessage, consumerEpoch)
 		if err != nil {
 			bc.errorMetric("KAFKA_COMMIT_ERR:" + metrics.KafkaErrorCode(err))
 			bc.Errorf("Failed to commit kafka consumer after batch was successfully committed to the destination: %v", err)
+			if errors.Is(err, errConsumerAssignmentChanged) {
+				//The loaded records may be replayed, but an old assignment must never
+				//advance the checkpoint now controlled by another group member.
+				return counters, state, false, err
+			}
 			committed := false
 			bc.restartConsumer(func() {
 				defer func() {
@@ -306,24 +298,11 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 				}
 
 			})
-			if !committed {
-				var tp []kafka.TopicPartition
-				//the restart above may have left no consumer at all (retired
-				//meanwhile), and the offset repair did not run either
-				if current := bc.consumer.Load(); current == nil {
-					err = bc.NewError("no kafka consumer to commit the batch with after restart")
-				} else {
-					tp, err = current.CommitMessage(latestMessage)
-				}
-				if err != nil {
-					bc.SystemErrorf("Failed to commit kafka consumer after batch was successfully committed to the destination: %v", err)
-					err = bc.NewError("Failed to commit kafka consumer: %v", err)
-					return
-				} else {
-					bc.Infof("Successfully committed kafka consumer after initial fail: %+v", tp)
-				}
-			} else {
+			if committed {
 				err = nil
+			} else {
+				err = bc.NewError("Failed to repair Kafka offset after the destination batch completed: %v", err)
+				return
 			}
 		}
 	} else if bulkerStream != nil {
@@ -333,13 +312,11 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 }
 
 // processFailed consumes the latest failed batch of messages and sends them to the 'failed' topic
-func (bc *BatchConsumerImpl) processFailed(firstPosition *kafka.TopicPartition, failedPosition *kafka.TopicPartition, originalErr error) (counters BatchCounters, err error) {
+func (bc *BatchConsumerImpl) processFailed(firstPosition *kafka.TopicPartition, failedPosition *kafka.TopicPartition, originalErr error, consumerEpoch uint64) (counters BatchCounters, err error) {
 	var producer *kafka.Producer
 	var commitedPosition = *firstPosition
 
 	retryBatchSize := bc.config.RetryConsumerBatchSize
-	consumer := bc.consumer.Load()
-
 	defer func() {
 		//recover
 		if r := recover(); r != nil {
@@ -353,7 +330,7 @@ func (bc *BatchConsumerImpl) processFailed(firstPosition *kafka.TopicPartition, 
 		if err != nil {
 			err = bc.NewError("Failed to put unsuccessful batch to 'failed' producer: %v", err)
 			//cleanup
-			_, err2 := consumer.SeekPartitions([]kafka.TopicPartition{commitedPosition})
+			_, err2 := bc.consumer.seekPartitions([]kafka.TopicPartition{commitedPosition}, consumerEpoch)
 			if err2 != nil {
 				bc.errorMetric("SEEK_ERROR")
 			}
@@ -374,13 +351,13 @@ func (bc *BatchConsumerImpl) processFailed(firstPosition *kafka.TopicPartition, 
 
 	bc.Infof("Rolling back to first offset %d (failed at %d)", firstPosition.Offset, failedPosition.Offset)
 	//Rollback consumer to committed offset
-	_, err = consumer.SeekPartitions([]kafka.TopicPartition{*firstPosition})
+	_, err = bc.consumer.seekPartitions([]kafka.TopicPartition{*firstPosition}, consumerEpoch)
 	if err != nil {
 		bc.errorMetric("SEEK_ERROR")
 		return BatchCounters{}, fmt.Errorf("failed to rollback kafka consumer offset: %v", err)
 	}
 	var groupMetadata *kafka.ConsumerGroupMetadata
-	groupMetadata, err = consumer.GetConsumerGroupMetadata()
+	groupMetadata, err = bc.consumer.groupMetadata(consumerEpoch)
 	if err != nil {
 		err = fmt.Errorf("failed to get consumer group metadata: %v", err)
 		return
@@ -395,14 +372,14 @@ func (bc *BatchConsumerImpl) processFailed(firstPosition *kafka.TopicPartition, 
 		}
 
 		for i := 0; i < retryBatchSize; i++ {
-			message, err = consumer.ReadMessage(bc.waitForMessages)
+			message, err = bc.consumer.readMessage(bc.waitForMessages, consumerEpoch)
 			if err != nil {
-				kafkaErr := err.(kafka.Error)
-				if kafkaErr.Code() == kafka.ErrTimedOut {
+				var kafkaErr kafka.Error
+				if errors.As(err, &kafkaErr) && kafkaErr.Code() == kafka.ErrTimedOut {
 					err = fmt.Errorf("failed to consume message: %v", err)
 					return
 				}
-				if kafkaErr.IsRetriable() {
+				if errors.As(err, &kafkaErr) && kafkaErr.IsRetriable() {
 					time.Sleep(10 * time.Second)
 					continue
 				} else {

--- a/bulker/bulkerapp/app/kafka_consumer_runtime.go
+++ b/bulker/bulkerapp/app/kafka_consumer_runtime.go
@@ -1,0 +1,693 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+const (
+	maxConsumerControlPollInterval = 10 * time.Second
+	consumerAssignmentPollInterval = time.Second
+	consumerReconnectMaxBackoff    = 30 * time.Second
+)
+
+var (
+	errConsumerRuntimeClosed     = errors.New("kafka consumer runtime is closed")
+	errConsumerNotStarted        = errors.New("kafka consumer is not started")
+	errConsumerAssignmentChanged = errors.New("kafka consumer assignment changed")
+)
+
+// groupConsumer is the part of kafka.Consumer used by the runtime. Keeping the
+// boundary here makes the group state machine testable without a broker.
+type groupConsumer interface {
+	SubscribeTopics([]string, kafka.RebalanceCb) error
+	Poll(int) kafka.Event
+	Assign([]kafka.TopicPartition) error
+	Unassign() error
+	IncrementalAssign([]kafka.TopicPartition) error
+	IncrementalUnassign([]kafka.TopicPartition) error
+	GetRebalanceProtocol() string
+	Assignment() ([]kafka.TopicPartition, error)
+	AssignmentLost() bool
+	Pause([]kafka.TopicPartition) error
+	Resume([]kafka.TopicPartition) error
+	QueryWatermarkOffsets(string, int32, int) (int64, int64, error)
+	Committed([]kafka.TopicPartition, int) ([]kafka.TopicPartition, error)
+	SeekPartitions([]kafka.TopicPartition) ([]kafka.TopicPartition, error)
+	CommitMessage(*kafka.Message) ([]kafka.TopicPartition, error)
+	GetConsumerGroupMetadata() (*kafka.ConsumerGroupMetadata, error)
+	Unsubscribe() error
+	Close() error
+	String() string
+}
+
+type groupConsumerFactory func(*kafka.ConfigMap) (groupConsumer, error)
+
+type consumerRuntimeHooks struct {
+	debugf       func(string, ...any)
+	infof        func(string, ...any)
+	errorf       func(string, ...any)
+	onKafkaError func(kafka.Error)
+}
+
+type consumerCommand struct {
+	run  func(*consumerSession)
+	done chan struct{}
+}
+
+// consumerRuntime serializes every operation on a Kafka consumer through one
+// owner goroutine. Slow destination work never receives the raw consumer; it
+// can only submit commands carrying the assignment epoch it read under.
+type consumerRuntime struct {
+	config              kafka.ConfigMap
+	topic               string
+	factory             groupConsumerFactory
+	hooks               consumerRuntimeHooks
+	maintenanceInterval time.Duration
+
+	commands  chan consumerCommand
+	stop      chan struct{}
+	done      chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+	closeErr  error
+}
+
+type consumerSession struct {
+	runtime *consumerRuntime
+
+	consumer groupConsumer
+	wanted   bool
+	//pauseRequested is the desired state. Keep it separate from pauseApplied
+	//so a failed Pause does not also disable the maintenance polls that retry it.
+	pauseRequested bool
+	pauseApplied   bool
+	epoch          uint64
+	pending        []*kafka.Message
+	rebalanceErr   error
+	rebalanceLost  bool
+	closing        bool
+
+	reconnectAt      time.Time
+	reconnectBackoff time.Duration
+}
+
+func newConsumerRuntime(config kafka.ConfigMap, topic string, hooks consumerRuntimeHooks, maxPollInterval time.Duration) *consumerRuntime {
+	return newConsumerRuntimeWithFactory(config, topic, hooks, func(config *kafka.ConfigMap) (groupConsumer, error) {
+		return kafka.NewConsumer(config)
+	}, consumerMaintenanceInterval(maxPollInterval))
+}
+
+func newConsumerRuntimeWithFactory(config kafka.ConfigMap, topic string, hooks consumerRuntimeHooks, factory groupConsumerFactory, maintenanceInterval time.Duration) *consumerRuntime {
+	runtime := &consumerRuntime{
+		config:              config,
+		topic:               topic,
+		factory:             factory,
+		hooks:               hooks,
+		maintenanceInterval: maintenanceInterval,
+		commands:            make(chan consumerCommand),
+		stop:                make(chan struct{}),
+		done:                make(chan struct{}),
+	}
+	return runtime
+}
+
+func consumerMaintenanceInterval(maxPollInterval time.Duration) time.Duration {
+	interval := maxPollInterval / 4
+	if interval <= 0 || interval > maxConsumerControlPollInterval {
+		return maxConsumerControlPollInterval
+	}
+	return interval
+}
+
+func (runtime *consumerRuntime) start() {
+	runtime.startOnce.Do(func() { go runtime.run() })
+}
+
+func (runtime *consumerRuntime) run() {
+	ticker := time.NewTicker(runtime.maintenanceInterval)
+	defer ticker.Stop()
+	defer close(runtime.done)
+
+	session := &consumerSession{runtime: runtime}
+	for {
+		select {
+		case command := <-runtime.commands:
+			command.run(session)
+			close(command.done)
+		case <-ticker.C:
+			session.maintain()
+		case <-runtime.stop:
+			session.wanted = false
+			runtime.closeErr = session.closeCurrent()
+			return
+		}
+	}
+}
+
+func (runtime *consumerRuntime) execute(run func(*consumerSession)) error {
+	runtime.start()
+	command := consumerCommand{run: run, done: make(chan struct{})}
+	select {
+	case runtime.commands <- command:
+	case <-runtime.done:
+		return errConsumerRuntimeClosed
+	}
+	select {
+	case <-command.done:
+		return nil
+	case <-runtime.done:
+		return errConsumerRuntimeClosed
+	}
+}
+
+func (runtime *consumerRuntime) init() (created bool, err error) {
+	err = runtime.execute(func(session *consumerSession) {
+		session.wanted = true
+		if session.consumer != nil {
+			return
+		}
+		created = true
+		err = session.open()
+	})
+	return
+}
+
+func (runtime *consumerRuntime) assignment(wait time.Duration) (partitions []kafka.TopicPartition, epoch uint64, err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		if session.consumer == nil {
+			err = errConsumerNotStarted
+			return
+		}
+		deadline := time.Now().Add(wait)
+		for {
+			select {
+			case <-session.runtime.stop:
+				err = errConsumerRuntimeClosed
+				epoch = session.epoch
+				return
+			default:
+			}
+			partitions, err = session.consumer.Assignment()
+			if err != nil || len(partitions) > 0 || wait <= 0 || !time.Now().Before(deadline) {
+				epoch = session.epoch
+				return
+			}
+			remaining := time.Until(deadline)
+			if remaining > consumerAssignmentPollInterval {
+				remaining = consumerAssignmentPollInterval
+			}
+			message, pollErr := session.poll(remaining)
+			if message != nil {
+				session.pending = append(session.pending, message)
+			}
+			if pollErr != nil && !isKafkaTimeout(pollErr) {
+				err = pollErr
+				epoch = session.epoch
+				return
+			}
+		}
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) readMessage(timeout time.Duration, expectedEpoch uint64) (message *kafka.Message, err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		if err = session.validateEpoch(expectedEpoch); err != nil {
+			return
+		}
+		if len(session.pending) > 0 {
+			message = session.pending[0]
+			session.pending = session.pending[1:]
+			return
+		}
+		message, err = session.poll(timeout)
+		if epochErr := session.validateEpoch(expectedEpoch); epochErr != nil {
+			if message != nil {
+				session.pending = append([]*kafka.Message{message}, session.pending...)
+				message = nil
+			}
+			err = epochErr
+		}
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) queryWatermarkOffsets(topic string, partition int32, timeoutMs int, expectedEpoch uint64) (low, high int64, err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		if err = session.validateEpoch(expectedEpoch); err != nil {
+			return
+		}
+		low, high, err = session.consumer.QueryWatermarkOffsets(topic, partition, timeoutMs)
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) committed(partitions []kafka.TopicPartition, timeoutMs int, expectedEpoch uint64) (offsets []kafka.TopicPartition, err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		if err = session.validateEpoch(expectedEpoch); err != nil {
+			return
+		}
+		offsets, err = session.consumer.Committed(partitions, timeoutMs)
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) seekPartitions(partitions []kafka.TopicPartition, expectedEpoch uint64) (result []kafka.TopicPartition, err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		if err = session.validateEpoch(expectedEpoch); err != nil {
+			return
+		}
+		result, err = session.consumer.SeekPartitions(partitions)
+		if err == nil {
+			session.discardPending(result)
+		}
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) commitMessage(message *kafka.Message, expectedEpoch uint64) (result []kafka.TopicPartition, err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		if err = session.validateEpoch(expectedEpoch); err != nil {
+			return
+		}
+		result, err = session.consumer.CommitMessage(message)
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) groupMetadata(expectedEpoch uint64) (metadata *kafka.ConsumerGroupMetadata, err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		if err = session.validateEpoch(expectedEpoch); err != nil {
+			return
+		}
+		metadata, err = session.consumer.GetConsumerGroupMetadata()
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) pause() (err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		err = session.setPaused(true)
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) resume() (err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		err = session.setPaused(false)
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) suspend() (err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		session.wanted = false
+		session.pauseRequested = false
+		err = session.closeCurrent()
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) restart(beforeOpen func()) (err error) {
+	executeErr := runtime.execute(func(session *consumerSession) {
+		session.wanted = true
+		if closeErr := session.closeCurrent(); closeErr != nil {
+			runtime.hooks.errorf("Failed to close Kafka consumer before restart: %v", closeErr)
+		}
+		if beforeOpen != nil {
+			beforeOpen()
+		}
+		err = session.open()
+	})
+	if executeErr != nil {
+		err = executeErr
+	}
+	return
+}
+
+func (runtime *consumerRuntime) description() string {
+	description := "not started"
+	_ = runtime.execute(func(session *consumerSession) {
+		if session.consumer != nil {
+			description = session.consumer.String()
+		}
+	})
+	return description
+}
+
+func (runtime *consumerRuntime) close() error {
+	runtime.start()
+	runtime.stopOnce.Do(func() { close(runtime.stop) })
+	<-runtime.done
+	return runtime.closeErr
+}
+
+func (session *consumerSession) open() error {
+	if session.consumer != nil {
+		return nil
+	}
+	consumer, err := session.runtime.factory(&session.runtime.config)
+	if err != nil {
+		session.scheduleReconnect()
+		return err
+	}
+	if err = consumer.SubscribeTopics([]string{session.runtime.topic}, func(_ *kafka.Consumer, event kafka.Event) error {
+		if session.closing {
+			return nil
+		}
+		session.rebalanceLost, session.rebalanceErr = session.handleRebalance(event)
+		return session.rebalanceErr
+	}); err != nil {
+		_ = consumer.Close()
+		session.scheduleReconnect()
+		return err
+	}
+	session.consumer = consumer
+	session.pauseApplied = false
+	session.pending = nil
+	session.reconnectAt = time.Time{}
+	session.reconnectBackoff = 0
+	session.runtime.hooks.infof("Consumer created: %s", consumer.String())
+	return nil
+}
+
+func (session *consumerSession) closeCurrent() error {
+	consumer := session.consumer
+	if consumer == nil {
+		return nil
+	}
+	description := consumer.String()
+	session.closing = true
+	session.consumer = nil
+	session.pending = nil
+	session.pauseApplied = false
+	session.epoch++
+	unsubscribeErr := consumer.Unsubscribe()
+	closeErr := consumer.Close()
+	session.closing = false
+	session.rebalanceLost, session.rebalanceErr = false, nil
+	session.runtime.hooks.infof("Consumer closed: %s unsubscribe: %v close: %v", description, unsubscribeErr, closeErr)
+	return closeErr
+}
+
+func (session *consumerSession) maintain() {
+	if session.consumer == nil {
+		if session.wanted && (session.reconnectAt.IsZero() || !time.Now().Before(session.reconnectAt)) {
+			if err := session.open(); err != nil {
+				session.runtime.hooks.errorf("Failed to recreate Kafka consumer: %v", err)
+			}
+		}
+		return
+	}
+	if !session.pauseRequested {
+		return
+	}
+	if !session.pauseApplied {
+		if err := session.applyPause(); err != nil {
+			session.runtime.hooks.errorf("Failed to pause Kafka consumer during maintenance: %v", err)
+		}
+	}
+	message, err := session.poll(0)
+	if message != nil {
+		session.pending = append(session.pending, message)
+	}
+	if err != nil && !isKafkaTimeout(err) {
+		session.runtime.hooks.errorf("Error while polling paused Kafka consumer: %v", err)
+	}
+}
+
+func (session *consumerSession) poll(timeout time.Duration) (*kafka.Message, error) {
+	if session.consumer == nil {
+		return nil, errConsumerNotStarted
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		timeoutMs := int(timeout / time.Millisecond)
+		if timeout > 0 {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return nil, kafka.NewError(kafka.ErrTimedOut, "consumer poll timed out", false)
+			}
+			timeoutMs = int(remaining / time.Millisecond)
+			if timeoutMs == 0 {
+				timeoutMs = 1
+			}
+		}
+		event := session.consumer.Poll(timeoutMs)
+		rebalanceLost, rebalanceErr := session.rebalanceLost, session.rebalanceErr
+		session.rebalanceLost, session.rebalanceErr = false, nil
+		if rebalanceLost || rebalanceErr != nil {
+			if err := session.recreate(); err != nil {
+				session.runtime.hooks.errorf("Failed to recreate Kafka consumer after rebalance failure: %v", err)
+			}
+			if rebalanceErr != nil {
+				return nil, fmt.Errorf("failed to apply Kafka rebalance: %w", rebalanceErr)
+			}
+			return nil, errConsumerAssignmentChanged
+		}
+		switch value := event.(type) {
+		case *kafka.Message:
+			if value.TopicPartition.Error != nil {
+				var kafkaErr kafka.Error
+				if errors.As(value.TopicPartition.Error, &kafkaErr) {
+					session.handleKafkaError(kafkaErr)
+				}
+				return nil, value.TopicPartition.Error
+			}
+			return value, nil
+		case kafka.AssignedPartitions:
+			lost, err := session.handleRebalance(value)
+			if err != nil || lost {
+				if recreateErr := session.recreate(); recreateErr != nil {
+					session.runtime.hooks.errorf("Failed to recreate Kafka consumer after rebalance failure: %v", recreateErr)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to apply Kafka rebalance: %w", err)
+				}
+				return nil, errConsumerAssignmentChanged
+			}
+		case kafka.RevokedPartitions:
+			lost, err := session.handleRebalance(value)
+			if err != nil || lost {
+				if recreateErr := session.recreate(); recreateErr != nil {
+					session.runtime.hooks.errorf("Failed to recreate Kafka consumer after rebalance failure: %v", recreateErr)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to apply Kafka rebalance: %w", err)
+				}
+				return nil, errConsumerAssignmentChanged
+			}
+		case kafka.Error:
+			session.handleKafkaError(value)
+			return nil, value
+		case nil:
+			return nil, kafka.NewError(kafka.ErrTimedOut, "consumer poll timed out", false)
+		}
+		if timeout == 0 {
+			return nil, nil
+		}
+	}
+}
+
+func (session *consumerSession) handleKafkaError(kafkaErr kafka.Error) {
+	session.runtime.hooks.onKafkaError(kafkaErr)
+	if shouldRecreateConsumer(kafkaErr) {
+		if err := session.recreate(); err != nil {
+			session.runtime.hooks.errorf("Failed to recreate Kafka consumer: %v", err)
+		}
+	}
+}
+
+func (session *consumerSession) handleRebalance(event kafka.Event) (lost bool, err error) {
+	switch value := event.(type) {
+	case kafka.AssignedPartitions:
+		err = session.onAssigned(value.Partitions)
+	case kafka.RevokedPartitions:
+		lost, err = session.onRevoked(value.Partitions)
+	default:
+		err = fmt.Errorf("unexpected Kafka rebalance event: %T", event)
+	}
+	return
+}
+
+func (session *consumerSession) onAssigned(partitions []kafka.TopicPartition) error {
+	session.epoch++
+	session.pending = nil
+	var err error
+	if session.consumer.GetRebalanceProtocol() == "COOPERATIVE" {
+		err = session.consumer.IncrementalAssign(partitions)
+	} else {
+		err = session.consumer.Assign(partitions)
+	}
+	if err != nil {
+		return err
+	}
+	session.pauseApplied = false
+	if session.pauseRequested && len(partitions) > 0 {
+		if err := session.consumer.Pause(partitions); err != nil {
+			return err
+		}
+		session.pauseApplied = true
+	}
+	session.runtime.hooks.debugf("Consumer assigned partitions at epoch %d: %v", session.epoch, partitions)
+	return nil
+}
+
+func (session *consumerSession) onRevoked(partitions []kafka.TopicPartition) (lost bool, err error) {
+	lost = session.consumer.AssignmentLost()
+	session.epoch++
+	session.pending = nil
+	if session.consumer.GetRebalanceProtocol() == "COOPERATIVE" {
+		err = session.consumer.IncrementalUnassign(partitions)
+	} else {
+		err = session.consumer.Unassign()
+	}
+	if err != nil {
+		session.runtime.hooks.errorf("Failed to unassign revoked partitions: %v", err)
+	}
+	session.pauseApplied = false
+	if lost {
+		session.runtime.hooks.onKafkaError(kafka.NewError(kafka.ErrUnknownMemberID, "partition assignment lost during rebalance", false))
+	}
+	session.runtime.hooks.debugf("Consumer revoked partitions at epoch %d: %v", session.epoch, partitions)
+	return
+}
+
+func (session *consumerSession) setPaused(paused bool) error {
+	if session.consumer == nil {
+		return errConsumerNotStarted
+	}
+	if session.pauseRequested == paused && session.pauseApplied == paused {
+		return nil
+	}
+	session.pauseRequested = paused
+	if paused {
+		return session.applyPause()
+	}
+	partitions, err := session.consumer.Assignment()
+	if err != nil {
+		return err
+	}
+	if len(partitions) > 0 {
+		if err = session.consumer.Resume(partitions); err != nil {
+			return err
+		}
+	}
+	session.pauseApplied = false
+	return nil
+}
+
+func (session *consumerSession) applyPause() error {
+	partitions, err := session.consumer.Assignment()
+	if err != nil {
+		return err
+	}
+	if len(partitions) == 0 {
+		session.pauseApplied = false
+		return nil
+	}
+	if err = session.consumer.Pause(partitions); err != nil {
+		return err
+	}
+	session.pauseApplied = true
+	return nil
+}
+
+func (session *consumerSession) discardPending(partitions []kafka.TopicPartition) {
+	type partitionKey struct {
+		topic     string
+		partition int32
+	}
+	targets := make(map[partitionKey]struct{}, len(partitions))
+	for _, partition := range partitions {
+		if partition.Error == nil && partition.Topic != nil {
+			targets[partitionKey{topic: *partition.Topic, partition: partition.Partition}] = struct{}{}
+		}
+	}
+	kept := session.pending[:0]
+	for _, message := range session.pending {
+		if message == nil || message.TopicPartition.Topic == nil {
+			kept = append(kept, message)
+			continue
+		}
+		key := partitionKey{topic: *message.TopicPartition.Topic, partition: message.TopicPartition.Partition}
+		if _, discard := targets[key]; !discard {
+			kept = append(kept, message)
+		}
+	}
+	session.pending = kept
+}
+
+func (session *consumerSession) validateEpoch(expected uint64) error {
+	if session.consumer == nil {
+		return errConsumerNotStarted
+	}
+	if expected != session.epoch {
+		return fmt.Errorf("%w: expected epoch %d, current epoch %d", errConsumerAssignmentChanged, expected, session.epoch)
+	}
+	return nil
+}
+
+func (session *consumerSession) recreate() error {
+	session.wanted = true
+	if err := session.closeCurrent(); err != nil {
+		session.runtime.hooks.errorf("Failed to close unusable Kafka consumer: %v", err)
+	}
+	return session.open()
+}
+
+func (session *consumerSession) scheduleReconnect() {
+	if session.reconnectBackoff == 0 {
+		session.reconnectBackoff = time.Second
+	} else {
+		session.reconnectBackoff *= 2
+		if session.reconnectBackoff > consumerReconnectMaxBackoff {
+			session.reconnectBackoff = consumerReconnectMaxBackoff
+		}
+	}
+	session.reconnectAt = time.Now().Add(session.reconnectBackoff)
+}
+
+func shouldRecreateConsumer(kafkaErr kafka.Error) bool {
+	return kafkaErr.Code() != kafka.ErrTimedOut && (kafkaErr.IsFatal() || !kafkaErr.IsRetriable())
+}
+
+func isKafkaTimeout(err error) bool {
+	var kafkaErr kafka.Error
+	return errors.As(err, &kafkaErr) && kafkaErr.Code() == kafka.ErrTimedOut
+}

--- a/bulker/bulkerapp/app/kafka_consumer_runtime_test.go
+++ b/bulker/bulkerapp/app/kafka_consumer_runtime_test.go
@@ -1,0 +1,489 @@
+package app
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeGroupConsumer struct {
+	mu sync.Mutex
+
+	events         chan kafka.Event
+	assignment     []kafka.TopicPartition
+	paused         bool
+	closed         bool
+	assignmentLost bool
+	protocol       string
+	pauseErr       error
+	rebalanceCb    kafka.RebalanceCb
+	pollCount      atomic.Int64
+	closeCount     atomic.Int64
+	inCallback     atomic.Bool
+	closedInCb     atomic.Bool
+}
+
+func newFakeGroupConsumer() *fakeGroupConsumer {
+	return &fakeGroupConsumer{events: make(chan kafka.Event, 16)}
+}
+
+func (consumer *fakeGroupConsumer) SubscribeTopics(_ []string, rebalanceCb kafka.RebalanceCb) error {
+	consumer.rebalanceCb = rebalanceCb
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) Poll(timeoutMs int) kafka.Event {
+	consumer.pollCount.Add(1)
+	if timeoutMs <= 0 {
+		select {
+		case event := <-consumer.events:
+			return consumer.deliver(event)
+		default:
+			return nil
+		}
+	}
+	timer := time.NewTimer(time.Duration(timeoutMs) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case event := <-consumer.events:
+		return consumer.deliver(event)
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (consumer *fakeGroupConsumer) deliver(event kafka.Event) kafka.Event {
+	if consumer.rebalanceCb != nil {
+		switch event.(type) {
+		case kafka.AssignedPartitions, kafka.RevokedPartitions:
+			consumer.inCallback.Store(true)
+			_ = consumer.rebalanceCb(nil, event)
+			consumer.inCallback.Store(false)
+			return nil
+		}
+	}
+	return event
+}
+
+func (consumer *fakeGroupConsumer) Assign(partitions []kafka.TopicPartition) error {
+	consumer.mu.Lock()
+	defer consumer.mu.Unlock()
+	consumer.assignment = append([]kafka.TopicPartition(nil), partitions...)
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) Unassign() error {
+	consumer.mu.Lock()
+	defer consumer.mu.Unlock()
+	consumer.assignment = nil
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) IncrementalAssign(partitions []kafka.TopicPartition) error {
+	consumer.mu.Lock()
+	defer consumer.mu.Unlock()
+	consumer.assignment = append(consumer.assignment, partitions...)
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) IncrementalUnassign(partitions []kafka.TopicPartition) error {
+	consumer.mu.Lock()
+	defer consumer.mu.Unlock()
+	removed := make(map[int32]struct{}, len(partitions))
+	for _, partition := range partitions {
+		removed[partition.Partition] = struct{}{}
+	}
+	kept := consumer.assignment[:0]
+	for _, partition := range consumer.assignment {
+		if _, ok := removed[partition.Partition]; !ok {
+			kept = append(kept, partition)
+		}
+	}
+	consumer.assignment = kept
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) GetRebalanceProtocol() string {
+	if consumer.protocol == "" {
+		return "EAGER"
+	}
+	return consumer.protocol
+}
+
+func (consumer *fakeGroupConsumer) Assignment() ([]kafka.TopicPartition, error) {
+	consumer.mu.Lock()
+	defer consumer.mu.Unlock()
+	return append([]kafka.TopicPartition(nil), consumer.assignment...), nil
+}
+
+func (consumer *fakeGroupConsumer) AssignmentLost() bool { return consumer.assignmentLost }
+
+func (consumer *fakeGroupConsumer) Pause([]kafka.TopicPartition) error {
+	consumer.mu.Lock()
+	defer consumer.mu.Unlock()
+	if consumer.pauseErr != nil {
+		return consumer.pauseErr
+	}
+	consumer.paused = true
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) Resume([]kafka.TopicPartition) error {
+	consumer.mu.Lock()
+	defer consumer.mu.Unlock()
+	consumer.paused = false
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) QueryWatermarkOffsets(string, int32, int) (int64, int64, error) {
+	return 0, 0, nil
+}
+
+func (consumer *fakeGroupConsumer) Committed(partitions []kafka.TopicPartition, _ int) ([]kafka.TopicPartition, error) {
+	return partitions, nil
+}
+
+func (consumer *fakeGroupConsumer) SeekPartitions(partitions []kafka.TopicPartition) ([]kafka.TopicPartition, error) {
+	return partitions, nil
+}
+
+func (consumer *fakeGroupConsumer) CommitMessage(message *kafka.Message) ([]kafka.TopicPartition, error) {
+	return []kafka.TopicPartition{message.TopicPartition}, nil
+}
+
+func (consumer *fakeGroupConsumer) GetConsumerGroupMetadata() (*kafka.ConsumerGroupMetadata, error) {
+	return nil, nil
+}
+
+func (consumer *fakeGroupConsumer) Unsubscribe() error { return nil }
+
+func (consumer *fakeGroupConsumer) Close() error {
+	consumer.closeCount.Add(1)
+	if consumer.inCallback.Load() {
+		consumer.closedInCb.Store(true)
+	}
+	consumer.mu.Lock()
+	consumer.closed = true
+	consumer.mu.Unlock()
+	return nil
+}
+
+func (consumer *fakeGroupConsumer) String() string { return "fake-consumer" }
+
+func newTestConsumerRuntime(factory groupConsumerFactory) *consumerRuntime {
+	noop := func(string, ...any) {}
+	return newConsumerRuntimeWithFactory(kafka.ConfigMap{}, "topic", consumerRuntimeHooks{
+		debugf:       noop,
+		infof:        noop,
+		errorf:       noop,
+		onKafkaError: func(kafka.Error) {},
+	}, factory, 5*time.Millisecond)
+}
+
+func TestConsumerMaintenanceInterval(t *testing.T) {
+	assert.Equal(t, 10*time.Second, consumerMaintenanceInterval(5*time.Minute))
+	assert.Equal(t, 5*time.Second, consumerMaintenanceInterval(20*time.Second))
+	assert.Equal(t, 10*time.Second, consumerMaintenanceInterval(0))
+}
+
+func assignRuntime(t *testing.T, runtime *consumerRuntime, consumer *fakeGroupConsumer) uint64 {
+	t.Helper()
+	topic := "topic"
+	consumer.events <- kafka.AssignedPartitions{Partitions: []kafka.TopicPartition{{Topic: &topic, Partition: 0}}}
+	partitions, epoch, err := runtime.assignment(100 * time.Millisecond)
+	require.NoError(t, err)
+	require.Len(t, partitions, 1)
+	return epoch
+}
+
+func TestConsumerRuntimePollsWhilePaused(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	created, err := runtime.init()
+	require.NoError(t, err)
+	require.True(t, created)
+	assignRuntime(t, runtime, consumer)
+	require.NoError(t, runtime.pause())
+	pollsBefore := consumer.pollCount.Load()
+
+	require.Eventually(t, func() bool {
+		return consumer.pollCount.Load() > pollsBefore
+	}, 100*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestConsumerRuntimeRetriesFailedPauseWhilePolling(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	assignRuntime(t, runtime, consumer)
+	pauseErr := errors.New("pause failed")
+	consumer.mu.Lock()
+	consumer.pauseErr = pauseErr
+	consumer.mu.Unlock()
+	pollsBefore := consumer.pollCount.Load()
+
+	require.ErrorIs(t, runtime.pause(), pauseErr)
+	require.Eventually(t, func() bool {
+		return consumer.pollCount.Load() > pollsBefore
+	}, 100*time.Millisecond, 5*time.Millisecond)
+	consumer.mu.Lock()
+	consumer.pauseErr = nil
+	consumer.mu.Unlock()
+	require.Eventually(t, func() bool {
+		consumer.mu.Lock()
+		defer consumer.mu.Unlock()
+		return consumer.paused
+	}, 100*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestConsumerRuntimeTreatsEmptyAssignmentAsHealthy(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	var factoryCalls atomic.Int64
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) {
+		factoryCalls.Add(1)
+		return consumer, nil
+	})
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	partitions, _, err := runtime.assignment(10 * time.Millisecond)
+	require.NoError(t, err)
+	assert.Empty(t, partitions)
+	assert.Equal(t, int64(1), factoryCalls.Load())
+}
+
+func TestConsumerRuntimeKeepsMessageReadWhileWaitingForAssignment(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	topic := "topic"
+	consumer.events <- kafka.AssignedPartitions{Partitions: []kafka.TopicPartition{{Topic: &topic, Partition: 0}}}
+	expected := &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: 0, Offset: 42}}
+	consumer.events <- expected
+
+	partitions, epoch, err := runtime.assignment(100 * time.Millisecond)
+	require.NoError(t, err)
+	require.Len(t, partitions, 1)
+	message, err := runtime.readMessage(20*time.Millisecond, epoch)
+	require.NoError(t, err)
+	assert.Same(t, expected, message)
+}
+
+func TestConsumerRuntimeRejectsOldEpochAfterRevocation(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	epoch := assignRuntime(t, runtime, consumer)
+	consumer.events <- kafka.RevokedPartitions{}
+
+	_, err = runtime.readMessage(20*time.Millisecond, epoch)
+	require.ErrorIs(t, err, errConsumerAssignmentChanged)
+	_, err = runtime.commitMessage(&kafka.Message{}, epoch)
+	require.ErrorIs(t, err, errConsumerAssignmentChanged)
+}
+
+func TestConsumerRuntimeReturnsMessagePartitionError(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	epoch := assignRuntime(t, runtime, consumer)
+	partitionErr := kafka.NewError(kafka.ErrTimedOut, "partition fetch timed out", false)
+	consumer.events <- &kafka.Message{TopicPartition: kafka.TopicPartition{Error: partitionErr}}
+
+	message, err := runtime.readMessage(20*time.Millisecond, epoch)
+	assert.Nil(t, message)
+	require.Error(t, err)
+	var kafkaErr kafka.Error
+	require.ErrorAs(t, err, &kafkaErr)
+	assert.Equal(t, kafka.ErrTimedOut, kafkaErr.Code())
+}
+
+func TestConsumerRuntimeKeepsMessageReadAfterRebalance(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	oldEpoch := assignRuntime(t, runtime, consumer)
+	topic := "topic"
+	partitions := []kafka.TopicPartition{{Topic: &topic, Partition: 0}}
+	consumer.events <- kafka.RevokedPartitions{Partitions: partitions}
+	consumer.events <- kafka.AssignedPartitions{Partitions: partitions}
+	expected := &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: 0, Offset: 42}}
+	consumer.events <- expected
+
+	message, err := runtime.readMessage(100*time.Millisecond, oldEpoch)
+	require.ErrorIs(t, err, errConsumerAssignmentChanged)
+	assert.Nil(t, message)
+
+	assigned, newEpoch, err := runtime.assignment(100 * time.Millisecond)
+	require.NoError(t, err)
+	require.Len(t, assigned, 1)
+	message, err = runtime.readMessage(20*time.Millisecond, newEpoch)
+	require.NoError(t, err)
+	assert.Same(t, expected, message)
+}
+
+func TestConsumerRuntimeDiscardsPendingMessagesAfterSeek(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	epoch := assignRuntime(t, runtime, consumer)
+	topic := "topic"
+	stale := &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: 0, Offset: 11}}
+	require.NoError(t, runtime.execute(func(session *consumerSession) {
+		session.pending = append(session.pending, stale)
+	}))
+
+	_, err = runtime.seekPartitions([]kafka.TopicPartition{{Topic: &topic, Partition: 0, Offset: 10}}, epoch)
+	require.NoError(t, err)
+	expected := &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: 0, Offset: 10}}
+	consumer.events <- expected
+	message, err := runtime.readMessage(20*time.Millisecond, epoch)
+	require.NoError(t, err)
+	assert.Same(t, expected, message)
+}
+
+func TestConsumerRuntimeRecreatesFatalConsumerInsideOwnerLoop(t *testing.T) {
+	first := newFakeGroupConsumer()
+	second := newFakeGroupConsumer()
+	consumers := []groupConsumer{first, second}
+	var factoryCalls atomic.Int64
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) {
+		index := int(factoryCalls.Add(1)) - 1
+		if index >= len(consumers) {
+			return nil, errors.New("unexpected extra consumer creation")
+		}
+		return consumers[index], nil
+	})
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	epoch := assignRuntime(t, runtime, first)
+	first.events <- kafka.NewError(kafka.ErrFatal, "fatal consumer failure", true)
+
+	_, err = runtime.readMessage(20*time.Millisecond, epoch)
+	require.Error(t, err)
+	assert.Equal(t, int64(2), factoryCalls.Load())
+	assert.Equal(t, int64(1), first.closeCount.Load())
+	assert.Equal(t, "fake-consumer", runtime.description())
+}
+
+func TestConsumerRuntimeKeepsReplacementPaused(t *testing.T) {
+	first := newFakeGroupConsumer()
+	second := newFakeGroupConsumer()
+	consumers := []groupConsumer{first, second}
+	var factoryCalls atomic.Int64
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) {
+		return consumers[int(factoryCalls.Add(1))-1], nil
+	})
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	assignRuntime(t, runtime, first)
+	require.NoError(t, runtime.pause())
+	first.events <- kafka.NewError(kafka.ErrFatal, "fatal consumer failure", true)
+
+	require.Eventually(t, func() bool {
+		return factoryCalls.Load() == 2
+	}, 100*time.Millisecond, 5*time.Millisecond)
+	topic := "topic"
+	second.events <- kafka.AssignedPartitions{Partitions: []kafka.TopicPartition{{Topic: &topic, Partition: 0}}}
+	require.Eventually(t, func() bool {
+		second.mu.Lock()
+		defer second.mu.Unlock()
+		return second.paused
+	}, 100*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestConsumerRuntimeRecreatesConsumerAfterAssignmentIsLost(t *testing.T) {
+	first := newFakeGroupConsumer()
+	first.assignmentLost = true
+	second := newFakeGroupConsumer()
+	consumers := []groupConsumer{first, second}
+	var factoryCalls atomic.Int64
+	var membershipErrors atomic.Int64
+	noop := func(string, ...any) {}
+	runtime := newConsumerRuntimeWithFactory(kafka.ConfigMap{}, "topic", consumerRuntimeHooks{
+		debugf: noop,
+		infof:  noop,
+		errorf: noop,
+		onKafkaError: func(err kafka.Error) {
+			if err.Code() == kafka.ErrUnknownMemberID {
+				membershipErrors.Add(1)
+			}
+		},
+	}, func(*kafka.ConfigMap) (groupConsumer, error) {
+		return consumers[int(factoryCalls.Add(1))-1], nil
+	}, 5*time.Millisecond)
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	epoch := assignRuntime(t, runtime, first)
+	first.events <- kafka.RevokedPartitions{}
+
+	_, err = runtime.readMessage(20*time.Millisecond, epoch)
+	require.ErrorIs(t, err, errConsumerAssignmentChanged)
+	assert.Equal(t, int64(2), factoryCalls.Load())
+	assert.Equal(t, int64(1), first.closeCount.Load())
+	assert.Equal(t, int64(1), membershipErrors.Load())
+	assert.False(t, first.closedInCb.Load())
+}
+
+func TestConsumerRuntimeSupportsCooperativeRebalances(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	consumer.protocol = "COOPERATIVE"
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+	t.Cleanup(func() { require.NoError(t, runtime.close()) })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	epoch := assignRuntime(t, runtime, consumer)
+	topic := "topic"
+	consumer.events <- kafka.RevokedPartitions{Partitions: []kafka.TopicPartition{{Topic: &topic, Partition: 0}}}
+
+	_, err = runtime.readMessage(20*time.Millisecond, epoch)
+	require.ErrorIs(t, err, errConsumerAssignmentChanged)
+	partitions, _, err := runtime.assignment(0)
+	require.NoError(t, err)
+	assert.Empty(t, partitions)
+}
+
+func TestConsumerRuntimeClosesConsumerExactlyOnce(t *testing.T) {
+	consumer := newFakeGroupConsumer()
+	runtime := newTestConsumerRuntime(func(*kafka.ConfigMap) (groupConsumer, error) { return consumer, nil })
+
+	_, err := runtime.init()
+	require.NoError(t, err)
+	require.NoError(t, runtime.close())
+	require.NoError(t, runtime.close())
+	assert.Equal(t, int64(1), consumer.closeCount.Load())
+}

--- a/bulker/bulkerapp/app/retry_consumer.go
+++ b/bulker/bulkerapp/app/retry_consumer.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -31,7 +32,7 @@ func NewRetryConsumer(repository *Repository, destinationId string, batchPeriodS
 	return &rc, nil
 }
 
-func (rc *RetryConsumer) shouldConsumeFuncImpl(partitionId int32, committedOffset, highOffset int64) bool {
+func (rc *RetryConsumer) shouldConsumeFuncImpl(partitionId int32, committedOffset, highOffset int64, consumerEpoch uint64) bool {
 	var firstPosition *kafka.TopicPartition
 	defer func() {
 		//recover
@@ -39,7 +40,7 @@ func (rc *RetryConsumer) shouldConsumeFuncImpl(partitionId int32, committedOffse
 			rc.SystemErrorf("Recovered from panic: %v", r)
 		}
 		if firstPosition != nil {
-			_, err := rc.consumer.Load().SeekPartitions([]kafka.TopicPartition{*firstPosition})
+			_, err := rc.consumer.seekPartitions([]kafka.TopicPartition{*firstPosition}, consumerEpoch)
 			if err != nil {
 				rc.SystemErrorf("Failed to seek to first position: %v", err)
 				//rc.restartConsumer()
@@ -48,10 +49,10 @@ func (rc *RetryConsumer) shouldConsumeFuncImpl(partitionId int32, committedOffse
 	}()
 	currentOffset := committedOffset
 	for currentOffset < highOffset {
-		message, err := rc.consumer.Load().ReadMessage(rc.waitForMessages)
+		message, err := rc.consumer.readMessage(rc.waitForMessages, consumerEpoch)
 		if err != nil {
-			kafkaErr := err.(kafka.Error)
-			if kafkaErr.Code() == kafka.ErrTimedOut {
+			var kafkaErr kafka.Error
+			if errors.As(err, &kafkaErr) && kafkaErr.Code() == kafka.ErrTimedOut {
 				rc.Debugf("Timeout. No messages to retry. %d-%d", committedOffset, highOffset)
 				return false
 			}
@@ -84,7 +85,7 @@ func (rc *RetryConsumer) batchSizes(_ *bulker.StreamOptions) (_, _, retryBatchSi
 
 }
 
-func (rc *RetryConsumer) processBatchImpl(_ *Destination, _, _, _, retryBatchSize int, highOffset int64, updatedHighOffset int) (counters BatchCounters, state bulker.State, nextBatch bool, err error) {
+func (rc *RetryConsumer) processBatchImpl(_ *Destination, _, _, _, retryBatchSize int, highOffset int64, updatedHighOffset int, consumerEpoch uint64) (counters BatchCounters, state bulker.State, nextBatch bool, err error) {
 	counters.firstOffset = int64(kafka.OffsetBeginning)
 
 	var firstPosition *kafka.TopicPartition
@@ -104,7 +105,7 @@ func (rc *RetryConsumer) processBatchImpl(_ *Destination, _, _, _, retryBatchSiz
 			counters.retryScheduled = 0
 			//cleanup
 			if firstPosition != nil {
-				_, err2 := rc.consumer.Load().SeekPartitions([]kafka.TopicPartition{*firstPosition})
+				_, err2 := rc.consumer.seekPartitions([]kafka.TopicPartition{*firstPosition}, consumerEpoch)
 				if err2 != nil {
 					rc.SystemErrorf("Failed to seek to first position: %v", err2)
 					//rc.restartConsumer()
@@ -131,23 +132,22 @@ func (rc *RetryConsumer) processBatchImpl(_ *Destination, _, _, _, retryBatchSiz
 			// we reached the end of the topic
 			break
 		}
-		message, err := rc.consumer.Load().ReadMessage(rc.waitForMessages)
+		message, err := rc.consumer.readMessage(rc.waitForMessages, consumerEpoch)
 		if err != nil {
-			kafkaErr := err.(kafka.Error)
-			if kafkaErr.Code() == kafka.ErrTimedOut {
+			var kafkaErr kafka.Error
+			if errors.As(err, &kafkaErr) && kafkaErr.Code() == kafka.ErrTimedOut {
 				nextBatch = false
 				// waitForMessages period is over. it's ok. considering batch as full
 				break
 			}
-			rc.onReadError(kafkaErr)
-			return counters, state, false, rc.NewError("Failed to consume event from topic. Retryable: %t: %v", kafkaErr.IsRetriable(), kafkaErr)
+			return counters, state, false, rc.NewError("Failed to consume event from topic: %v", err)
 		}
 		if firstPosition != nil && message.TopicPartition.Partition != firstPosition.Partition {
 			// partition assignment may change in the middle of consumption (rebalance)
 			// all messages in the batch must belong to a single partition to commit their offsets atomically.
 			// seek the foreign message back so it is re-read later and commit what was already consumed
 			rc.Infof("Got message from partition %d while consuming partition %d. Stopping batch", message.TopicPartition.Partition, firstPosition.Partition)
-			_, seekErr := rc.consumer.Load().SeekPartitions([]kafka.TopicPartition{message.TopicPartition})
+			_, seekErr := rc.consumer.seekPartitions([]kafka.TopicPartition{message.TopicPartition}, consumerEpoch)
 			if seekErr != nil {
 				rc.SystemErrorf("Failed to seek back message from partition %d: %v", message.TopicPartition.Partition, seekErr)
 			}
@@ -217,7 +217,7 @@ func (rc *RetryConsumer) processBatchImpl(_ *Destination, _, _, _, retryBatchSiz
 	if !txOpened {
 		return
 	}
-	groupMetadata, err := rc.consumer.Load().GetConsumerGroupMetadata()
+	groupMetadata, err := rc.consumer.groupMetadata(consumerEpoch)
 	if err != nil {
 		return counters, state, false, fmt.Errorf("failed to get consumer group metadata: %v", err)
 	}


### PR DESCRIPTION
## Summary

- replace overlapping heartbeat, pointer-swap, and restart coordination with one group-aware runtime shared by batch and retry consumers
- serialize all Kafka consumer operations in one owner goroutine and model assignment changes with epochs
- treat empty assignments as healthy shared-group members and use dynamic membership to avoid static-member fencing
- keep paused members polling, retry failed pause application, and recreate unusable sessions inside the owner loop
- prevent stale buffered records from surviving seeks and reject commits from obsolete assignment epochs

## Safety details

- a synchronous rebalance callback applies eager or cooperative assignment changes inside Poll; recreation happens only after the callback unwinds
- records observed during assignment waits or epoch transitions are retained for the valid epoch
- partition-scoped Kafka errors follow the same metrics and recreation policy as consumer errors
- batch destination completion can replay after a rebalance, but cannot commit through a replacement group generation

## Stack

This is an architectural follow-up to #1494, which remains the immediate containment fix for JITSU-214. The PR is based on that branch so this review contains only the runtime refactor.

## Test plan

- go test -race ./bulkerapp/app -run Test\(ConsumerRuntime\|ConsumerMaintenance\|MembershipLossReason\) -count=1
- go test ./bulkerapp/... -run ^$ -count=1
- go vet ./bulkerapp/...
- go test ./bulkerapp/app -run ^\(TestGoodAndBadStreams\|TestBatchSizeBytes\|TestEventsRetry\)$ -count=1 -timeout=15m