### PR TITLE
JITSU-179 Validate Bulker SQL type hints

### DIFF
--- a/bulker/README.md
+++ b/bulker/README.md
@@ -23,7 +23,9 @@ Send a JSON object to Bulker, and it will make sure the object is saved to the d
 - **JSON flattening.** Your object is flattened — `{a: {b: 1}}` becomes `{a_b: 1}`.
 - **Schema management for semi-structured data.** For each field, Bulker makes sure a corresponding
   column exists in the destination table, and creates it if not. The type is best-guessed from the
-  value, or set explicitly with a type hint: `{"a": "test", "__sql_type_a": "varchar(4)"}`.
+  value, or set explicitly with a type hint: `{"a": "test", "__sql_type_a": "varchar(4)"}`. Type
+  hints must match the destination driver's supported type allowlist; SQL clauses and expressions
+  are ignored.
 - **Reliability.** The object goes to a Kafka queue immediately, so if the warehouse is down, data
   isn't lost.
 - **Streaming or batching.** Data goes to the warehouse either as soon as it's available in Kafka

--- a/bulker/bulkerlib/implementations/sql/abstract.go
+++ b/bulker/bulkerlib/implementations/sql/abstract.go
@@ -137,6 +137,7 @@ func (ps *AbstractSQLStream) preprocess(object types.Object, skipTypeHints bool)
 		if err != nil {
 			return nil, nil, err
 		}
+		sqlTypesHints = filterSQLTypesHints(ps.sqlAdapter.Type(), sqlTypesHints)
 	}
 	if len(ps.customTypes) > 0 {
 		if sqlTypesHints == nil {

--- a/bulker/bulkerlib/implementations/sql/processor.go
+++ b/bulker/bulkerlib/implementations/sql/processor.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"fmt"
 	"github.com/jitsucom/bulker/bulkerlib/implementations"
 	"github.com/jitsucom/bulker/bulkerlib/types"
 	types2 "github.com/jitsucom/bulker/jitsubase/types"
@@ -22,6 +21,7 @@ func ProcessEvents(tableName string, event types.Object, customTypes types.SQLTy
 		if err != nil {
 			return nil, nil, err
 		}
+		sqlTypesHints = filterSQLTypesHintsForAnyDriver(sqlTypesHints)
 	}
 	if len(customTypes) > 0 {
 		if sqlTypesHints == nil {
@@ -71,17 +71,8 @@ func _extractSQLTypesHints(key string, object types.Object, result types.SQLType
 			//when columnName is empty it means that provided sql type is meant for the whole object
 			//e.g. to map nested object to sql JSON type you can add the following property to nested object: "__sql_type_": "JSON" )
 			mappedColumnName := utils.JoinNonEmptyStrings("_", key, columnName)
-			switch val := v.(type) {
-			case []any:
-				if len(val) > 1 {
-					result[mappedColumnName] = types.SQLColumn{Type: fmt.Sprint(val[0]), DdlType: fmt.Sprint(val[1]), Override: true}
-				} else {
-					result[mappedColumnName] = types.SQLColumn{Type: fmt.Sprint(val[0]), Override: true}
-				}
-			case string:
-				result[mappedColumnName] = types.SQLColumn{Type: val, Override: true}
-			default:
-				return fmt.Errorf("incorrect type of value for '__sql_type_' hint: %T", v)
+			if hint, ok := parseSQLTypeHint(v); ok {
+				result[mappedColumnName] = hint
 			}
 		} else if val, ok := v.(types.Object); ok {
 			err := _extractSQLTypesHints(utils.JoinNonEmptyStrings("_", key, k), val, result)
@@ -92,6 +83,44 @@ func _extractSQLTypesHints(key string, object types.Object, result types.SQLType
 	}
 
 	return nil
+}
+
+func parseSQLTypeHint(value any) (types.SQLColumn, bool) {
+	switch value := value.(type) {
+	case string:
+		if value == "" {
+			return types.SQLColumn{}, false
+		}
+		return types.SQLColumn{Type: value, Override: true}, true
+	case []any:
+		values := make([]string, len(value))
+		for i, item := range value {
+			stringValue, ok := item.(string)
+			if !ok {
+				return types.SQLColumn{}, false
+			}
+			values[i] = stringValue
+		}
+		return parseSQLTypeHintArray(values)
+	case []string:
+		return parseSQLTypeHintArray(value)
+	default:
+		return types.SQLColumn{}, false
+	}
+}
+
+func parseSQLTypeHintArray(value []string) (types.SQLColumn, bool) {
+	if len(value) < 1 || len(value) > 2 || value[0] == "" {
+		return types.SQLColumn{}, false
+	}
+	hint := types.SQLColumn{Type: value[0], Override: true}
+	if len(value) == 2 {
+		if value[1] == "" {
+			return types.SQLColumn{}, false
+		}
+		hint.DdlType = value[1]
+	}
+	return hint, true
 }
 
 //

--- a/bulker/bulkerlib/implementations/sql/sql_type_hints.go
+++ b/bulker/bulkerlib/implementations/sql/sql_type_hints.go
@@ -1,0 +1,126 @@
+package sql
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/jitsucom/bulker/bulkerlib/types"
+)
+
+var (
+	postgresSQLTypeHint  = regexp.MustCompile(`(?i)^(?:text|varchar(?:\([1-9][0-9]{0,5}\))?|character +varying(?:\([1-9][0-9]{0,5}\))?|uuid|bigint|double +precision|timestamp(?:\([0-6]\))?(?: +with(?:out)? +time +zone)?|date|boolean|jsonb?)$`)
+	mysqlSQLTypeHint     = regexp.MustCompile(`(?i)^(?:text|varchar(?:\([1-9][0-9]{0,5}\))?|bigint|double|timestamp(?:\([0-6]\))?|boolean|tinyint\(1\)|json)$`)
+	redshiftSQLTypeHint  = regexp.MustCompile(`(?i)^(?:character +varying(?:\([1-9][0-9]{0,5}\))?|varchar(?:\([1-9][0-9]{0,5}\))?|bigint|double +precision|timestamp(?:\([0-6]\))?(?: +with(?:out)? +time +zone)?|boolean|super)$`)
+	snowflakeSQLTypeHint = regexp.MustCompile(
+		`(?i)^(?:text|varchar(?:\([1-9][0-9]{0,7}\))?|bigint|number(?:\([1-9][0-9]?(?:,[0-9]{1,2})?\))?|double +precision|float|timestamp(?:_(?:tz|ntz|ltz))?(?:\([0-9]\))?|boolean|variant|object|array)$`,
+	)
+	bigquerySQLTypeHint = regexp.MustCompile(`(?i)^(?:string|bytes|integer|int64|float|float64|decimal|numeric|bigdecimal|bignumeric|boolean|bool|timestamp|record|struct|date|time|datetime|geography|interval|json|range)$`)
+	duckdbSQLTypeHint   = regexp.MustCompile(`(?i)^(?:text|varchar(?:\([1-9][0-9]{0,5}\))?|uuid|bigint|int|double|float|timestamp(?:\([0-6]\))?(?: +with(?:out)? +time +zone)?|boolean|bool|json)$`)
+
+	clickhouseScalarSQLTypeHint = regexp.MustCompile(
+		`(?i)^(?:string|fixedstring\([1-9][0-9]{0,5}\)|uuid|int(?:8|16|32|64|128|256)?|uint(?:8|16|32|64|128|256)?|float(?:32|64)?|decimal(?:32|64|128|256)?\([0-9]{1,3}(?:,[0-9]{1,3})?\)|date(?:32)?|datetime(?:64(?:\([0-9]\))?)?|json)$`,
+	)
+)
+
+var sqlTypeHintDrivers = [...]string{
+	PostgresBulkerTypeId,
+	MySQLBulkerTypeId,
+	RedshiftBulkerTypeId,
+	SnowflakeBulkerTypeId,
+	BigqueryBulkerTypeId,
+	ClickHouseBulkerTypeId,
+	DuckDBBulkerTypeId,
+}
+
+// filterSQLTypesHints removes event-provided type hints that are not valid for
+// the destination driver. Stream-level ColumnTypes options are merged after
+// this filter and are deliberately outside the __sql_type trust boundary.
+func filterSQLTypesHints(driver string, hints types.SQLTypes) types.SQLTypes {
+	for name, hint := range hints {
+		if !isSQLColumnHintAllowed(driver, hint) {
+			delete(hints, name)
+		}
+	}
+	return hints
+}
+
+// ProcessEvents predates adapter-aware processing. Keep it safe by accepting a
+// hint only when one supported driver allows both its cast and DDL types.
+func filterSQLTypesHintsForAnyDriver(hints types.SQLTypes) types.SQLTypes {
+	for name, hint := range hints {
+		allowed := false
+		for _, driver := range sqlTypeHintDrivers {
+			if isSQLColumnHintAllowed(driver, hint) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			delete(hints, name)
+		}
+	}
+	return hints
+}
+
+func isSQLColumnHintAllowed(driver string, hint types.SQLColumn) bool {
+	if !isSQLTypeHintAllowed(driver, hint.Type) {
+		return false
+	}
+	return hint.DdlType == "" || isSQLTypeHintAllowed(driver, hint.DdlType)
+}
+
+func isSQLTypeHintAllowed(driver, sqlType string) bool {
+	if sqlType == "" || sqlType != strings.TrimSpace(sqlType) {
+		return false
+	}
+	switch driver {
+	case PostgresBulkerTypeId:
+		return postgresSQLTypeHint.MatchString(sqlType)
+	case MySQLBulkerTypeId:
+		return mysqlSQLTypeHint.MatchString(sqlType)
+	case RedshiftBulkerTypeId:
+		return redshiftSQLTypeHint.MatchString(sqlType)
+	case SnowflakeBulkerTypeId:
+		return snowflakeSQLTypeHint.MatchString(sqlType)
+	case BigqueryBulkerTypeId:
+		return bigquerySQLTypeHint.MatchString(sqlType)
+	case ClickHouseBulkerTypeId:
+		return isClickHouseSQLTypeHintAllowed(sqlType)
+	case DuckDBBulkerTypeId:
+		return duckdbSQLTypeHint.MatchString(sqlType)
+	default:
+		return false
+	}
+}
+
+func isClickHouseSQLTypeHintAllowed(sqlType string) bool {
+	if clickhouseScalarSQLTypeHint.MatchString(sqlType) {
+		return true
+	}
+	if inner, ok := unwrapSQLType(sqlType, "Nullable"); ok {
+		if clickhouseScalarSQLTypeHint.MatchString(inner) {
+			return true
+		}
+		arrayInner, array := unwrapSQLType(inner, "Array")
+		return array && strings.EqualFold(arrayInner, "JSON")
+	}
+	if inner, ok := unwrapSQLType(sqlType, "LowCardinality"); ok {
+		if clickhouseScalarSQLTypeHint.MatchString(inner) {
+			return true
+		}
+		nullableInner, nullable := unwrapSQLType(inner, "Nullable")
+		return nullable && clickhouseScalarSQLTypeHint.MatchString(nullableInner)
+	}
+	if inner, ok := unwrapSQLType(sqlType, "Array"); ok {
+		return strings.EqualFold(inner, "JSON")
+	}
+	return false
+}
+
+func unwrapSQLType(sqlType, wrapper string) (string, bool) {
+	prefixLength := len(wrapper) + 1
+	if len(sqlType) <= prefixLength || !strings.EqualFold(sqlType[:len(wrapper)], wrapper) || sqlType[len(wrapper)] != '(' || sqlType[len(sqlType)-1] != ')' {
+		return "", false
+	}
+	return sqlType[prefixLength : len(sqlType)-1], true
+}

--- a/bulker/bulkerlib/implementations/sql/sql_type_hints_test.go
+++ b/bulker/bulkerlib/implementations/sql/sql_type_hints_test.go
@@ -1,0 +1,118 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/jitsucom/bulker/bulkerlib/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLTypeHintAllowlist(t *testing.T) {
+	testCases := []struct {
+		name    string
+		driver  string
+		sqlType string
+		allowed bool
+	}{
+		{name: "postgres varchar", driver: PostgresBulkerTypeId, sqlType: "varchar(4)", allowed: true},
+		{name: "postgres timestamp", driver: PostgresBulkerTypeId, sqlType: "timestamp with time zone", allowed: true},
+		{name: "mysql json", driver: MySQLBulkerTypeId, sqlType: "JSON", allowed: true},
+		{name: "redshift super", driver: RedshiftBulkerTypeId, sqlType: "super", allowed: true},
+		{name: "snowflake variant", driver: SnowflakeBulkerTypeId, sqlType: "VARIANT", allowed: true},
+		{name: "snowflake number", driver: SnowflakeBulkerTypeId, sqlType: "NUMBER(38,0)", allowed: true},
+		{name: "bigquery lowercase json", driver: BigqueryBulkerTypeId, sqlType: "json", allowed: true},
+		{name: "bigquery float", driver: BigqueryBulkerTypeId, sqlType: "FLOAT", allowed: true},
+		{name: "clickhouse float alias", driver: ClickHouseBulkerTypeId, sqlType: "FLOAT", allowed: true},
+		{name: "clickhouse nullable datetime", driver: ClickHouseBulkerTypeId, sqlType: "Nullable(DateTime64(6))", allowed: true},
+		{name: "clickhouse low cardinality nullable", driver: ClickHouseBulkerTypeId, sqlType: "LowCardinality(Nullable(Int64))", allowed: true},
+		{name: "clickhouse nullable json array", driver: ClickHouseBulkerTypeId, sqlType: "Nullable(Array(JSON))", allowed: true},
+		{name: "duckdb timestamp", driver: DuckDBBulkerTypeId, sqlType: "timestamp without time zone", allowed: true},
+
+		{name: "sql statement", driver: PostgresBulkerTypeId, sqlType: "TEXT); DROP TABLE users;--", allowed: false},
+		{name: "default expression", driver: PostgresBulkerTypeId, sqlType: "varchar(4) default text", allowed: false},
+		{name: "quoted expression", driver: ClickHouseBulkerTypeId, sqlType: "Enum8('a'=1)", allowed: false},
+		{name: "extra clickhouse clause", driver: ClickHouseBulkerTypeId, sqlType: "String DEFAULT now()", allowed: false},
+		{name: "unbalanced wrapper", driver: ClickHouseBulkerTypeId, sqlType: "Nullable(String))", allowed: false},
+		{name: "unknown wrapper", driver: ClickHouseBulkerTypeId, sqlType: "SimpleAggregateFunction(sum, Int64)", allowed: false},
+		{name: "wrong driver", driver: BigqueryBulkerTypeId, sqlType: "varchar(4)", allowed: false},
+		{name: "outer whitespace", driver: BigqueryBulkerTypeId, sqlType: " JSON", allowed: false},
+		{name: "unknown driver", driver: "unknown", sqlType: "text", allowed: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.allowed, isSQLTypeHintAllowed(testCase.driver, testCase.sqlType))
+		})
+	}
+}
+
+func TestFilterSQLTypesHints(t *testing.T) {
+	hints := types.SQLTypes{
+		"safe":         {Type: "String", Override: true},
+		"safe_pair":    {Type: "JSON", DdlType: "Nullable(JSON)", Override: true},
+		"wrong_driver": {Type: "super", Override: true},
+		"mixed_pair":   {Type: "String", DdlType: "super", Override: true},
+		"expression":   {Type: "String); DROP TABLE events;--", Override: true},
+	}
+
+	filterSQLTypesHints(ClickHouseBulkerTypeId, hints)
+
+	require.Equal(t, types.SQLTypes{
+		"safe":      {Type: "String", Override: true},
+		"safe_pair": {Type: "JSON", DdlType: "Nullable(JSON)", Override: true},
+	}, hints)
+}
+
+func TestExtractSQLTypesHintsIgnoresMalformedValues(t *testing.T) {
+	event := types.NewObject(8)
+	event.Set("safe", "value")
+	event.Set("__sql_type_safe", "JSON")
+	event.Set("__sql_type_legacy_array", []any{"super"})
+	event.Set("__sql_type_pair", []any{"String", "Nullable(String)"})
+	event.Set("__sql_type_empty", []any{})
+	event.Set("__sql_type_too_many", []any{"String", "String", "String"})
+	event.Set("__sql_type_non_string", []any{"String", 42})
+	event.Set("__sql_type_number", 42)
+
+	hints, err := extractSQLTypesHints(event)
+	require.NoError(t, err)
+	require.Equal(t, types.SQLTypes{
+		"safe":         {Type: "JSON", Override: true},
+		"legacy_array": {Type: "super", Override: true},
+		"pair":         {Type: "String", DdlType: "Nullable(String)", Override: true},
+	}, hints)
+	require.Equal(t, 1, event.Len())
+	value, ok := event.Get("safe")
+	require.True(t, ok)
+	require.Equal(t, "value", value)
+}
+
+func TestProcessEventsDropsUnsafeHint(t *testing.T) {
+	event := types.NewObject(2)
+	event.Set("name", "test")
+	event.Set("__sql_type_name", "text default current_user")
+
+	header, processed, err := ProcessEvents("events", event, nil, func(value string) string { return value }, true, true, nil, false)
+	require.NoError(t, err)
+	require.Len(t, header.Fields, 1)
+	_, overridden := header.Fields[0].GetSuggestedSQLType()
+	require.False(t, overridden)
+	_, hintPresent := processed.Get("__sql_type_name")
+	require.False(t, hintPresent)
+}
+
+func TestFilterSQLTypesHintsForAnyDriverRequiresOneCompatibleDriver(t *testing.T) {
+	hints := types.SQLTypes{
+		"bigquery":   {Type: "FLOAT", Override: true},
+		"redshift":   {Type: "super", Override: true},
+		"mixed_pair": {Type: "FLOAT", DdlType: "super", Override: true},
+		"expression": {Type: "text default current_user", Override: true},
+	}
+
+	filterSQLTypesHintsForAnyDriver(hints)
+
+	require.Equal(t, types.SQLTypes{
+		"bigquery": {Type: "FLOAT", Override: true},
+		"redshift": {Type: "super", Override: true},
+	}, hints)
+}


### PR DESCRIPTION
## Summary

- validate event-provided `__sql_type` cast and DDL values against per-driver allowlists before flattening and schema generation
- ignore malformed or unsafe hints while preserving the forms used by active production workspaces
- add compatibility and injection regression tests, and document the validation behavior

## Production compatibility

- BigQuery: `FLOAT`, `json`
- ClickHouse: `FLOAT`, `Float64`, `JSON`, and bounded legacy wrappers such as `Nullable(...)`
- Redshift: legacy one-element `["super"]` hints

## Test plan

- `go test ./bulkerlib/implementations/sql`

JITSU-179
