### PR TITLE
ci: skip AI reviews on PR metadata edits

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,7 +2,7 @@ name: AI Review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [newjitsu]
   workflow_dispatch:


### PR DESCRIPTION
Pushing code and then editing a PR description could schedule two AI reviews of the same commit. Remove `edited` from the caller’s pull request triggers so metadata edits no longer start another review.

Validation: `git diff --check` passed; verified that the only change is removal of `edited`, preserving the other triggers and shared workflow configuration.
